### PR TITLE
add slack-notification resource_types when required

### DIFF
--- a/pipelines/binary-builder.yml
+++ b/pipelines/binary-builder.yml
@@ -3,6 +3,10 @@ resource_types:
     type: docker-image
     source:
       repository: cfbuildpacks/concourse2tracker
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
 resources:
   - name: binary-builder
     type: git

--- a/pipelines/cf-release.yml
+++ b/pipelines/cf-release.yml
@@ -1,5 +1,11 @@
 <% supported_languages = %w(go ruby binary staticfile nodejs php python java java-offline) %>
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: buildpacks-ci
     type: git

--- a/pipelines/notifications.yml
+++ b/pipelines/notifications.yml
@@ -4,6 +4,10 @@ resource_types:
   type: docker-image
   source:
     repository: pcfseceng/email-resource
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
 
 resources:
   - name: monday-funday

--- a/pipelines/stacks.yml
+++ b/pipelines/stacks.yml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: monday-funday
     type: cron

--- a/pipelines/templates/buildpack.yml
+++ b/pipelines/templates/buildpack.yml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: buildpacks-pivnet-uploader
     type: git


### PR DESCRIPTION
To reduce concourse pre-requisite setup,  it adds slack-notification resource_types