### PR TITLE
ensure lock is released if fetching sources fails

### DIFF
--- a/pipelines/binary-buildpack.yml
+++ b/pipelines/binary-buildpack.yml
@@ -85,10 +85,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-CF-LTS
     serial: true
     plan:
@@ -110,10 +110,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new Binary buildpack and upload artifacts
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -197,10 +197,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: binary-buildpack-release
     serial: true
     plan:

--- a/pipelines/binary-buildpack.yml
+++ b/pipelines/binary-buildpack.yml
@@ -71,20 +71,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: binary-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: binary-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -96,20 +97,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: binary-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: binary-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -140,29 +142,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          resource: binary-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: binary-pivotal-buildpack
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: binary-pivotal-buildpack-cached
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            resource: binary-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: binary-pivotal-buildpack
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: binary-pivotal-buildpack-cached
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -174,29 +177,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          resource: binary-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: binary-pivotal-buildpack
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: binary-pivotal-buildpack-cached
-          passed: [ "detect new Binary buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            resource: binary-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: binary-pivotal-buildpack
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: binary-pivotal-buildpack-cached
+            passed: [ "detect new Binary buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/brats-binary-beta.yml
+++ b/pipelines/brats-binary-beta.yml
@@ -36,19 +36,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -60,19 +61,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -84,19 +86,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -108,19 +111,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -132,19 +136,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -156,19 +161,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -180,19 +186,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -204,19 +211,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -228,19 +236,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -252,19 +261,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            BRATS_BRANCH: cf-binary-beta
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              BRATS_BRANCH: cf-binary-beta
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:

--- a/pipelines/brats-binary-beta.yml
+++ b/pipelines/brats-binary-beta.yml
@@ -49,10 +49,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge-binary-beta
     serial: true
     plan:
@@ -73,10 +73,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS-binary-beta
     serial: true
     plan:
@@ -97,10 +97,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge-binary-beta
     serial: true
     plan:
@@ -121,10 +121,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS-binary-beta
     serial: true
     plan:
@@ -145,10 +145,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge-binary-beta
     serial: true
     plan:
@@ -169,10 +169,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS-binary-beta
     serial: true
     plan:
@@ -193,10 +193,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge-binary-beta
     serial: true
     plan:
@@ -217,10 +217,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS-binary-beta
     serial: true
     plan:
@@ -241,10 +241,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge-binary-beta
     serial: true
     plan:
@@ -265,7 +265,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/brats-develop.yml
+++ b/pipelines/brats-develop.yml
@@ -36,19 +36,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: go
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: go
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -60,19 +61,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: go
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: go
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -84,19 +86,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -108,19 +111,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -132,19 +136,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -156,19 +161,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -180,19 +186,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -204,19 +211,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -228,19 +236,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: hhvm
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: hhvm
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -252,19 +261,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: hhvm
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: hhvm
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -276,19 +286,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -300,19 +311,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -324,19 +336,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -348,19 +361,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            BRATS_BRANCH: develop
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              BRATS_BRANCH: develop
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:

--- a/pipelines/brats-develop.yml
+++ b/pipelines/brats-develop.yml
@@ -49,10 +49,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-go-CF-edge
     serial: true
     plan:
@@ -73,10 +73,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-LTS
     serial: true
     plan:
@@ -97,10 +97,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge
     serial: true
     plan:
@@ -121,10 +121,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS
     serial: true
     plan:
@@ -145,10 +145,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge
     serial: true
     plan:
@@ -169,10 +169,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS
     serial: true
     plan:
@@ -193,10 +193,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge
     serial: true
     plan:
@@ -217,10 +217,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-LTS
     serial: true
     plan:
@@ -241,10 +241,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-edge
     serial: true
     plan:
@@ -265,10 +265,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS
     serial: true
     plan:
@@ -289,10 +289,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge
     serial: true
     plan:
@@ -313,10 +313,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS
     serial: true
     plan:
@@ -337,10 +337,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge
     serial: true
     plan:
@@ -361,7 +361,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/brats.yml
+++ b/pipelines/brats.yml
@@ -36,18 +36,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: go
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: go
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -59,18 +60,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: go
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: go
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -82,18 +84,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -105,18 +108,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: python
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: python
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -128,18 +132,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -151,18 +156,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: nodejs
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: nodejs
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -174,18 +180,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -197,18 +204,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: php
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: php
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -220,18 +228,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: hhvm
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: hhvm
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -243,18 +252,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: hhvm
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: hhvm
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -266,18 +276,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -289,18 +300,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: ruby
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: ruby
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -312,18 +324,19 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -335,18 +348,19 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: brats
-        - {get: brats-time-resource, trigger: true}
-      - task: bin-tests
-        file: buildpacks-ci/tasks/brats.yml
-        config:
-          params:
-            LANGUAGE: jruby
-            CI_CF_USERNAME: {{ci-cf-username}}
-            CI_CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: brats
+          - {get: brats-time-resource, trigger: true}
+        - task: bin-tests
+          file: buildpacks-ci/tasks/brats.yml
+          config:
+            params:
+              LANGUAGE: jruby
+              CI_CF_USERNAME: {{ci-cf-username}}
+              CI_CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:

--- a/pipelines/brats.yml
+++ b/pipelines/brats.yml
@@ -48,10 +48,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-go-CF-edge
     serial: true
     plan:
@@ -71,10 +71,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-LTS
     serial: true
     plan:
@@ -94,10 +94,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-python-CF-edge
     serial: true
     plan:
@@ -117,10 +117,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-LTS
     serial: true
     plan:
@@ -140,10 +140,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-nodejs-CF-edge
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-LTS
     serial: true
     plan:
@@ -186,10 +186,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-php-CF-edge
     serial: true
     plan:
@@ -209,10 +209,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-LTS
     serial: true
     plan:
@@ -232,10 +232,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-hhvm-CF-edge
     serial: true
     plan:
@@ -255,10 +255,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-LTS
     serial: true
     plan:
@@ -278,10 +278,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-ruby-CF-edge
     serial: true
     plan:
@@ -301,10 +301,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-LTS
     serial: true
     plan:
@@ -324,10 +324,10 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: brats-jruby-CF-edge
     serial: true
     plan:
@@ -347,7 +347,7 @@ jobs:
             CI_CF_USERNAME: {{ci-cf-username}}
             CI_CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments

--- a/pipelines/go-buildpack.yml
+++ b/pipelines/go-buildpack.yml
@@ -90,29 +90,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          resource: go-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: go-pivotal-buildpack
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: go-pivotal-buildpack-cached
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            resource: go-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: go-pivotal-buildpack
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: go-pivotal-buildpack-cached
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -124,29 +125,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          resource: go-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: go-pivotal-buildpack
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: go-pivotal-buildpack-cached
-          passed: [ "detect new Go buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            resource: go-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: go-pivotal-buildpack
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: go-pivotal-buildpack-cached
+            passed: [ "detect new Go buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -248,20 +250,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: go-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: go-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -273,20 +276,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: go-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: go-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/go-buildpack.yml
+++ b/pipelines/go-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: go-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -65,19 +65,20 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: machete-firewall-test
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: machete-firewall-test
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -89,19 +90,20 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: machete-firewall-test
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: machete-firewall-test
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -78,10 +78,10 @@ jobs:
           params:
             STACKS: cflinuxfs2
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: machete-firewall-CF-LTS
     serial: true
     plan:
@@ -102,10 +102,10 @@ jobs:
           params:
             STACKS: cflinuxfs2
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: buildpack-packager
     serial: true
     plan:

--- a/pipelines/nodejs-buildpack.yml
+++ b/pipelines/nodejs-buildpack.yml
@@ -90,29 +90,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          resource: nodejs-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: nodejs-pivotal-buildpack
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: nodejs-pivotal-buildpack-cached
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            resource: nodejs-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: nodejs-pivotal-buildpack
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: nodejs-pivotal-buildpack-cached
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -124,29 +125,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          resource: nodejs-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: nodejs-pivotal-buildpack
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: nodejs-pivotal-buildpack-cached
-          passed: [ "detect new NodeJS buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            resource: nodejs-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: nodejs-pivotal-buildpack
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: nodejs-pivotal-buildpack-cached
+            passed: [ "detect new NodeJS buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -248,20 +250,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: nodejs-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: nodejs-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -273,20 +276,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: nodejs-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: nodejs-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/nodejs-buildpack.yml
+++ b/pipelines/nodejs-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: nodejs-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/php-buildpack.yml
+++ b/pipelines/php-buildpack.yml
@@ -71,29 +71,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: php-buildpack
-          trigger: true
-      - task: rspec
-        config:
-          platform: linux
-          image: docker:///cfbuildpacks/ci#buildpack
-          inputs:
-            - name: buildpacks-ci
-            - name: ci-tools
-            - name: php-buildpack
-            - name: deployments-buildpacks
-            - name: cf-environments
-          run:
-            path: buildpacks-ci/scripts/php-buildpack.sh
-          params:
-            STACKS: cflinuxfs2
-            COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: php-buildpack
+            trigger: true
+        - task: rspec
+          config:
+            platform: linux
+            image: docker:///cfbuildpacks/ci#buildpack
+            inputs:
+              - name: buildpacks-ci
+              - name: ci-tools
+              - name: php-buildpack
+              - name: deployments-buildpacks
+              - name: cf-environments
+            run:
+              path: buildpacks-ci/scripts/php-buildpack.sh
+            params:
+              STACKS: cflinuxfs2
+              COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -105,29 +106,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: php-buildpack
-          trigger: true
-      - task: rspec
-        config:
-          platform: linux
-          image: docker:///cfbuildpacks/ci#buildpack
-          inputs:
-            - name: buildpacks-ci
-            - name: ci-tools
-            - name: php-buildpack
-            - name: deployments-buildpacks
-            - name: cf-environments
-          run:
-            path: buildpacks-ci/scripts/php-buildpack.sh
-          params:
-            STACKS: cflinuxfs2
-            COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: php-buildpack
+            trigger: true
+        - task: rspec
+          config:
+            platform: linux
+            image: docker:///cfbuildpacks/ci#buildpack
+            inputs:
+              - name: buildpacks-ci
+              - name: ci-tools
+              - name: php-buildpack
+              - name: deployments-buildpacks
+              - name: cf-environments
+            run:
+              path: buildpacks-ci/scripts/php-buildpack.sh
+            params:
+              STACKS: cflinuxfs2
+              COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -158,30 +160,31 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          resource: php-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: php-pivotal-buildpack
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: php-pivotal-buildpack-cached
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            resource: php-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: php-pivotal-buildpack
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: php-pivotal-buildpack-cached
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -193,29 +196,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          resource: php-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: php-pivotal-buildpack
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: php-pivotal-buildpack-cached
-          passed: [ "detect new PHP buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
-            CF_PASSWORD: {{ci-cf-password}}
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            resource: php-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: php-pivotal-buildpack
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: php-pivotal-buildpack-cached
+            passed: [ "detect new PHP buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
+              CF_PASSWORD: {{ci-cf-password}}
           ensure:
            rivileged: true
             put: cf-lts-environments

--- a/pipelines/php-buildpack.yml
+++ b/pipelines/php-buildpack.yml
@@ -94,10 +94,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: php-buildpack-CF-LTS
     serial: true
     plan:
@@ -128,10 +128,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new PHP buildpack and upload artifacts
     serial: true
     plan:
@@ -182,10 +182,10 @@ jobs:
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: php-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -216,11 +216,11 @@ jobs:
             STACKS: cflinuxfs2
             COMPOSER_GITHUB_OAUTH_TOKEN: {{composer-github-oauth-token}}
             CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+          ensure:
+           rivileged: true
+            put: cf-lts-environments
+            params:
+            release: cf-environments
   - name: php-buildpack-release
     serial: true
     plan:

--- a/pipelines/python-buildpack.yml
+++ b/pipelines/python-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: python-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/python-buildpack.yml
+++ b/pipelines/python-buildpack.yml
@@ -90,29 +90,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          resource: python-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: python-pivotal-buildpack
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: python-pivotal-buildpack-cached
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            resource: python-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: python-pivotal-buildpack
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: python-pivotal-buildpack-cached
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -124,29 +125,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          resource: python-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: python-pivotal-buildpack
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: python-pivotal-buildpack-cached
-          passed: [ "detect new Python buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            resource: python-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: python-pivotal-buildpack
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: python-pivotal-buildpack-cached
+            passed: [ "detect new Python buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -248,20 +250,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: python-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: python-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -273,20 +276,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: python-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: python-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/ruby-buildpack.yml
+++ b/pipelines/ruby-buildpack.yml
@@ -113,10 +113,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -147,10 +147,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-release
     serial: true
     plan:
@@ -262,10 +262,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: ruby-buildpack-CF-LTS
     serial: true
     plan:
@@ -287,7 +287,7 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments

--- a/pipelines/ruby-buildpack.yml
+++ b/pipelines/ruby-buildpack.yml
@@ -90,29 +90,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          resource: ruby-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: ruby-pivotal-buildpack
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: ruby-pivotal-buildpack-cached
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            resource: ruby-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: ruby-pivotal-buildpack
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: ruby-pivotal-buildpack-cached
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -124,29 +125,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          resource: ruby-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: ruby-pivotal-buildpack
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: ruby-pivotal-buildpack-cached
-          passed: [ "detect new Ruby buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            resource: ruby-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: ruby-pivotal-buildpack
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: ruby-pivotal-buildpack-cached
+            passed: [ "detect new Ruby buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -248,20 +250,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: ruby-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: ruby-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -273,20 +276,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: ruby-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: ruby-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/staticfile-buildpack.yml
+++ b/pipelines/staticfile-buildpack.yml
@@ -71,20 +71,21 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: staticfile-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: staticfile-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -96,20 +97,21 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          resource: staticfile-buildpack
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            resource: staticfile-buildpack
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:
@@ -140,29 +142,30 @@ jobs:
         resource: cf-edge-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          resource: staticfile-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: staticfile-pivotal-buildpack
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: staticfile-pivotal-buildpack-cached
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            resource: staticfile-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: staticfile-pivotal-buildpack
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: staticfile-pivotal-buildpack-cached
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-edge-environments
           params:
@@ -174,29 +177,30 @@ jobs:
         resource: cf-lts-environments
         params:
           acquire: true
-      - aggregate:
-        - get: buildpacks-ci
-        - get: ci-tools
-        - get: deployments-buildpacks
-        - get: buildpack
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          resource: staticfile-buildpack-master
-          trigger: true
-        - get: pivotal-buildpacks
-          resource: staticfile-pivotal-buildpack
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          trigger: true
-        - get: pivotal-buildpacks-cached
-          resource: staticfile-pivotal-buildpack-cached
-          passed: [ "detect new Staticfile buildpack and upload artifacts" ]
-          trigger: true
-      - task: rspec
-        file: buildpacks-ci/tasks/test-buildpack-for-release.yml
-        config:
-          params:
-            STACKS: cflinuxfs2
-            CF_PASSWORD: {{ci-cf-password}}
-        privileged: true
+      - do:
+        - aggregate:
+          - get: buildpacks-ci
+          - get: ci-tools
+          - get: deployments-buildpacks
+          - get: buildpack
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            resource: staticfile-buildpack-master
+            trigger: true
+          - get: pivotal-buildpacks
+            resource: staticfile-pivotal-buildpack
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            trigger: true
+          - get: pivotal-buildpacks-cached
+            resource: staticfile-pivotal-buildpack-cached
+            passed: [ "detect new Staticfile buildpack and upload artifacts" ]
+            trigger: true
+        - task: rspec
+          file: buildpacks-ci/tasks/test-buildpack-for-release.yml
+          config:
+            params:
+              STACKS: cflinuxfs2
+              CF_PASSWORD: {{ci-cf-password}}
+          privileged: true
         ensure:
           put: cf-lts-environments
           params:

--- a/pipelines/staticfile-buildpack.yml
+++ b/pipelines/staticfile-buildpack.yml
@@ -85,10 +85,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-CF-LTS
     serial: true
     plan:
@@ -110,10 +110,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: detect new Staticfile buildpack and upload artifacts
     serial: true
     plan:
@@ -163,10 +163,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-edge-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-edge-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-CF-LTS-master
     serial: true
     plan:
@@ -197,10 +197,10 @@ jobs:
             STACKS: cflinuxfs2
             CF_PASSWORD: {{ci-cf-password}}
         privileged: true
-      - put: cf-lts-environments
-        conditions: [success, failure]
-        params:
-          release: cf-environments
+        ensure:
+          put: cf-lts-environments
+          params:
+            release: cf-environments
   - name: staticfile-buildpack-release
     serial: true
     plan:


### PR DESCRIPTION
previously the lock would only be released after running the task; if for whatever reason fetching resources fails, the lock would still be held.

this change comes at the cost of additional nesting in pretty much every job though, which might not be worth it if fetching resources pretty much never fails (the lock could always just be manually released).

feel free to close if so; just wanted to point it out.