### PR TITLE
Add hatchling dependency for pipenv.

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -87,6 +87,7 @@ module DependencyBuild
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'wheel')
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'invoke')
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'flit_core')
+          Runner.run('pip3', 'download', '--no-binary', ':all:', 'hatchling')
           Runner.run('tar', 'zcvf', old_file_path, '.')
         end
       end


### PR DESCRIPTION
- this is now required to build pipenv.