### PR TITLE
Remove incorrect words from jruby dependencies

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -714,8 +714,13 @@ class Builder
         raise "Unsupported jruby version line #{source_input.version}"
       end
 
+
       # Create a copy of the source_input to prevent mutating version for later use
       full_version = "#{source_input.version}-ruby-#{ruby_version}"
+
+      filename = "#{binary_builder.base_dir}/#{source_input_name}-#{full_version}-linux-x64.tgz"
+      Archive.strip_incorrect_words_yaml_from_tar(filename)
+
       binary_builder.build(
           SourceInput.new(
               source_input.name,
@@ -730,7 +735,7 @@ class Builder
       out_data.merge!(
           artifact_output.move_dependency(
               source_input.name,
-              "#{binary_builder.base_dir}/#{source_input.name}-#{full_version}-linux-x64.tgz",
+              filename,
               "#{source_input.name}_#{full_version}_linux_x64_#{stack}",
           )
       )

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -718,9 +718,6 @@ class Builder
       # Create a copy of the source_input to prevent mutating version for later use
       full_version = "#{source_input.version}-ruby-#{ruby_version}"
 
-      filename = "#{binary_builder.base_dir}/#{source_input_name}-#{full_version}-linux-x64.tgz"
-      Archive.strip_incorrect_words_yaml_from_tar(filename)
-
       binary_builder.build(
           SourceInput.new(
               source_input.name,
@@ -731,6 +728,9 @@ class Builder
               source_input.git_commit_sha
           )
       )
+
+      filename = "#{binary_builder.base_dir}/#{source_input.name}-#{full_version}-linux-x64.tgz"
+      Archive.strip_incorrect_words_yaml_from_tar(filename)
 
       out_data.merge!(
           artifact_output.move_dependency(


### PR DESCRIPTION
Relating this this issue https://github.com/cloudfoundry/ruby-buildpack/issues/125

We need to remove the invalid file from all ruby dependencies as well as ruby.

Thanks,

Andrew