### PR TITLE
externalize some github url to concourse credentials

### DIFF
--- a/pipelines/binary-builder.yml
+++ b/pipelines/binary-builder.yml
@@ -2,84 +2,84 @@ resources:
   - name: binary-builder
     type: git
     source:
-      uri: https://github.com/cloudfoundry/binary-builder.git
+      uri: {{binary-builder-git-uri}}
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: builds-out
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: nginx-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ nginx-builds.yml ]
   - name: php-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ php-builds.yml ]
   - name: php7-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ php7-builds.yml ]
   - name: node-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ node-builds.yml ]
   - name: ruby-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ ruby-builds.yml ]
   - name: jruby-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ jruby-builds.yml ]
   - name: httpd-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ httpd-builds.yml ]
   - name: python-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ python-builds.yml ]
   - name: bundler-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ bundler-builds.yml ]
   - name: build-tar
     type: s3
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       versioned_file: /concourse-artifacts/binary-builder-source.tgz
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
@@ -88,14 +88,14 @@ resources:
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ godep-builds.yml ]
   - name: glide-builds
     type: git
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ glide-builds.yml ]
   - name: concourse2tracker
     type: concourse2tracker
@@ -127,25 +127,25 @@ resources:
       branch: resource-pools
       pool: cf-edge-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: godep-new-releases
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-release-notifications
       private_key: {{buildpacks-ci-private-key}}
       paths: [ godep.yaml ]
   - name: glide-new-releases
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-release-notifications
       private_key: {{buildpacks-ci-private-key}}
       paths: [ glide.yaml ]
   - name: composer-new-releases
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-release-notifications
       private_key: {{buildpacks-ci-private-key}}
       paths: [ composer.yaml ]
@@ -154,7 +154,7 @@ resources:
     source:
       branch: binary-builds
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       paths: [ composer-builds.yml ]
 
 jobs:

--- a/pipelines/brats.yml
+++ b/pipelines/brats.yml
@@ -12,21 +12,21 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: cf-edge-environments
     type: pool
     source:
       branch: resource-pools
       pool: cf-edge-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: cf-lts-environments
     type: pool
     source:
       branch: resource-pools
       pool: cf-lts-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
 
 jobs:
 <% %w(go python nodejs php hhvm ruby jruby).each do |language| %>

--- a/pipelines/buildpacks-ci.yml
+++ b/pipelines/buildpacks-ci.yml
@@ -2,13 +2,13 @@ resources:
   - name: ci-master
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri}}
       branch: master
       private_key: {{buildpacks-ci-private-key}}
   - name: ci-develop
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
       branch: develop
   - name: concourse2tracker
     type: concourse2tracker

--- a/pipelines/cf-release-azure.yml
+++ b/pipelines/cf-release-azure.yml
@@ -4,7 +4,7 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: bosh-lite
     type: git
     source:
@@ -17,7 +17,7 @@ resources:
   - name: cf-release
     type: git
     source:
-      uri: https://github.com/cloudfoundry/cf-release
+      uri: {{cf-release-git-uri}}
       branch: develop
   - name: cf-release-develop
     type: git
@@ -32,7 +32,7 @@ resources:
   - name: deployments-buildpacks
     type: git
     source:
-      uri: git@github.com:pivotal-cf/deployments-buildpacks
+      uri: {{deployments-git-uri}}
       private_key: {{deployments-private-key}}
       branch: master
   - name: cf-release-deployment

--- a/pipelines/cf-release.yml
+++ b/pipelines/cf-release.yml
@@ -4,7 +4,7 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: bosh-lite
     type: git
     source:
@@ -17,7 +17,7 @@ resources:
   - name: cf-release
     type: git
     source:
-      uri: https://github.com/cloudfoundry/cf-release
+      uri: {{cf-release-git-uri}}
       branch: develop
   - name: cf-release-develop
     type: git

--- a/pipelines/concourse2tracker-resource.yml
+++ b/pipelines/concourse2tracker-resource.yml
@@ -3,7 +3,7 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
       paths: [ "lib/concourse2tracker-resource" ]
   - name: concourse2tracker-image
     type: docker-image

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -3,16 +3,16 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: deployments-buildpacks
     type: git
     source:
-      uri: git@github.com:pivotal-cf/deployments-buildpacks
+      uri: {{deployments-git-url}}
       private_key: {{deployments-private-key}}
   - name: buildpack-packager
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpack-packager.git
+      uri: {{buildpack-packager-git-uri}}
       branch: master
       private_key: {{buildpack-packager-private-key}}
   - name: buildpack-packager-github-release
@@ -24,7 +24,7 @@ resources:
   - name: machete
     type: git
     source:
-      uri: git@github.com:cloudfoundry/machete.git
+      uri: {{machete-git-uri}}
       branch: master
       private_key: {{machete-private-key}}
   - name: machete-github-release
@@ -40,7 +40,7 @@ resources:
   - name: cf-release
     type: git
     source:
-      uri: https://github.com/cloudfoundry/cf-release
+      uri: {{cf-release-git-uri}}
   - name: nanny-time-resource
     type: time
     source:

--- a/pipelines/notifications.yml
+++ b/pipelines/notifications.yml
@@ -13,23 +13,23 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: new-releases
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-release-notifications
       private_key: {{buildpacks-ci-private-key}}
   - name: new-cves
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-cve-notifications
       private_key: {{buildpacks-ci-private-key}}
   - name: new-buildpack-cves
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-buildpack-cve-notifications
       private_key: {{buildpacks-ci-private-key}}
   - name: stacks

--- a/pipelines/php_notifications.yml
+++ b/pipelines/php_notifications.yml
@@ -14,7 +14,7 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: pecl-gearman
     type: new_version_resource
     source:

--- a/pipelines/stacks.yml
+++ b/pipelines/stacks.yml
@@ -8,7 +8,7 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: stacks
     type: git
     source:
@@ -24,28 +24,28 @@ resources:
   - name: stack-s3
     type: s3
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       regexp: cflinuxfs2-(.*).tar.gz
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
   - name: receipt-s3
     type: s3
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       regexp: cflinuxfs2_receipt-(.*)
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
   - name: version
     type: semver
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       key: versions/stack
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
   - name: cflinuxfs2-rootfs-release-version
     type: semver
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       initial_version: 0.1.0-rc.1
       key: versions/cflinuxfs2-rootfs-release
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
@@ -113,7 +113,7 @@ resources:
   - name: cf-release-rc
     type: git
     source:
-      uri: https://github.com/cloudfoundry/cf-release
+      uri: {{cf-release-git-uri}}
       branch: release-candidate
   - name: cf-release-develop
     type: git
@@ -156,7 +156,7 @@ resources:
   - name: new-cves
     type: git
     source:
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
       branch: new-cve-notifications
       private_key: {{buildpacks-ci-private-key}}
       paths: [ ubuntu14.04.yaml ]

--- a/pipelines/templates/bosh-lite-cf-edge.yml
+++ b/pipelines/templates/bosh-lite-cf-edge.yml
@@ -36,11 +36,11 @@ resources:
       branch: resource-pools
       pool: {{resource-pool}}
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: machete
     type: git
     source:

--- a/pipelines/templates/bosh-lite-cf-lts.yml
+++ b/pipelines/templates/bosh-lite-cf-lts.yml
@@ -36,11 +36,11 @@ resources:
       branch: resource-pools
       pool: {{resource-pool}}
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: machete
     type: git
     source:

--- a/pipelines/templates/buildpack.yml
+++ b/pipelines/templates/buildpack.yml
@@ -8,21 +8,21 @@ resources:
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: cf-edge-environments
     type: pool
     source:
       branch: resource-pools
       pool: cf-edge-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: cf-lts-environments
     type: pool
     source:
       branch: resource-pools
       pool: cf-lts-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: compile-extensions
     type: git
     source:
@@ -57,14 +57,14 @@ resources:
   - name: pivotal-buildpack
     type: s3
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       regexp: <%= language %>_buildpack-v(.*).zip
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
   - name: pivotal-buildpack-cached
     type: s3
     source:
-      bucket: pivotal-buildpacks
+      bucket: {{pivotal-buildpacks-s3-bucket-name}}
       regexp: <%= language %>_buildpack-cached-v(.*).zip
       access_key_id: {{pivotal-buildpacks-s3-access-key}}
       secret_access_key: {{pivotal-buildpacks-s3-secret-key}}

--- a/pipelines/templates/pull-request.yml
+++ b/pipelines/templates/pull-request.yml
@@ -11,11 +11,11 @@ resources:
       branch: resource-pools
       pool: cf-edge-environments
       private_key: {{buildpacks-ci-private-key}}
-      uri: git@github.com:cloudfoundry/buildpacks-ci.git
+      uri: {{buildpacks-ci-git-uri}}
   - name: buildpacks-ci
     type: git
     source:
-      uri: https://github.com/cloudfoundry/buildpacks-ci
+      uri: {{buildpacks-ci-git-uri-public}}
   - name: deployments-buildpacks
     type: git
     source:


### PR DESCRIPTION
To be able to run buildpack-ci pipeline from another github organization, github url should be externalized to concourse credentials.   
Here is the list of new credentials required by concourse with this PR:
deployments-git-url: git@github.com:pivotal-cf/deployments-buildpacks
buildpack-packager-git-uri: git@github.com:cloudfoundry/buildpack-packager.git
buildpack-packager-git-uri-public: https://github.com/cloudfoundry/buildpack-packager
binary-builder-git-uri: https://github.com/cloudfoundry/binary-builder.git
machete-git-uri: git@github.com:cloudfoundry/machete.git
cf-release-git-uri: https://github.com/cloudfoundry/cf-release
buildpacks-ci-git-uri-public: https://github.com/cloudfoundry/buildpacks-ci
buildpacks-ci-git-uri: git@github.com:cloudfoundry/buildpacks-ci.git