### PR TITLE
Remove .NET Core SDK 2.1.8X from SDK CNB

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -72,7 +72,6 @@ dependencies:
         removal_strategy: keep_all
       dotnet-core-sdk-cnb:
         lines:
-          - line: 2.1.8X
           - line: 3.1.4X
           - line: 5.0.1X
           - line: 5.0.2X


### PR DESCRIPTION
Removes 2.1.8X from the .NET Core SDK CNB pipeline since we no longer use this version in the buildpack.