### PR TITLE
Story ID: 169051314 update cnb dependencies

### DIFF
--- a/spec/tasks/update-cnb-dependency/update-cnb-dependency_spec.rb
+++ b/spec/tasks/update-cnb-dependency/update-cnb-dependency_spec.rb
@@ -1,0 +1,408 @@
+# encoding: utf-8
+require 'spec_helper'
+require_relative '../../../tasks/update-cnb-dependency/cnb_dependencies'
+
+describe CNBDependencies do
+  subject {
+    described_class.new(
+        dep,
+        line,
+        removal_strategy,
+        dependencies,
+        dependencies_latest_released
+    )
+  }
+
+  context 'updating default_versions' do
+    context "removal_strategy isn't remove_all" do
+      let(:removal_strategy) {'remove_none'}
+
+    end
+
+    context "removal_strategy is remove_all" do
+      let(:removal_strategy) {'remove_all'}
+
+    end
+
+  end
+
+  context 'switching dependencies' do
+    let(:dependencies) do
+      [['stack1'], ['stack2']].map do |stack|
+        [
+          { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => stack }
+        ]
+      end.flatten.sort_by { |d| [d['id'], d['version'], d['stacks']] }.freeze
+    end
+    let(:dependencies_latest_released) do
+      [['stack1'], ['stack2']].map do |stack|
+        [
+          { 'id' => 'bundler', 'version' => '1.2.1', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '1.2.2', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '2.3.1', 'stacks' => stack },
+          { 'id' => 'ruby', 'version' => '2.3.2', 'stacks' => stack }
+        ]
+      end.flatten.sort_by { |d| [d['id'], d['version'], d['stacks']] }.freeze
+    end
+
+    context 'no version line specified' do
+      let(:line) {nil}
+      let(:removal_strategy) {'remove_all'}
+
+      context 'new version is newer than all existing' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack1'] } }
+
+        it 'replaces all of the idd dependencies' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack1'] }
+          ])
+        end
+      end
+      context 'new version is older than any existing' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '2.0.0', 'stacks' => ['stack1'] }}
+        it 'returns unchanged dependencies' do
+          expect(subject.switch).to eq(dependencies)
+        end
+      end
+    end
+
+    context 'version line is major' do
+      let(:line) {"major"}
+      let(:removal_strategy) {'remove_all'}
+
+      context 'new version is newer than all existing on its line', :focus => true do
+        let(:dep) {{'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1'] }}
+        it 'replaces all of the idd dependencies on its line' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack2'] },
+            {'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1'] },
+            {'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack2'] },
+            {'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack2'] }
+                                ])
+        end
+      end
+      context 'new version is part of a new line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack1'] }}
+        it 'Maintains all old dependencies and adds the new one' do
+          expect(subject.switch).to eq(dependencies + [
+              {'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack1']}
+          ])
+        end
+      end
+      context 'new version is older than any existing on its line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '2.3.5', 'stacks' => ['stack1'] }}
+        it 'returns unchanged dependencies' do
+          expect(subject.switch).to eq(dependencies)
+        end
+      end
+    end
+
+    context 'version line is minor' do
+      let(:line) {"minor"}
+      let(:removal_strategy) {'remove_all'}
+
+      context 'new version is newer than all existing on its line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '1.2.5', 'stacks' => ['stack1']}}
+        it 'replaces all of the idd dependencies on its line' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack2'] },
+            {'id' => 'ruby', 'version' => '1.2.5', 'stacks' => ['stack1']},
+            {'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1']},
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack2'] },
+            {'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack2'] },
+            {'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack2'] }
+                                ])
+        end
+      end
+      context 'new version is part of a new line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '2.4.0', 'stacks' => ['stack1']}}
+        it 'Maintains all old dependencies and adds the new one' do
+          expect(subject.switch).to eq(dependencies + [
+              {'id' => 'ruby', 'version' => '2.4.0', 'stacks' => ['stack1']}
+          ])
+        end
+      end
+      context 'new version is older than any existing on its line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '2.3.5', 'stacks' => ['stack1']}}
+        it 'returns unchanged dependencies' do
+          expect(subject.switch).to eq(dependencies)
+        end
+      end
+    end
+
+    context 'removal_strategy is keep_latest_released' do
+      let(:line) {'major'}
+      let(:removal_strategy) {'keep_latest_released'}
+
+      context 'new version is newer than all existing on its line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1'] }}
+        it 'replaces all of the idd dependencies on its line keeping the latest from last released buildpack' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack2'] }
+          ])
+        end
+      end
+    end
+
+    context 'removal_strategy is keep_all' do
+      let(:line) {'major'}
+      let(:removal_strategy) {'keep_all'}
+      context 'new version is newer than all existing on its line' do
+        let(:dep) {{'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1'] }}
+        it 'replaces all of the idd dependencies on its line keeping the latest from last released buildpack' do
+          expect(subject.switch).to eq([
+                                    {'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1']},
+                                    {'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2']},
+                                    {'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2']},
+                                    {'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack2']},
+                                    {'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack2']},
+                                    {'id' => 'ruby', 'version' => '1.4.0', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack2']},
+                                    {'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1']},
+                                    {'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack2']}
+                                ])
+        end
+      end
+    end
+
+    context 'nginx' do
+      let(:dependencies_latest_released) {[
+          {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+          {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+          {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack1']},
+          {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2']},
+      ]}
+      let(:dependencies) {[
+          {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+          {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+          {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack1']},
+          {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2']},
+      ].freeze}
+      let(:line) { 'nginx' }
+      let(:removal_strategy) { 'remove_all' }
+
+      context 'updating the stable line first' do
+        let(:dep) {{'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']}}
+
+        it 'replaces the stable line and keeps the main line' do
+          expect(subject.switch).to eq([
+                                    {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+                                    {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack1']},
+                                    {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2']},
+                                    {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']}
+                                ])
+        end
+      end
+
+      context 'updating the main line first' do
+        let(:dep) {{'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']}}
+
+        it 'replaces the main line and keeps the stable line' do
+          expect(subject.switch).to eq([
+                                    {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+                                    {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+                                    {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2']},
+                                    {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']}
+                                ])
+        end
+      end
+
+      context 'when the main line is already up-to-date' do
+        let(:dependencies) {[
+            {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+            {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack2']},
+        ].freeze}
+        let(:dep) {{'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']}}
+
+        it 'replaces the stable line and keeps the up-to-date main line' do
+          expect(subject.switch).to eq([
+                                    {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+                                    {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']},
+                                    {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']},
+                                    {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack2']}
+                                ])
+        end
+      end
+
+      context 'when the stable line is already up-to-date' do
+        let(:dependencies) {[
+            {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2']},
+            {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack2']},
+        ].freeze}
+        let(:dep) {{'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']}}
+
+        it 'replaces the main line and keeps the up-to-date stable line' do
+          expect(subject.switch).to eq([
+                                  { 'id' => 'nginx', 'version' => '1.13.1', 'stacks' => ['stack2'] },
+                                  {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack1']},
+                                  {'id' => 'nginx', 'version' => '1.14.0', 'stacks' => ['stack2']},
+                                  {'id' => 'nginx', 'version' => '1.15.0', 'stacks' => ['stack1']}
+                                ])
+        end
+      end
+
+      context 'updating patch versions' do
+        let(:dependencies) {[
+            {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+            {'id' => 'nginx', 'version' => '1.13.2', 'stacks' => ['stack1']},
+            {'id' => 'nginx', 'version' => '1.13.2', 'stacks' => ['stack2']},
+        ].freeze}
+        let(:dep) {{'id' => 'nginx', 'version' => '1.13.3', 'stacks' => ['stack1']}}
+
+        it 'replaces the patch version' do
+          expect(subject.switch).to eq([
+                                  {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack1']},
+                                  {'id' => 'nginx', 'version' => '1.12.0', 'stacks' => ['stack2']},
+                                  {'id' => 'nginx', 'version' => '1.13.2', 'stacks' => ['stack2']},
+                                  {'id' => 'nginx', 'version' => '1.13.3', 'stacks' => ['stack1']}
+                                ])
+        end
+      end
+    end
+
+    context 'adding a new stack' do
+      let(:dependencies) do
+          [
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] }
+          ]
+      end
+      let(:dependencies_latest_released) do
+          [
+            { 'id' => 'bundler', 'version' => '1.2.1', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.2', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.1', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.2', 'stacks' => ['stack1'] }
+          ]
+      end
+
+      let(:line) {nil}
+      let(:removal_strategy) {'remove_all'}
+
+      context 'new version with new stack' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack2'] } }
+
+        it 'does not affect any existing versions' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '3.0.0', 'stacks' => ['stack2'] }
+          ])
+        end
+      end
+
+      context 'rebuilt version but with new stack' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] } }
+
+        it 'does not affect any existing versions' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+          ])
+        end
+      end
+      context 'rebuilt version, only one existing version, but with new stack' do
+        let(:dep) { { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] } }
+
+        it 'does not affect any existing versions' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack2'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+          ])
+        end
+      end
+
+      context 'the new dep expands the number of stacks for an existing dep' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1', 'stack2'] } }
+        let(:line) { 'major' }
+
+        it 'replaces the existing dep with a dep with the extra stacks' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.2.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.3.4', 'stacks' => ['stack1', 'stack2'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+          ])
+        end
+      end
+
+      context 'the new dep is the latest version and contains new stacks' do
+        let(:dep) { { 'id' => 'ruby', 'version' => '1.4.4', 'stacks' => ['stack1', 'stack2'] } }
+        let(:line) { 'major' }
+
+        it 'adds the dep with a dep with the extra stacks and removes the old ones' do
+          expect(subject.switch).to eq([
+            { 'id' => 'bundler', 'version' => '1.2.3', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '1.4.4', 'stacks' => ['stack1', 'stack2'] },
+            { 'id' => 'ruby', 'version' => '2.3.4', 'stacks' => ['stack1'] },
+            { 'id' => 'ruby', 'version' => '2.3.6', 'stacks' => ['stack1'] },
+          ])
+        end
+      end
+    end
+  end
+end

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -489,10 +489,15 @@ class Builder
       )
       out_data[:source_pgp] = source_pgp
 
-    when 'CAAPM', 'appdynamics', 'miniconda2', 'miniconda3'
+    when 'CAAPM', 'appdynamics'
       results = Sha.check_sha(source_input)
       out_data[:sha256] = results[1]
       out_data[:url] = source_input.url
+
+    when 'miniconda2', 'miniconda3'
+      out_data[:url] = "https://github.com/conda/conda/archive/#{source_input.version}.tar.gz"
+      results = Sha.check_sha(out_data[:url])
+      out_data[:sha256] = results[1]
 
     when -> (elem) { cnb_list.include?(elem) }
       results = Sha.check_sha(source_input)

--- a/tasks/update-cnb-dependency/cnb_dependencies.rb
+++ b/tasks/update-cnb-dependency/cnb_dependencies.rb
@@ -1,4 +1,4 @@
-class Dependencies
+class CNBDependencies
   def initialize(dep, line, removal_strategy, dependencies, dependencies_latest_released)
     @dep = dep
     @line = line
@@ -33,7 +33,17 @@ class Dependencies
     end
   end
 
+  def update_default_dependencies(defaults)
+  end
+
   private
+
+  def update_default_deps(buildpack_toml, removal_strategy)
+    if buildpack_toml.dig('metadata', 'default_versions').nil?
+      return false
+    end
+    removal_strategy == "remove_all"
+  end
 
   def latest?
     @matching_deps.all? do |d|

--- a/tasks/update-cnb-dependency/cnb_dependencies.rb
+++ b/tasks/update-cnb-dependency/cnb_dependencies.rb
@@ -37,14 +37,6 @@ class CNBDependencies
   end
 
   private
-
-  def update_default_deps(buildpack_toml, removal_strategy)
-    if buildpack_toml.dig('metadata', 'default_versions').nil?
-      return false
-    end
-    removal_strategy == "remove_all"
-  end
-
   def latest?
     @matching_deps.all? do |d|
       Gem::Version.new(@dep['version']) > Gem::Version.new(d['version'])

--- a/tasks/update-cnb-dependency/cnb_dependencies.rb
+++ b/tasks/update-cnb-dependency/cnb_dependencies.rb
@@ -33,9 +33,6 @@ class CNBDependencies
     end
   end
 
-  def update_default_dependencies(defaults)
-  end
-
   private
   def latest?
     @matching_deps.all? do |d|

--- a/tasks/update-cnb-dependency/cnb_dependency_updates.rb
+++ b/tasks/update-cnb-dependency/cnb_dependency_updates.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+class CNBDependencyUpdates
+  class << self
+    # Replace all Time objects with DateTime (needed to use toml library)
+    # Will not replace Time objects if they occur as the key in a map.
+    def replace_date_with_time(obj, parent_obj = nil, accessor = nil)
+      if obj.class == Time
+        converted_time = time_to_datetime(obj)
+        if parent_obj == nil
+          return converted_time
+        end
+        parent_obj[accessor] = converted_time
+
+      elsif obj.class == Array
+        obj.each_with_index  do |val,index|
+          obj[index] = replace_date_with_time(val,obj,index)
+        end
+        return obj
+      elsif obj.class == Hash
+        obj.each do |key, value|
+          obj[key] = replace_date_with_time(value, obj, key)
+        end
+        return obj
+      else obj
+      end
+    end
+
+    # TODO: Move to buildpack_toml class
+    def update_dependency_deprecation_dates(deprecation_date, deprecation_link, version_line, dependency_name, deprecation_match, deprecation_dates)
+        dependency_deprecation_date = {
+            'version_line' => version_line.downcase,
+            'name'         => dependency_name,
+            'date'         => DateTime.parse(deprecation_date),
+            'link'         => deprecation_link,
+        }
+
+        unless deprecation_match.nil? or deprecation_match.empty? or deprecation_match.downcase == 'null'
+          dependency_deprecation_date['match'] = deprecation_match
+        end
+
+        deprecation_dates.reject{ |d| d['version_line'] == version_line.downcase and d['name'] == dependency_name}
+                          .push(dependency_deprecation_date)
+                          .sort_by{ |d| [d['name'], d['version_line'] ]}
+    end
+
+    def commit_message(dependency_name, resource_version, rebuilt, removed, total_stacks)
+      commit_message = "Add #{dependency_name} #{resource_version}"
+      commit_message = "Rebuild #{dependency_name} #{resource_version}" if rebuilt
+      if removed.length > 0
+        commit_message = "#{commit_message}, remove #{dependency_name} #{removed.join(', ')}"
+      end
+      commit_message + "\n\nfor stack(s) #{total_stacks.join(', ')}"
+    end
+
+    # TODO: Move to buildpack_toml class
+    def update_default_deps?(buildpack_toml, removal_strategy)
+      if buildpack_toml.dig('metadata', 'default_versions').nil?
+        return false
+      end
+      removal_strategy == "remove_all"
+    end
+
+    # TODO: Separate 2 purposes: dep updates, and commit message
+    def update_stacks_list(stack, dependency_name, stacks_so_far, stacks_map)
+      if (stack == 'any-stack') || (stack == 'cflinuxfs3' && dependency_name == 'dep') # TODO Figure out if temporary
+        stacks_so_far += stacks_map.values
+        v3_stacks = stacks_map.values
+      else
+        stacks_so_far += [stacks_map[stack]]
+        v3_stacks = [stacks_map[stack]]
+        if stack == 'bionic'
+          if dependency_name == "go" or dependency_name == "dep"
+            v3_stacks += [stacks_map['tiny']]
+            stacks_so_far |= [stacks_map['tiny']]
+          end
+        end
+      end
+      [v3_stacks, stacks_so_far]
+    end
+
+    private
+    def time_to_datetime(time)
+      DateTime.parse(time.to_s)
+    end
+  end
+end

--- a/tasks/update-cnb-dependency/dependency.rb
+++ b/tasks/update-cnb-dependency/dependency.rb
@@ -1,0 +1,30 @@
+require 'yaml'
+
+buildpacks_ci_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+config = YAML.load_file(File.join(buildpacks_ci_dir, 'pipelines/config/dependency-builds.yml'))
+V3_DEP_IDS = config['v3_dep_ids']
+V3_DEP_NAMES = config['v3_dep_names']
+
+class Dependency
+  attr_reader :id, :name, :version, :uri, :sha256, :stacks, :osl, :source, :source_sha256
+  def initialize(dependency_name, resource_version, url, sha256, stacks, source_url, source_sha256)
+      @id = V3_DEP_IDS.fetch(dependency_name, dependency_name)
+      @name = V3_DEP_NAMES[dependency_name]
+      @version = resource_version
+      @uri = url
+      @sha256 = sha256
+      @stacks = stacks
+      unless source_sha256.nil? or source_sha256 == ""
+        @source = correct_source_url(source_url)
+        @source_sha256 = source_sha256
+      end
+  end
+
+  private
+  def correct_source_url(source_url)
+    if @id.include? 'miniconda'
+      return "https://github.com/conda/conda/archive/#{version}.tar.gz"
+    end
+    source_url
+  end
+end

--- a/tasks/update-cnb-dependency/run.rb
+++ b/tasks/update-cnb-dependency/run.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 require 'date'
 require 'set'
 require 'yaml'
-require_relative './dependencies'
+require_relative './cnb_dependencies'
 
 buildpacks_ci_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
 require_relative "#{buildpacks_ci_dir}/lib/git-client"
@@ -171,7 +171,7 @@ Dir[dependency_build_glob].each do |stack_dependency_build|
                      .select {|d| d['id'] == V3_DEP_IDS.fetch(dependency_name, dependency_name)}
                      .map {|d| d['version']}
 
-  buildpack_toml['metadata']['dependencies'] = Dependencies.new(
+  buildpack_toml['metadata']['dependencies'] = CNBDependencies.new(
       dep,
       version_line_type,
       removal_strategy,
@@ -182,6 +182,11 @@ Dir[dependency_build_glob].each do |stack_dependency_build|
   new_versions = buildpack_toml['metadata']['dependencies']
                      .select {|d| d['id'] == V3_DEP_IDS.fetch(dependency_name, dependency_name)}
                      .map {|d| d['version']}
+
+  if update_default_deps(buildpack_toml, removal_strategy)
+    default_deps = buildpack_toml.dig('metadata', 'default_versions')
+    default_deps[dependency_name] = version
+  end
 
   added += (new_versions - old_versions).uniq.sort
   removed += (old_versions - new_versions).uniq.sort

--- a/tasks/update-cnb-dependency/run.rb
+++ b/tasks/update-cnb-dependency/run.rb
@@ -98,6 +98,7 @@ Dir[dependency_build_glob].each do |stack_dependency_build|
   if CNBDependencyUpdates.update_default_deps?(buildpack_toml, removal_strategy)
     default_deps = buildpack_toml.dig('metadata', 'default_versions')
     default_deps[dependency_name] = version
+    buildpack_toml['metadata']['default_versions'] = default_deps
   end
 
   added += (new_versions - old_versions).uniq.sort


### PR DESCRIPTION
The problems that the story came to solve is updating the default versions, if we are supposed to, with the current version. I first made a method for that (update_default_deps?), though I wasn't sure if that cases were all correct (I know that if the removal_strategy is `remove_all`, we only keep the latest, so then we definitely want to update default dependencies, but otherwise I wasn't sure whether we should or not). 

In dealing with the refactor, I first tried to take out all segmented pieces of work from `tasks/update-cnb-dependencies/run.rb`, moving them as static methods into a `CNBDependencyUpdates` module as a temporary step. In so doing, I took out/changed a few things:
* We'd had a particular case with `miniconda`, where for some reason, we were changing the `source-url`. I changed that in `tasks/build-binary-new/builder.rb` to use the source we were saying in our buildpacks (it looks like there was a mismatch, because we download it from the miniconda site, which has more stable distributions (and skips some of them from Github), but the ultimate source is at `github.com/conda/conda`). 
* The logic to update default-deprecation dates isn't tied to any particular stack, and shouldn't live in that large loop for each stack/file in public-ci-robots. I moved it out of that
* We had logic for appdynamics and CAAPM, but given that we don't build the partner CNBs, that logic isn't relevant for us, so I took it out
* We had a false comment for the rebuild case
* I made a Dependency class to wrap the concept of a dependency, and move some specific miniconda logic (updating the `source-url` if it is not the github url).

Now that it is more deconstructed, I thought that the way I would move forward in the refactor would be:
1. Make a BuildpackToml class to wrap all information, and all adjustments made to the buildpack toml information, and move a number of the methods that I pulled into CNBDependencyUpdates into that. 
1. Change the CNBDependencies class so that it isn't constructed with a particular dependency, but instead wraps all the logic to compare two BuildpackToml objects, and switch a dependency based on a `removal_strategy`); and pass in a particular dependency to the oddly named `switch` method, instead of just the one it was constructed with

I'm glad to hear other ideas, and to look at the results after I get back from vacation. 