### PR TITLE
169680854 collapse dependencies

### DIFF
--- a/tasks/update-cnb-dependency/buildpack_toml.go
+++ b/tasks/update-cnb-dependency/buildpack_toml.go
@@ -31,27 +31,49 @@ var (
 	DefaultVersionsKey  = "default-versions"
 )
 
-func (buildpackTOML BuildpackTOML) Dependencies() (Dependencies, error) {
-	var deps Dependencies
-	err := mapstructure.Decode(buildpackTOML.Metadata[DependenciesKey], &deps)
-	return deps, err
-}
-
-func (buildpackTOML *BuildpackTOML) SaveDependencies(deps Dependencies) {
-	buildpackTOML.Metadata[DependenciesKey] = deps
-}
-
-func (buildpackTOML BuildpackTOML) DeprecationDates() (DeprecationDates, error) {
-	var deprecationDates DeprecationDates
-	err := mapstructure.Decode(buildpackTOML.Metadata[DeprecationDatesKey], &deprecationDates)
-	return deprecationDates, err
-}
-
-func (buildpackTOML *BuildpackTOML) SaveDeprecationDates(dates DeprecationDates) {
-	if len(dates) > 0 {
-		buildpackTOML.Metadata[DeprecationDatesKey] = dates // Metadata is untyped so we can get empty values
+func (buildpackTOML *BuildpackTOML) UpdateDependenciesWith(dep Dependency, newDeps Dependencies, versionsToKeep int) (Dependencies, Dependencies, error) {
+	deps, err := buildpackTOML.loadDependencies()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to decode dependencies")
 	}
+
+	updatedDeps, err := deps.Update(dep, newDeps, flags.versionLine, versionsToKeep)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to add new dependencies to the dependencies list")
+	}
+	buildpackTOML.saveDependencies(updatedDeps)
+
+	return deps, updatedDeps, nil
 }
+
+func (buildpackTOML *BuildpackTOML) UpdateDeprecationDatesWith(date DependencyDeprecationDate) error {
+	deprecationDates, err := buildpackTOML.loadDeprecationDates()
+	if err != nil {
+		return errors.Wrap(err, "failed to decode deprecation dates")
+	}
+
+	updatedDeprecationDates, err := deprecationDates.Update(date)
+	if err != nil {
+		return errors.Wrap(err, "failed to update deprecation dates")
+	}
+	buildpackTOML.saveDeprecationDates(updatedDeprecationDates)
+
+	return nil
+}
+
+func (buildpackTOML *BuildpackTOML) UpdateOrdersWith(dep Dependency) {
+	buildpackTOML.Orders = buildpackTOML.Orders.Update(dep)
+}
+
+// This wont work until golang 1.13
+//func (buildpackTOML *BuildpackTOML) RemoveEmptyMetadataFields() {
+//	for k, v := range buildpackTOML.Metadata {
+//		value := reflect.ValueOf(v)
+//		if value.IsZero(v) {
+//			delete(buildpackTOML.Metadata, k)
+//		}
+//	}
+//}
 
 func (buildpackTOML BuildpackTOML) WriteToFile(filepath string) error {
 	buildpackTOMLFile, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
@@ -61,7 +83,29 @@ func (buildpackTOML BuildpackTOML) WriteToFile(filepath string) error {
 	defer buildpackTOMLFile.Close()
 
 	if err := toml.NewEncoder(buildpackTOMLFile).Encode(buildpackTOML); err != nil {
-		return errors.Wrap(err, "failed to save updated buildpack.toml")
+		return errors.Wrap(err, "failed to update the buildpack.toml")
 	}
 	return nil
+}
+
+func (buildpackTOML BuildpackTOML) loadDependencies() (Dependencies, error) {
+	var deps Dependencies
+	err := mapstructure.Decode(buildpackTOML.Metadata[DependenciesKey], &deps)
+	return deps, err
+}
+
+func (buildpackTOML *BuildpackTOML) saveDependencies(deps Dependencies) {
+	buildpackTOML.Metadata[DependenciesKey] = deps
+}
+
+func (buildpackTOML BuildpackTOML) loadDeprecationDates() (DeprecationDates, error) {
+	var deprecationDates DeprecationDates
+	err := mapstructure.Decode(buildpackTOML.Metadata[DeprecationDatesKey], &deprecationDates)
+	return deprecationDates, err
+}
+
+func (buildpackTOML *BuildpackTOML) saveDeprecationDates(dates DeprecationDates) {
+	if len(dates) > 0 {
+		buildpackTOML.Metadata[DeprecationDatesKey] = dates
+	}
 }

--- a/tasks/update-cnb-dependency/buildpack_toml.go
+++ b/tasks/update-cnb-dependency/buildpack_toml.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -23,12 +24,34 @@ type BuildpackTOML struct {
 type Metadata map[string]interface{}
 
 var (
-	IncludeFilesKey = "include_files"
-	PrePackageKey = "pre_package"
+	IncludeFilesKey     = "include_files"
+	PrePackageKey       = "pre_package"
 	DeprecationDatesKey = "dependency_deprecation_dates"
-	DependenciesKey = "dependencies"
-	DefaultVersionsKey = "default-versions"
+	DependenciesKey     = "dependencies"
+	DefaultVersionsKey  = "default-versions"
 )
+
+func (buildpackTOML BuildpackTOML) Dependencies() (Dependencies, error) {
+	var deps Dependencies
+	err := mapstructure.Decode(buildpackTOML.Metadata[DependenciesKey], &deps)
+	return deps, err
+}
+
+func (buildpackTOML *BuildpackTOML) SaveDependencies(deps Dependencies) {
+	buildpackTOML.Metadata[DependenciesKey] = deps
+}
+
+func (buildpackTOML BuildpackTOML) DeprecationDates() (DeprecationDates, error) {
+	var deprecationDates DeprecationDates
+	err := mapstructure.Decode(buildpackTOML.Metadata[DeprecationDatesKey], &deprecationDates)
+	return deprecationDates, err
+}
+
+func (buildpackTOML *BuildpackTOML) SaveDeprecationDates(dates DeprecationDates) {
+	if len(dates) > 0 {
+		buildpackTOML.Metadata[DeprecationDatesKey] = dates // Metadata is untyped so we can get empty values
+	}
+}
 
 func (buildpackTOML BuildpackTOML) WriteToFile(filepath string) error {
 	buildpackTOMLFile, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)

--- a/tasks/update-cnb-dependency/dependencies.go
+++ b/tasks/update-cnb-dependency/dependencies.go
@@ -22,10 +22,10 @@ type Dependency struct {
 	Version      string   `toml:"version"`
 }
 
-func (deps Dependencies) Update(flags Flags, dep Dependency, depsToAdd Dependencies) (Dependencies, error) {
+func (deps Dependencies) Update(dep Dependency, depsToAdd Dependencies, versionLine string, versionsToKeep int) (Dependencies, error) {
 	originalDeps := deps.ExpandByStack()
 	updatedDeps := originalDeps.MergeWith(depsToAdd)
-	updatedDeps, err := updatedDeps.RemoveOldDeps(dep.ID, flags.versionLine, flags.versionsToKeep)
+	updatedDeps, err := updatedDeps.RemoveOldDeps(dep.ID, versionLine, versionsToKeep)
 	if err != nil {
 		return Dependencies{}, errors.Wrap(err, "failed to remove old dependencies")
 	}

--- a/tasks/update-cnb-dependency/dependencies_test.go
+++ b/tasks/update-cnb-dependency/dependencies_test.go
@@ -27,8 +27,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-2", Stacks: []string{"some-stack-1"}, Version: "2.0.0"},
 				}
 
-				newDeps, err := existingDeps.MergeWith(depsToAdd)
-				require.NoError(t, err)
+				newDeps := existingDeps.MergeWith(depsToAdd)
 				assert.Equal(t, Dependencies{
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "2.0.0"},
@@ -49,8 +48,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-1", Stacks: []string{"some-stack-2"}, Version: "2.0.0"},
 				}
 
-				newDeps, err := existingDeps.MergeWith(depsToAdd)
-				require.NoError(t, err)
+				newDeps := existingDeps.MergeWith(depsToAdd)
 				assert.Equal(t, Dependencies{
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
 					{ID: "some-id-1", Stacks: []string{"some-stack-2"}, Version: "1.0.0"},
@@ -71,8 +69,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-1", Stacks: []string{"some-stack-2"}, Version: "2.0.0"},
 				}
 
-				newDeps, err := existingDeps.MergeWith(depsToAdd)
-				require.NoError(t, err)
+				newDeps := existingDeps.MergeWith(depsToAdd)
 				assert.Equal(t, Dependencies{
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
 					{ID: "some-id-1", Stacks: []string{"some-stack-2"}, Version: "1.0.0"},
@@ -93,8 +90,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "2.0.0", SHA256: "some-new-sha"},
 				}
 
-				newDeps, err := existingDeps.MergeWith(depsToAdd)
-				require.NoError(t, err)
+				newDeps := existingDeps.MergeWith(depsToAdd)
 				assert.Equal(t, Dependencies{
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0", SHA256: "some-new-sha"},
 					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "2.0.0", SHA256: "some-new-sha"},

--- a/tasks/update-cnb-dependency/dependencies_test.go
+++ b/tasks/update-cnb-dependency/dependencies_test.go
@@ -226,7 +226,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-3", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
 				}
 
-				newDeps := originalDeps.CollapseEqualDependecies()
+				newDeps := originalDeps.CollapseByStack()
 				assert.Equal(t, collapsedDeps, newDeps)
 			})
 		})
@@ -251,7 +251,7 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 					{ID: "some-id-6", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
 				}
 
-				newDeps := originalDeps.CollapseEqualDependecies()
+				newDeps := originalDeps.CollapseByStack()
 				assert.Equal(t, collapsedDeps, newDeps)
 			})
 		})

--- a/tasks/update-cnb-dependency/dependencies_test.go
+++ b/tasks/update-cnb-dependency/dependencies_test.go
@@ -207,4 +207,53 @@ func testDependencies(t *testing.T, when spec.G, it spec.S) {
 			assert.EqualError(t, err, `please specify a valid number of versions (>0) to retain`)
 		})
 	})
+
+	when("CollapseEqualDependencies", func() {
+		when("there are equal dependencies to be collapsed", func() {
+			it("combines equal dependencies, and leaves dependencies which aren't equal", func() {
+				originalDeps := Dependencies{
+					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
+					{ID: "some-id-1", Stacks: []string{"some-stack-2"}, Version: "1.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-1"}, Version: "2.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-2"}, Version: "2.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-3"}, Version: "2.0.0"},
+					{ID: "some-id-3", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
+				}
+
+				collapsedDeps := Dependencies{
+					{ID: "some-id-1", Stacks: []string{"some-stack-1", "some-stack-2"}, Version: "1.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-1", "some-stack-2", "some-stack-3"}, Version: "2.0.0"},
+					{ID: "some-id-3", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
+				}
+
+				newDeps := originalDeps.CollapseEqualDependecies()
+				assert.Equal(t, collapsedDeps, newDeps)
+			})
+		})
+
+		when("there are no equal dependencies to be collapsed", func() {
+			it("leaves the dependencies the same", func() {
+				originalDeps := Dependencies{
+					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-2"}, Version: "1.0.0"},
+					{ID: "some-id-3", Stacks: []string{"some-stack-1"}, Version: "2.0.0"},
+					{ID: "some-id-4", Stacks: []string{"some-stack-2"}, Version: "2.0.0"},
+					{ID: "some-id-5", Stacks: []string{"some-stack-3"}, Version: "2.0.0"},
+					{ID: "some-id-6", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
+				}
+
+				collapsedDeps := Dependencies{
+					{ID: "some-id-1", Stacks: []string{"some-stack-1"}, Version: "1.0.0"},
+					{ID: "some-id-2", Stacks: []string{"some-stack-2"}, Version: "1.0.0"},
+					{ID: "some-id-3", Stacks: []string{"some-stack-1"}, Version: "2.0.0"},
+					{ID: "some-id-4", Stacks: []string{"some-stack-2"}, Version: "2.0.0"},
+					{ID: "some-id-5", Stacks: []string{"some-stack-3"}, Version: "2.0.0"},
+					{ID: "some-id-6", Stacks: []string{"some-stack-2"}, Version: "3.0.0"},
+				}
+
+				newDeps := originalDeps.CollapseEqualDependecies()
+				assert.Equal(t, collapsedDeps, newDeps)
+			})
+		})
+	})
 }

--- a/tasks/update-cnb-dependency/generate_commit_message.go
+++ b/tasks/update-cnb-dependency/generate_commit_message.go
@@ -16,8 +16,7 @@ func GenerateCommitMessage(oldDeps, newDeps Dependencies, dep Dependency, storyI
 
 func findAddedDeps(dep Dependency, oldDeps, newDeps Dependencies) (bool, bool, map[string]bool) {
 	var added, rebuilt bool
-	// Use maps to ensure no duplicates
-	stacks := map[string]bool{}
+	uniqueStacks := map[string]bool{}
 
 	for _, newDep := range newDeps {
 		if newDep.ID != dep.ID || newDep.Version != dep.Version {
@@ -34,11 +33,11 @@ func findAddedDeps(dep Dependency, oldDeps, newDeps Dependencies) (bool, bool, m
 		}
 
 		for _, stack := range newDep.Stacks {
-			stacks[stack] = true
+			uniqueStacks[stack] = true
 		}
 	}
 
-	return added, rebuilt, stacks
+	return added, rebuilt, uniqueStacks
 }
 
 func findRemovedDeps(dep Dependency, oldDeps, newDeps Dependencies, stacks map[string]bool) (map[string]bool, map[string]bool) {

--- a/tasks/update-cnb-dependency/main.go
+++ b/tasks/update-cnb-dependency/main.go
@@ -75,7 +75,7 @@ func updateCNBDependencies() error {
 		return errors.Wrap(err, "failed to remove old dependencies")
 	}
 
-	collapsedUpdatedDeps := updatedDeps.CollapseEqualDependecies()
+	collapsedUpdatedDeps := updatedDeps.CollapseByStack()
 
 	updatedOrder := config.BuildpackTOML.Orders.UpdateOrderDependencyVersion(config.Dep)
 

--- a/tasks/update-cnb-dependency/main.go
+++ b/tasks/update-cnb-dependency/main.go
@@ -75,6 +75,8 @@ func updateCNBDependencies() error {
 		return errors.Wrap(err, "failed to remove old dependencies")
 	}
 
+	collapsedUpdatedDeps := updatedDeps.CollapseEqualDependecies()
+
 	updatedOrder := config.BuildpackTOML.Orders.UpdateOrderDependencyVersion(config.Dep)
 
 	var deprecationDates DeprecationDates
@@ -87,11 +89,11 @@ func updateCNBDependencies() error {
 		return errors.Wrap(err, "failed to update deprecation dates")
 	}
 
-	config.BuildpackTOML.Metadata[DependenciesKey] = updatedDeps
+	config.BuildpackTOML.Metadata[DependenciesKey] = collapsedUpdatedDeps
 	if len(updatedDeprecationDates) > 0 {
 		config.BuildpackTOML.Metadata[DeprecationDatesKey] = updatedDeprecationDates
 	}
-	// onfig.BuildpackTOML.Metadata = zeroMetadata(config.BuildpackTOML.Metadata => see comment below
+	// config.BuildpackTOML.Metadata = zeroMetadata(config.BuildpackTOML.Metadata => see comment below
 
 	config.BuildpackTOML.Orders = updatedOrder
 

--- a/tasks/update-cnb-dependency/main_test.go
+++ b/tasks/update-cnb-dependency/main_test.go
@@ -1,13 +1,14 @@
 package main_test
 
 import (
-	"github.com/mitchellh/mapstructure"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/BurntSushi/toml"
 	. "github.com/cloudfoundry/buildpacks-ci/tasks/update-cnb-dependency"
@@ -80,9 +81,9 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 			var buildpackTOML BuildpackTOML
 			_, err = toml.DecodeFile(filepath.Join(outputDir, "buildpack.toml"), &buildpackTOML)
 			require.NoError(t, err)
-			assert.Equal(t, "./scripts/build.sh", buildpackTOML.Metadata[PrePackageKey], )
-			assert.Equal(t, "random", buildpackTOML.Metadata["random"], )
-			assert.Equal(t, []interface{}{"bin/build", "bin/detect", "buildpack.toml"}, buildpackTOML.Metadata[IncludeFilesKey], )
+			assert.Equal(t, "./scripts/build.sh", buildpackTOML.Metadata[PrePackageKey])
+			assert.Equal(t, "random", buildpackTOML.Metadata["random"])
+			assert.Equal(t, []interface{}{"bin/build", "bin/detect", "buildpack.toml"}, buildpackTOML.Metadata[IncludeFilesKey])
 			assert.Equal(t, map[string]interface{}{
 				"some-dep": "2.x",
 			}, buildpackTOML.Metadata[DefaultVersionsKey])
@@ -266,16 +267,7 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 					SHA256:       "sha256-for-binary-1.0.1",
 					Source:       "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz",
 					SourceSHA256: "sha256-for-source-1.0.1",
-					Stacks:       []string{"io.buildpacks.stacks.bionic"},
-					URI:          "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz",
-					Version:      "1.0.1",
-				},
-				{
-					ID:           "org.cloudfoundry.some-child",
-					SHA256:       "sha256-for-binary-1.0.1",
-					Source:       "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz",
-					SourceSHA256: "sha256-for-source-1.0.1",
-					Stacks:       []string{"org.cloudfoundry.stacks.cflinuxfs3"},
+					Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"},
 					URI:          "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz",
 					Version:      "1.0.1",
 				},
@@ -375,24 +367,7 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 					SHA256:       "sha256-for-binary-1.0.1",
 					Source:       "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz",
 					SourceSHA256: "sha256-for-source-1.0.1",
-					Stacks:       []string{"io.buildpacks.stacks.bionic"},
-					URI:          "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz",
-					Version:      "1.0.1",
-				},
-				{
-					ID:           "org.cloudfoundry.some-child",
-					SHA256:       "sha256-for-binary-1.0.1",
-					Source:       "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz",
-					SourceSHA256: "sha256-for-source-1.0.1",
-					Stacks:       []string{"org.cloudfoundry.stacks.cflinuxfs3"},
-					URI:          "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz",
-					Version:      "1.0.1",
-				}, {
-					ID:           "org.cloudfoundry.some-child",
-					SHA256:       "sha256-for-binary-1.0.1",
-					Source:       "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz",
-					SourceSHA256: "sha256-for-source-1.0.1",
-					Stacks:       []string{"org.cloudfoundry.stacks.tiny"},
+					Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3", "org.cloudfoundry.stacks.tiny"},
 					URI:          "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz",
 					Version:      "1.0.1",
 				},

--- a/tasks/update-cnb-dependency/orders.go
+++ b/tasks/update-cnb-dependency/orders.go
@@ -11,7 +11,7 @@ type Group struct {
 	Version string `toml:"version"`
 }
 
-func (orders Orders) UpdateOrderDependencyVersion(dep Dependency) Orders {
+func (orders Orders) Update(dep Dependency) Orders {
 	for i, order := range orders {
 		for j, group := range order.Group {
 			if group.ID == dep.ID {

--- a/tasks/update-cnb-dependency/orders_test.go
+++ b/tasks/update-cnb-dependency/orders_test.go
@@ -15,7 +15,7 @@ func TestOrders(t *testing.T) {
 }
 
 func testOrders(t *testing.T, when spec.G, it spec.S) {
-	when("UpdateOrderDependencyVersion", func() {
+	when("Update", func() {
 		dep := Dependency{
 			ID:      "dep",
 			Version: "1.2.3",
@@ -26,7 +26,7 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 
 		when("order is empty", func() {
 			it("shouldn't do anything", func() {
-				assert.Equal(t, nilOrders.UpdateOrderDependencyVersion(dep), nilOrders)
+				assert.Equal(t, nilOrders.Update(dep), nilOrders)
 			})
 		})
 
@@ -42,7 +42,7 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 						ID:      "dep",
 						Version: "1.2.3",
 					}}}}
-				updatedOrder := orders.UpdateOrderDependencyVersion(dep)
+				updatedOrder := orders.Update(dep)
 				assert.Equal(t, expectedOrders, updatedOrder)
 			})
 		})
@@ -54,7 +54,7 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 						ID:      "dep",
 						Version: "1.2.2",
 					}}}}
-				updatedOrder := orders.UpdateOrderDependencyVersion(dep)
+				updatedOrder := orders.Update(dep)
 				assert.Equal(t, orders, updatedOrder)
 			})
 		})
@@ -65,7 +65,7 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 					ID:      "dep",
 					Version: "1.2.2",
 				}}}}
-				updatedOrder := orders.UpdateOrderDependencyVersion(dep)
+				updatedOrder := orders.Update(dep)
 				expectedOrders := Orders{{Group: []Group{{
 					ID:      "dep",
 					Version: "1.2.3",
@@ -114,7 +114,7 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 							ID:      "dep3",
 							Version: "1.2.2",
 						}}}}
-				updatedOrder := orders.UpdateOrderDependencyVersion(dep)
+				updatedOrder := orders.Update(dep)
 				assert.Equal(t, expectedOrders, updatedOrder)
 			})
 		})


### PR DESCRIPTION
This implements a CollapseWithStack() method to collapse the expanded dependencies, such that equal dependency objects with different stacks will be combined. This should reduce the size of our `buildpack.tomls`. 