### PR TITLE
switch from 'conditions' to 'ensure' per 0.57

### DIFF
--- a/pipelines/binary-buildpack.yml
+++ b/pipelines/binary-buildpack.yml
@@ -85,10 +85,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-CF-LTS
     serial: true
     plan:
@@ -110,10 +110,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new Binary buildpack and upload artifacts
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -197,10 +197,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-release
     serial: true
     plan:

--- a/pipelines/brats-binary-beta.yml
+++ b/pipelines/brats-binary-beta.yml
@@ -49,10 +49,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge-binary-beta
     serial: true
     plan:
@@ -73,10 +73,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS-binary-beta
     serial: true
     plan:
@@ -97,10 +97,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge-binary-beta
     serial: true
     plan:
@@ -121,10 +121,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS-binary-beta
     serial: true
     plan:
@@ -145,10 +145,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge-binary-beta
     serial: true
     plan:
@@ -169,10 +169,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS-binary-beta
     serial: true
     plan:
@@ -193,10 +193,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge-binary-beta
     serial: true
     plan:
@@ -217,10 +217,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS-binary-beta
     serial: true
     plan:
@@ -241,10 +241,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge-binary-beta
     serial: true
     plan:
@@ -265,7 +265,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/brats-develop.yml
+++ b/pipelines/brats-develop.yml
@@ -49,10 +49,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-go-CF-edge
     serial: true
     plan:
@@ -73,10 +73,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-LTS
     serial: true
     plan:
@@ -97,10 +97,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge
     serial: true
     plan:
@@ -121,10 +121,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS
     serial: true
     plan:
@@ -145,10 +145,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge
     serial: true
     plan:
@@ -169,10 +169,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS
     serial: true
     plan:
@@ -193,10 +193,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge
     serial: true
     plan:
@@ -217,10 +217,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-LTS
     serial: true
     plan:
@@ -241,10 +241,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-edge
     serial: true
     plan:
@@ -265,10 +265,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS
     serial: true
     plan:
@@ -289,10 +289,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge
     serial: true
     plan:
@@ -313,10 +313,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS
     serial: true
     plan:
@@ -337,10 +337,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge
     serial: true
     plan:
@@ -361,7 +361,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/brats.yml
+++ b/pipelines/brats.yml
@@ -48,10 +48,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-go-CF-edge
     serial: true
     plan:
@@ -71,10 +71,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-LTS
     serial: true
     plan:
@@ -94,10 +94,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge
     serial: true
     plan:
@@ -117,10 +117,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS
     serial: true
     plan:
@@ -140,10 +140,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS
     serial: true
     plan:
@@ -186,10 +186,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge
     serial: true
     plan:
@@ -209,10 +209,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-LTS
     serial: true
     plan:
@@ -232,10 +232,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-edge
     serial: true
     plan:
@@ -255,10 +255,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS
     serial: true
     plan:
@@ -278,10 +278,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge
     serial: true
     plan:
@@ -301,10 +301,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS
     serial: true
     plan:
@@ -324,10 +324,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge
     serial: true
     plan:
@@ -347,7 +347,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/go-buildpack.yml
+++ b/pipelines/go-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -78,10 +78,10 @@ jobs:
           params:
             STACKS: cflinuxfs2
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: machete-firewall-CF-LTS
     serial: true
     plan:
@@ -102,10 +102,10 @@ jobs:
           params:
             STACKS: cflinuxfs2
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: buildpack-packager
     serial: true
     plan:

--- a/pipelines/nodejs-buildpack.yml
+++ b/pipelines/nodejs-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/php-buildpack.yml
+++ b/pipelines/php-buildpack.yml
@@ -94,10 +94,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: php-buildpack-CF-LTS
     serial: true
     plan:
@@ -128,10 +128,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new PHP buildpack and upload artifacts
     serial: true
     plan:
@@ -182,10 +182,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: php-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -216,11 +216,11 @@ jobs:
             STACKS: cflinuxfs2
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+          ensure:
+           rivileged: true
+            put: cf-lts-environments
+            params:
+            release: cf-environments
   - name: php-buildpack-release
     serial: true
     plan:

--- a/pipelines/python-buildpack.yml
+++ b/pipelines/python-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/ruby-buildpack.yml
+++ b/pipelines/ruby-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/staticfile-buildpack.yml
+++ b/pipelines/staticfile-buildpack.yml
@@ -85,10 +85,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-CF-LTS
     serial: true
     plan:
@@ -110,10 +110,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new Staticfile buildpack and upload artifacts
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -197,10 +197,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-release
     serial: true
     plan:


### PR DESCRIPTION
`conditions` will be removed soon; `ensure` is the way to go, and has the advantage of running even if something errors