### PR TITLE
Generate V2B release issues on Github

### DIFF
--- a/lib/release-github-issue-generator.rb
+++ b/lib/release-github-issue-generator.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'octokit'
 
 class ReleaseGithubIssueGenerator
   def initialize(octokit_client)

--- a/lib/release-github-issue-generator.rb
+++ b/lib/release-github-issue-generator.rb
@@ -1,28 +1,20 @@
 require 'yaml'
 
 class ReleaseGithubIssueGenerator
-  attr_reader :buildpack_name, :previous_buildpack_version, :old_manifest, :new_manifest
-
-  def initialize(octokit_client, buildpack_name:, previous_buildpack_version:,
-                old_manifest:, new_manifest:)
+  def initialize(octokit_client)
     @client = octokit_client
-    @buildpack_name = buildpack_name
-    @previous_buildpack_version = previous_buildpack_version
-
-    @old_manifest = old_manifest
-    @new_manifest = new_manifest
   end
 
-  def run!
-    # description = File.read(description_file_path).strip
+  def run(buildpack_name, previous_buildpack_version, old_manifest, new_manifest)
+    @previous_buildpack_version = previous_buildpack_version
+    @old_manifest = old_manifest
+    @new_manifest = new_manifest
     issue_name = "**Release:** #{buildpack_name}-buildpack #{new_release_version}"
 
     issue_description = "**Check the buildpack's develop branch for feature changes"
     issue_description += "\n**Dependency Changes:**\n\n"
     issue_description += generate_dependency_changes
     issue_description += "\nRefer to [release instructions](https://docs.cloudfoundry.org/buildpacks/releasing_a_new_buildpack_version.html).\n"
-
-    repos = File.read(repos_file_path).strip.split("\n")
 
     create_issues(issue_name, issue_description, buildpack_name)
   end

--- a/tasks/generate-buildpack-release-github-issue/run.rb
+++ b/tasks/generate-buildpack-release-github-issue/run.rb
@@ -2,9 +2,6 @@
 require 'octokit'
 require_relative '../../lib/release-github-issue-generator'
 
-## Required
-github_token = ENV.fetch('GITHUB_ACCESS_TOKEN') or raise 'Must supply env GITHUB_ACCESS_TOKEN'
-
 buildpack_name = ENV.fetch('BUILDPACK_NAME')
 previous_buildpack_version = `git -C buildpack-develop tag`.split("\n").map{ |i| i.strip.delete('v') }
   .select { |i| i =~ /\d+\.\d+\.\d+/ }.map { |i| Gem::Version.new(i) }.sort.last.to_s
@@ -12,10 +9,8 @@ previous_buildpack_version = `git -C buildpack-develop tag`.split("\n").map{ |i|
 old_manifest = `git -C buildpack-develop show v#{previous_buildpack_version}:manifest.yml`
 new_manifest = File.read('buildpack-develop/manifest.yml')
 
-client = Octokit::Client.new :access_token => github_token
+client = Octokit::Client.new :access_token => ENV.fetch('GITHUB_ACCESS_TOKEN')
 
-release_github_issue_creator = ReleaseGithubIssueGenerator.new(client: client)
 puts "Running ReleaseGithubIssueGenerator for #{buildpack_name}"
 
-# release_github_issue_creator.run!
-release_github_issue_creator.run(buildpack_name, previous_buildpack_version, old_manifest, new_manifest)
+ReleaseGithubIssueGenerator.new(client).run(buildpack_name, previous_buildpack_version, old_manifest, new_manifest)

--- a/tasks/generate-buildpack-release-github-issue/run.rb
+++ b/tasks/generate-buildpack-release-github-issue/run.rb
@@ -14,14 +14,8 @@ new_manifest = File.read('buildpack-develop/manifest.yml')
 
 client = Octokit::Client.new :access_token => github_token
 
-release_github_issue_creator = ReleaseGithubIssueGenerator.new(
-  client: client,
-  buildpack_name: buildpack_name,
-  previous_buildpack_version: previous_buildpack_version,
-  old_manifest:               old_manifest,
-  new_manifest:               new_manifest
-
-)
+release_github_issue_creator = ReleaseGithubIssueGenerator.new(client: client)
 puts "Running ReleaseGithubIssueGenerator for #{buildpack_name}"
 
-release_github_issue_creator.run!
+# release_github_issue_creator.run!
+release_github_issue_creator.run(buildpack_name, previous_buildpack_version, old_manifest, new_manifest)


### PR DESCRIPTION
Generates a release issue for V2B issues similar to what happens in https://github.com/cloudfoundry/buildpacks-ci/tree/master/tasks/create-buildpack-release-tracker-story but on Github

The following issue is an example of an issue that can be created with this:
https://github.com/cloudfoundry/go-buildpack/issues/148

To Do:
Automatically add it to the right project
Figure out how to add story details