### PR TITLE
Remove all references to incorrect_words.yaml

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -408,8 +408,7 @@ module Archive
     def strip_incorrect_words_yaml_from_tar(filename)
       Dir.mktmpdir do |dir|
         Runner.run('tar', '-C', dir, '-xf', filename)
-        Runner.run('rm', '-f', dir + '/lib/ruby/gems/2.4.0/gems/did_you_mean-1.1.0/evaluation/incorrect_words.yaml')
-        Runner.run('rm', '-f', dir + '/lib/ruby/gems/2.5.0/gems/did_you_mean-1.2.0/evaluation/incorrect_words.yaml')
+        Runner.run("find", dir, "-type", "f" "-name", "incorrect_words.yaml", "-delete")
         Runner.run('tar', '-C', dir, '-czf', filename, '.')
       end
     end

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -408,7 +408,7 @@ module Archive
     def strip_incorrect_words_yaml_from_tar(filename)
       Dir.mktmpdir do |dir|
         Runner.run('tar', '-C', dir, '-xf', filename)
-        Runner.run("find", dir, "-type", "f" "-name", "incorrect_words.yaml", "-delete")
+        Runner.run('find', dir, '-type', 'f', '-name', 'incorrect_words.yaml', '-delete')
         Runner.run('tar', '-C', dir, '-czf', filename, '.')
       end
     end


### PR DESCRIPTION
Changed to remove all references to the incorrect_words.yaml instead of listing the paths.