### PR TITLE
Update .NET Buildpack dependencies lines to only keep 1 of each patch version (latest)

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -59,26 +59,14 @@ dependencies:
           - line: 3.1.4X
             deprecation_date: 2022-12-03
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-          - line: 5.0.1X
-            deprecation_date: 2022-05-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-          - line: 5.0.2X
-            deprecation_date: 2022-05-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-          - line: 5.0.3X
-            deprecation_date: 2022-05-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
           - line: 5.0.4X
             deprecation_date: 2022-05-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-          - line: 6.0.1X
-            deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
           - line: 6.0.2X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_all
-    versions_to_keep: 99
+        removal_strategy: keep_latest_released
+    versions_to_keep: 1
     any_stack: true
   dotnet-runtime:
     buildpacks:
@@ -93,8 +81,8 @@ dependencies:
           - line: 6.0.X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_all
-    versions_to_keep: 2
+        removal_strategy: keep_latest_released
+    versions_to_keep: 1
     any_stack: true
   dotnet-aspnetcore:
     buildpacks:
@@ -109,8 +97,8 @@ dependencies:
           - line: 6.0.X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_all
-    versions_to_keep: 2
+        removal_strategy: keep_latest_released
+    versions_to_keep: 1
     any_stack: true
   glide:
     buildpacks:


### PR DESCRIPTION
Related to https://github.com/cloudfoundry/dotnet-core-buildpack/issues/518.