### PR TITLE
fix missing branch name customization

### DIFF
--- a/pipelines/binary-builder.yml
+++ b/pipelines/binary-builder.yml
@@ -16,6 +16,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: builds-out
     type: git
     source:

--- a/pipelines/buildpack-checksums.yml
+++ b/pipelines/buildpack-checksums.yml
@@ -10,6 +10,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: deploy-buildpack-verify
     type: cf
     source:

--- a/pipelines/buildpacks-ci.yml
+++ b/pipelines/buildpacks-ci.yml
@@ -14,7 +14,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
-      branch: develop
+      branch: {{buildpacks-ci-git-uri-public-develop-branch}}
   - name: concourse2tracker
     type: concourse2tracker
 jobs:

--- a/pipelines/cf-release-azure.yml
+++ b/pipelines/cf-release-azure.yml
@@ -5,6 +5,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: bosh-lite
     type: git
     source:

--- a/pipelines/dotnet-core-buildpack.yml
+++ b/pipelines/dotnet-core-buildpack.yml
@@ -4,6 +4,7 @@ resources:
     type: git
     source:
       uri: {{buildpacks-ci-git-uri-public}}
+      branch: {{buildpacks-ci-git-uri-public-branch}}
   - name: cf-edge-environments
     type: pool
     source:


### PR DESCRIPTION
branch:  {{buildpacks-ci-git-uri-public-branch}} is associated with  {{buildpacks-ci-git-uri-public}}
branch: {{buildpacks-ci-git-uri-public-develop-branch}}  is also associated with  {{buildpacks-ci-git-uri-public}}