### PR TITLE
Need to specify a TLS library with configure script

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -452,7 +452,7 @@ module DependencyBuild
       Dir.chdir('source') do
         Runner.run('tar', 'zxf', "curl-#{source_input.version}.tar.gz")
         Dir.chdir("curl-#{source_input.version}") do
-          Runner.run('./configure', "--prefix=#{built_path}")
+          Runner.run('./configure', "--prefix=#{built_path}", "--with-openssl")
           Runner.run('make')
           Runner.run('make install')
         end


### PR DESCRIPTION
The recent version of curl forces specification of a TLS library with configure.

Solves https://github.com/paketo-buildpacks/dep-server/issues/36

Context: https://github.com/curl/curl/pull/6897
