### PR TITLE
Check the compiled artifact binaries are correct before upload

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -459,6 +459,11 @@ jobs: ##########################################################################
                 pivotal-buildpack-cached: pivotal-buildpack-cached-<%= stack %>
               output_mapping:
                 buildpack-artifacts: buildpack-artifacts-<%= stack %>
+            - task: check-built-artifacts
+              file: buildpacks-ci/tasks/check-built-artifacts/task.yml
+              input_mapping:
+                pivotal-buildpack: pivotal-buildpack-<%= stack %>
+                pivotal-buildpack-cached: pivotal-buildpack-cached-<%= stack %>
             - put: pivotal-buildpack-<%= stack %>
               params:
                 file: buildpack-artifacts-<%= stack %>/uncached/*_buildpack*-v*.zip

--- a/tasks/check-built-artifacts/run.sh
+++ b/tasks/check-built-artifacts/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -l
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Check both the cached and uncached artifacts to make sure the executables
+# have been compiled correctly
+
+export supply_binary_type finalize_binary_type
+
+supply_binary_type=$(unzip -q pivotal-buildpack -d uncached && file uncached/bin/supply)
+finalize_binary_type=$(file uncached/bin/finalize)
+
+if [[ $supply_binary_type != *"ELF 64-bit LSB executable, x86-64, version 1 (SYSV)"* &&
+$finalize_binary_type != *"ELF 64-bit LSB executable, x86-64, version 1 (SYSV)"* ]]; then
+  echo "uncached buildpack: supply or finalize scripts are not compiled correctly"
+  exit 1
+fi
+
+supply_binary_type=$(unzip -q pivotal-buildpack-cached -d cached && file cached/bin/supply)
+finalize_binary_type=$(file cached/bin/finalize)
+if [[ $supply_binary_type != *"ELF 64-bit LSB executable, x86-64, version 1 (SYSV)"* &&
+$finalize_binary_type != *"ELF 64-bit LSB executable, x86-64, version 1 (SYSV)"* ]]; then
+  echo "cached buildpack: supply or finalize scripts are not compiled correctly"
+  exit 1
+fi
+
+rm -rf cached uncached
+exit 0

--- a/tasks/check-built-artifacts/task.yml
+++ b/tasks/check-built-artifacts/task.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/ci
+inputs:
+  - name: pivotal-buildpack
+  - name: pivotal-buildpack-cached
+run:
+  path: buildpacks-ci/tasks/check-built-artifacts/run.sh


### PR DESCRIPTION
During [this run](https://buildpacks.ci.cf-app.com/teams/main/pipelines/r-buildpack/jobs/detect-new-version-and-upload-artifacts/builds/50) of the R buildpack `detect-new-version-and-upload-artifacts` Concourse job, it was discovered that the uncached buildpack was not compiled correctly. We are not sure how this happened, but we do not check that the buildpack zip archives look correct when they come out of the buildpack packager. As a result, we published a broken buildpack.

This adds a check in which we unzip both the cached and uncached buildpacks and double check that the finalize/supply binaries look correct.

Asking for a review on this change before I push to master. and fly these updates