### PR TITLE
Add Oauth token support to depwatcher

### DIFF
--- a/dockerfiles/depwatcher/src/depwatcher/base.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/base.cr
@@ -4,10 +4,22 @@ require "http/client"
 module Depwatcher
   abstract class HTTPClient
     abstract def get(url : String) : HTTP::Client::Response
+    def injectOauthAuthorizationTokenIntoHeader(headers : HTTP::Headers? = nil)
+      # read token from env variable e.g. github authorization token
+      apiKey = ENV["OAUTH_AUTHORIZATION_TOKEN"]?
+      if headers == nil
+        headers = HTTP::Headers.new
+      end
+      if apiKey != nil
+        headers.not_nil!["Authorization"] = "token " + apiKey.not_nil!
+      end
+      return headers
+    end
   end
 
   class HTTPClientImpl < HTTPClient
     def get(url : String, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+      headers = injectOauthAuthorizationTokenIntoHeader(headers)
       response = HTTP::Client.get(url, headers)
       if response.status_code == 301 || response.status_code == 302
         get(response.headers["location"], headers)
@@ -21,6 +33,7 @@ module Depwatcher
 
   class HTTPClientInsecure < HTTPClient
     def get(url : String, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+      headers = injectOauthAuthorizationTokenIntoHeader(headers)
       context = OpenSSL::SSL::Context::Client.insecure
       response = HTTP::Client.get(url, headers: headers, tls: context)
       if response.status_code == 301 || response.status_code == 302


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>

This PR allows to use OAUTH tokens with the depwatcher (like github authentication tokens) by setting the environment variable `OAUTH_AUTHORIZATION_TOKEN`.

We added this feature because we constantly got http error 403 from github because too many people/pipelines on our network were accessing it. 