### PR TITLE
Adds 'python3.7-dev' packaage to fix pip3 errors when installing poetry

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -21,7 +21,7 @@ module DependencyBuild
 
     def setup_python
       Runner.run('apt', 'update')
-      Runner.run('apt', 'install', '-y', 'curl', 'python3.7', 'python3.7-distutils')
+      Runner.run('apt', 'install', '-y', 'curl', 'python3.7', 'python3.7-distutils', 'python3.7-dev')
       Runner.run('curl', '-L', 'https://bootstrap.pypa.io/get-pip.py', '-o', 'get-pip.py')
       Runner.run('python3.7', 'get-pip.py')
       Runner.run('pip3', 'install', '--upgrade', 'pip', 'setuptools')


### PR DESCRIPTION
It seems that building `poetry` fails in some execution contexts due to the absence of the `python3.7-dev` OS package.

While attempting to execute the builder code on Ubuntu 18.04.6 LTS, the following error was observed:
```
Error:    c/_cffi_backend.c:2:10: fatal error: Python.h: No such file or directory
             #include <Python.h>
                      ^~~~~~~~~~
```
The documentation for the `cffi` python package mentions `python-dev` as a requirement for packaging `cffi` on non-Windows platforms. (See the "Requirements" section [here](https://cffi.readthedocs.io/en/latest/installation.html))

Though this has only been observed with `poetry` so far, it seemed appropriate to modify the `setup_python` code here.
