### PR TITLE
Modify YML config to build new extensions for PHP

### DIFF
--- a/tasks/build-binary-new/php-extensions.yml
+++ b/tasks/build-binary-new/php-extensions.yml
@@ -127,6 +127,36 @@ extensions:
   md5: f07a87ae08f79fdca448fad3f1d359f4
   klass: PeclRecipe
 
+  #bundled w/PHP
+- name: tidy
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: enchant
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: interbase
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: pdo_firebird
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: wddx
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: xmlrpc
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: recode
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+
   #non-standard
 - name: amqp
   version: 1.9.3

--- a/tasks/build-binary-new/php7-extensions.yml
+++ b/tasks/build-binary-new/php7-extensions.yml
@@ -90,10 +90,6 @@ extensions:
   version: 3.0.5
   md5: 844bd1528161518a47415f709214bae9
   klass: PeclRecipe
-- name: readline
-  version: nil
-  md5: nil
-  klass: ReadlineRecipe
 - name: redis
   version: 4.1.1
   md5: 32488f1d214e60afc5e027ae2d1e895f
@@ -122,6 +118,40 @@ extensions:
   version: 3.0.4
   md5: 7e37aae409be7fc25ac31f918f5fa2eb
   klass: MemcachedPeclRecipe
+
+#bundled w/PHP
+- name: tidy
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: enchant
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: interbase
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: pdo_firebird
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: readline
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: wddx
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: xmlrpc
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: recode
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
 
 #non-standard
 - name: amqp

--- a/tasks/build-binary-new/php72-extensions.yml
+++ b/tasks/build-binary-new/php72-extensions.yml
@@ -94,10 +94,6 @@ extensions:
   version: 3.0.5
   md5: 844bd1528161518a47415f709214bae9
   klass: PeclRecipe
-- name: readline
-  version: nil
-  md5: nil
-  klass: ReadlineRecipe
 - name: redis
   version: 4.1.1
   md5: 32488f1d214e60afc5e027ae2d1e895f
@@ -122,6 +118,40 @@ extensions:
   version: nil
   md5: nil
   klass: SodiumRecipe
+
+#bundled w/PHP
+- name: tidy
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: enchant
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: interbase
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: pdo_firebird
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: readline
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: wddx
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: xmlrpc
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
+- name: recode
+  version: nil
+  md5: nil
+  klass: FakePeclRecipe
 
 #non-standard
 - name: amqp


### PR DESCRIPTION
These changes are to be paired with https://github.com/cloudfoundry/binary-builder/pull/40 which allows us to build several new extensions for use with PHP.