### PR TITLE
use custom bucket name on binary builder upload

### DIFF
--- a/pipelines/binary-builder.yml
+++ b/pipelines/binary-builder.yml
@@ -230,6 +230,7 @@ jobs:
           file: buildpacks-ci/tasks/push-binary.yml
           params:
             BINARY_NAME: <%= runtime %>
+            BUCKET_NAME: {{pivotal-buildpacks-s3-bucket-name}}
             AWS_ACCESS_KEY_ID: {{pivotal-buildpacks-s3-access-key}}
             AWS_SECRET_ACCESS_KEY: {{pivotal-buildpacks-s3-secret-key}}
             AWS_DEFAULT_REGION: us-east-1

--- a/scripts/push-binary.rb
+++ b/scripts/push-binary.rb
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 binary_name = ENV['BINARY_NAME']
+bucket_name= ENV['BUCKET_NAME']
 file_path   = Dir.glob("binary-builder-artifacts/#{binary_name}-*.{tar.gz,tgz,phar}").first
 unless file_path
   puts 'No binaries detected for upload.'
@@ -13,10 +14,10 @@ file_name = File.basename(file_path)
 
 if binary_name == "composer" then
   version = file_name.gsub("composer-","").gsub(".phar","")
-  aws_url =  "s3://pivotal-buildpacks/php/binaries/trusty/composer/#{version}"
+  aws_url =  "s3://#{bucket_name}/php/binaries/trusty/composer/#{version}"
   file_name = "composer.phar"
 else
-  aws_url =  "s3://pivotal-buildpacks/concourse-binaries/#{binary_name}"
+  aws_url =  "s3://#{bucket_name}/concourse-binaries/#{binary_name}"
 end
 
 


### PR DESCRIPTION
Reminder: if PR #8 is merged before, and a public credential is created, add a line `bucket_name: pivotal-buildpacks` to public-credentials 