### PR TITLE
Retain optional field for buildpack order.groups

### DIFF
--- a/tasks/update-cnb-dependency/main_test.go
+++ b/tasks/update-cnb-dependency/main_test.go
@@ -1,13 +1,14 @@
 package main_test
 
 import (
-	"github.com/mitchellh/mapstructure"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/BurntSushi/toml"
 	. "github.com/cloudfoundry/buildpacks-ci/tasks/update-cnb-dependency"
@@ -80,9 +81,9 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 			var buildpackTOML BuildpackTOML
 			_, err = toml.DecodeFile(filepath.Join(outputDir, "buildpack.toml"), &buildpackTOML)
 			require.NoError(t, err)
-			assert.Equal(t, "./scripts/build.sh", buildpackTOML.Metadata[PrePackageKey], )
-			assert.Equal(t, "random", buildpackTOML.Metadata["random"], )
-			assert.Equal(t, []interface{}{"bin/build", "bin/detect", "buildpack.toml"}, buildpackTOML.Metadata[IncludeFilesKey], )
+			assert.Equal(t, "./scripts/build.sh", buildpackTOML.Metadata[PrePackageKey])
+			assert.Equal(t, "random", buildpackTOML.Metadata["random"])
+			assert.Equal(t, []interface{}{"bin/build", "bin/detect", "buildpack.toml"}, buildpackTOML.Metadata[IncludeFilesKey])
 			assert.Equal(t, map[string]interface{}{
 				"some-dep": "2.x",
 			}, buildpackTOML.Metadata[DefaultVersionsKey])
@@ -247,6 +248,13 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it.After(func() {
+			expectedGoldenFile, err := ioutil.ReadFile("testdata/updating-parent-cnb/golden_buildpack.toml")
+			require.NoError(t, err)
+
+			actualBuildpackTOML,err := ioutil.ReadFile(filepath.Join(outputDir, "buildpack.toml"))
+			require.NoError(t, err)
+
+			assert.Equal(t, actualBuildpackTOML, expectedGoldenFile)
 			require.NoError(t, os.RemoveAll(outputDir))
 		})
 
@@ -292,8 +300,9 @@ func testUpdateCNBDependencyTask(t *testing.T, when spec.G, it spec.S) {
 
 			assert.Equal(t, Orders{{Group: []Group{
 				{
-					ID:      "org.cloudfoundry.some-child",
-					Version: "1.0.1",
+					ID:       "org.cloudfoundry.some-child",
+					Version:  "1.0.1",
+					Optional: true,
 				},
 				{
 					ID:      "org.cloudfoundry.other-child",

--- a/tasks/update-cnb-dependency/orders.go
+++ b/tasks/update-cnb-dependency/orders.go
@@ -7,8 +7,9 @@ type Order struct {
 }
 
 type Group struct {
-	ID      string `toml:"id"`
-	Version string `toml:"version"`
+	ID       string `toml:"id"`
+	Version  string `toml:"version"`
+	Optional bool   `toml:"optional,omitempty"`
 }
 
 func (orders Orders) UpdateOrderDependencyVersion(dep Dependency) Orders {

--- a/tasks/update-cnb-dependency/orders_test.go
+++ b/tasks/update-cnb-dependency/orders_test.go
@@ -36,11 +36,13 @@ func testOrders(t *testing.T, when spec.G, it spec.S) {
 					Group: []Group{{
 						ID:      "dep",
 						Version: "1.2.3",
+						Optional: true,
 					}}}}
 				expectedOrders := Orders{{
 					Group: []Group{{
 						ID:      "dep",
 						Version: "1.2.3",
+						Optional: true,
 					}}}}
 				updatedOrder := orders.UpdateOrderDependencyVersion(dep)
 				assert.Equal(t, expectedOrders, updatedOrder)

--- a/tasks/update-cnb-dependency/testdata/updating-parent-cnb/buildpack.toml
+++ b/tasks/update-cnb-dependency/testdata/updating-parent-cnb/buildpack.toml
@@ -22,6 +22,7 @@ version = "1.0.0"
 [[order.group]]
 id = "org.cloudfoundry.some-child"
 version = "1.0.0"
+optional = true
 
 [[order.group]]
 id = "org.cloudfoundry.other-child"

--- a/tasks/update-cnb-dependency/testdata/updating-parent-cnb/golden_buildpack.toml
+++ b/tasks/update-cnb-dependency/testdata/updating-parent-cnb/golden_buildpack.toml
@@ -1,0 +1,38 @@
+api = "0.2"
+
+[buildpack]
+  id = "org.cloudfoundry.some-parent"
+  name = "Some Parent Buildpack"
+  version = "{{.Version}}"
+
+[metadata]
+  include_files = ["buildpack.toml"]
+
+  [[metadata.dependencies]]
+    id = "org.cloudfoundry.some-child"
+    sha256 = "sha256-for-binary-1.0.1"
+    source = "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz"
+    source_sha256 = "sha256-for-source-1.0.1"
+    stacks = ["io.buildpacks.stacks.bionic"]
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz"
+    version = "1.0.1"
+
+  [[metadata.dependencies]]
+    id = "org.cloudfoundry.some-child"
+    sha256 = "sha256-for-binary-1.0.1"
+    source = "https://github.com/cloudfoundry/some-child-cnb/archive/v1.0.1.tar.gz"
+    source_sha256 = "sha256-for-source-1.0.1"
+    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
+    uri = "https://buildpacks.cloudfoundry.org/dependencies/org.cloudfoundry.some-child/org.cloudfoundry.some-child-1.0.1-any-stack-bbbbbbbb.tgz"
+    version = "1.0.1"
+
+[[order]]
+
+  [[order.group]]
+    id = "org.cloudfoundry.some-child"
+    version = "1.0.1"
+    optional = true
+
+  [[order.group]]
+    id = "org.cloudfoundry.other-child"
+    version = "2.0.0"


### PR DESCRIPTION
 - Adds test for golden file of metabuildpack generation (see: https://youtu.be/8hQG7QlcLBk?t=823)

[#169716321]