### PR TITLE
JRuby 9.1.X not having security patches

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -153,7 +153,6 @@ dependencies:
     buildpacks:
       ruby:
         lines:
-          - line: 9.1.X
           - line: 9.2.X
           - line: 9.3.X
     source_type: jruby


### PR DESCRIPTION
JRuby 9.1.X contains a high number of CVEs and does not support security patches. JRuby does not provide a page announcing which versions are deprecated, but it can be assumed since this version has not had a patch release since April.

References for the detailed CVEs found: https://github.com/cloudfoundry/ruby-buildpack/issues/448