### PR TITLE
Adding `--with-http_v2_module` for http_v2 support

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -239,6 +239,7 @@ module DependencyBuild
             '--prefix=/',
             '--error-log-path=stderr',
             '--with-http_ssl_module',
+            '--with-http_v2_module',
             '--with-http_realip_module',
             '--with-http_gunzip_module',
             '--with-http_gzip_static_module',


### PR DESCRIPTION
Added '--with-http_v2_module' flag to base_nginx_options for default http_v2 module support.