### PR TITLE
add branch name customization for buildpacks-ci git resource.

### DIFF
--- a/pipelines/brats.yml
+++ b/pipelines/brats.yml
@@ -13,6 +13,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
   - name: cf-edge-environments
     type: pool
     source:

--- a/pipelines/cf-release.yml
+++ b/pipelines/cf-release.yml
@@ -11,6 +11,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
   - name: bosh-lite
     type: git
     source:

--- a/pipelines/concourse2tracker-resource.yml
+++ b/pipelines/concourse2tracker-resource.yml
@@ -3,6 +3,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
       paths: [ "lib/concourse2tracker-resource" ]
   - name: concourse2tracker-image
     type: docker-image

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -4,6 +4,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
   - name: deployments-buildpacks
     type: git
     source:

--- a/pipelines/notifications.yml
+++ b/pipelines/notifications.yml
@@ -24,6 +24,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
   - name: new-releases
     type: git
     source:

--- a/pipelines/php-notifications.yml
+++ b/pipelines/php-notifications.yml
@@ -15,6 +15,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch:  {{buildpacks-ci-git-uri-public-branch}}
   - name: pecl-cassandra
     type: new_version_resource
     source:

--- a/pipelines/stacks.yml
+++ b/pipelines/stacks.yml
@@ -15,6 +15,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: stacks
     type: git
     source:

--- a/pipelines/templates/bosh-lite-cf-edge.yml
+++ b/pipelines/templates/bosh-lite-cf-edge.yml
@@ -41,6 +41,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: machete
     type: git
     source:

--- a/pipelines/templates/bosh-lite-cf-lts.yml
+++ b/pipelines/templates/bosh-lite-cf-lts.yml
@@ -41,6 +41,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: machete
     type: git
     source:

--- a/pipelines/templates/buildpack.yml
+++ b/pipelines/templates/buildpack.yml
@@ -15,6 +15,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: cf-edge-environments
     type: pool
     source:

--- a/pipelines/templates/pull-request.yml
+++ b/pipelines/templates/pull-request.yml
@@ -21,6 +21,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: deployments-buildpacks
     type: git
     source:

--- a/public-config.yml
+++ b/public-config.yml
@@ -4,6 +4,7 @@ buildpacks-binaries-s3-bucket: pivotal-buildpacks
 domain_name: cf-app.com
 
 buildpacks-ci-git-uri-public-develop-branch: develop
+buildpacks-ci-git-uri-public-branch: master
 
 buildpacks-docker-ci-repo: cfbuildpacks/ci
 buildpacks-docker-user-email: cf-buildpacks-eng@pivotal.io


### PR DESCRIPTION
branch:  {{buildpacks-ci-git-uri-public-branch}} is associated with  {{buildpacks-ci-git-uri-public}}