### PR TITLE
fix bosh deployment target

### DIFF
--- a/pipelines/templates/bosh-lite-cf-edge.yml
+++ b/pipelines/templates/bosh-lite-cf-edge.yml
@@ -7,7 +7,7 @@ resources:
   - name: cf-deployment
     type: bosh-deployment
     source:
-      target: https://{{deployment-name}}.<%= domain_name %>:25555
+      target: https://<%= full_deployment_name +  '.' + domain_name %>:25555
       username: admin
       password: {{bosh-lite-password}}
       deployment: cf-warden
@@ -15,7 +15,7 @@ resources:
   - name: diego-deployment
     type: bosh-deployment
     source:
-      target: https://{{deployment-name}}.<%= domain_name %>:25555
+      target: https://<%= full_deployment_name +  '.' + domain_name %>:25555
       username: admin
       password: {{bosh-lite-password}}
       deployment: cf-warden-diego

--- a/pipelines/templates/bosh-lite-cf-lts.yml
+++ b/pipelines/templates/bosh-lite-cf-lts.yml
@@ -7,7 +7,7 @@ resources:
   - name: cf-deployment
     type: bosh-deployment
     source:
-      target: https://{{deployment-name}}.<%= domain_name %>:25555
+      target: https://<%= full_deployment_name +  '.' + domain_name %>:25555
       username: admin
       password: {{bosh-lite-password}}
       deployment: cf-warden
@@ -15,7 +15,7 @@ resources:
   - name: diego-deployment
     type: bosh-deployment
     source:
-      target: https://{{deployment-name}}.<%= domain_name %>:25555
+      target: https://<%= full_deployment_name +  '.' + domain_name %>:25555
       username: admin
       password: {{bosh-lite-password}}
       deployment: cf-warden-diego


### PR DESCRIPTION
use erb `full_deployment_name` instead of concourse property  `deployment-name` to avoid double quote in target url