### PR TITLE
Set OCI8 version for PHP 7

### DIFF
--- a/tasks/build-binary-new/php7-base-extensions.yml
+++ b/tasks/build-binary-new/php7-base-extensions.yml
@@ -198,8 +198,8 @@ extensions:
   md5: 29fc866198d61bccdbc4c4f53fb7ef06
   klass: PeclRecipe
 - name: oci8
-  version: 3.2.1
-  md5: 309190ef3ede2779a617c9375d32ea7a
+  version: 2.2.0
+  md5: 678d2a647881cd8e5b458c669dcce215
   klass: OraclePeclRecipe
 - name: pdo_oci
   version: nil


### PR DESCRIPTION
PHP 7 needs oci8-2.2.0, see https://pecl.php.net/package/oci8