### PR TITLE
Update the Python version used to build Pip dependency

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -18,29 +18,18 @@ end
 
 module DependencyBuild
   class << self
-
-    def self.build_python_for_pip(python_version)
-     # The python_version argument is the version of python that we are building for pip. It requires major, minor and
-     # patch. Eg: 3.7.4
-
-     Runner.run('apt', 'update')
-     Runner.run('apt', 'install', '-y', 'build-essential', 'zlib1g-dev', 'libncurses5-dev', 'libgdbm-dev', 'libnss3-dev', 'libssl-dev', 'libsqlite3-dev', 'libreadline-dev', 'libffi-dev', 'curl' ,'libbz2-dev')
-     Runner.run('mkdir', '-p', '/tmp/python/')
-     Runner.run('curl', '-L', 'https://www.python.org/ftp/python/' + python_version + '/Python-' + python_version + '.tgz', '-o', '/tmp/python/Python-' + python_version + '.tgz')
-     Runner.run('tar', '-xzf', '/tmp/python/Python.tgz', '-C', '/tmp/python/')
-     Runner.run('cd', '/tmp/python/Python-' + python_version + ' && ./configure && make && make install')
-    end
-
     def bundle_pip_dependencies(source_input)
       # final resting place for pip source and dependencies
       file_path = "/tmp/pip-#{source_input.version}.tgz"
       ENV['LC_CTYPE'] = 'en_US.UTF-8'
 
       # For the latest version of pip, it requires python version >= 3.7 (ref: https://github.com/pypa/pip/pull/10641),
-      # so we need to build python >= 3.7 first.
+      # so we need to install python >= 3.7 first.
 
-      build_python_for_pip('3.7.11')
-
+      Runner.run('apt', 'update')
+      Runner.run('apt', 'install', '-y', 'curl', 'python3.7', 'python3.7-distutils')
+      Runner.run('curl', '-L', 'https://bootstrap.pypa.io/get-pip.py', '-o', 'get-pip.py')
+      Runner.run('python3.7', 'get-pip.py')
       Runner.run('pip3', 'install', '--upgrade', 'pip')
       Runner.run('pip3', 'install', '--upgrade', 'setuptools')
       Dir.mktmpdir do |dir|

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -18,12 +18,29 @@ end
 
 module DependencyBuild
   class << self
+
+    def self.build_python_for_pip(python_version)
+     # The python_version argument is the version of python that we are building for pip. It requires major, minor and
+     # patch. Eg: 3.7.4
+
+     Runner.run('apt', 'update')
+     Runner.run('apt', 'install', '-y', 'build-essential', 'zlib1g-dev', 'libncurses5-dev', 'libgdbm-dev', 'libnss3-dev', 'libssl-dev', 'libsqlite3-dev', 'libreadline-dev', 'libffi-dev', 'curl' ,'libbz2-dev')
+     Runner.run('mkdir', '-p', '/tmp/python/')
+     Runner.run('curl', '-L', 'https://www.python.org/ftp/python/' + python_version + '/Python-' + python_version + '.tgz', '-o', '/tmp/python/Python-' + python_version + '.tgz')
+     Runner.run('tar', '-xzf', '/tmp/python/Python.tgz', '-C', '/tmp/python/')
+     Runner.run('cd', '/tmp/python/Python-' + python_version + ' && ./configure && make && make install')
+    end
+
     def bundle_pip_dependencies(source_input)
       # final resting place for pip source and dependencies
       file_path = "/tmp/pip-#{source_input.version}.tgz"
       ENV['LC_CTYPE'] = 'en_US.UTF-8'
-      Runner.run('apt', 'update')
-      Runner.run('apt-get', 'install', '-y', 'python3-pip')
+
+      # For the latest version of pip, it requires python version >= 3.7 (ref: https://github.com/pypa/pip/pull/10641),
+      # so we need to build python >= 3.7 first.
+
+      build_python_for_pip('3.7.11')
+
       Runner.run('pip3', 'install', '--upgrade', 'pip')
       Runner.run('pip3', 'install', '--upgrade', 'setuptools')
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
# Context

With the release of `Pip 22.0.0` any version of Pip `≥22.0.0` will require a Python version `≥ 3.7` ([ref](https://github.com/pypa/pip/pull/10641)).

# Solution

- Removed the command `apt-get install python3-pip` since it installs `Python 3.6.8`.
- Add the command `apt install` to install `python3.7` and `python3.7-distutils`.
- Install pip tool using the [`get-pip.py`](https://bootstrap.pypa.io/get-pip.py) script