### PR TITLE
Pin pip to previous version in setup toolchain.

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -24,7 +24,7 @@ module DependencyBuild
       Runner.run('apt', 'install', '-y', 'curl', 'python3.7', 'python3.7-distutils', 'python3.7-dev')
       Runner.run('curl', '-L', 'https://bootstrap.pypa.io/get-pip.py', '-o', 'get-pip.py')
       Runner.run('python3.7', 'get-pip.py')
-      Runner.run('pip3', 'install', '--upgrade', 'pip', 'setuptools')
+      Runner.run('pip3', 'install', '--upgrade', 'pip==22.0.4', 'setuptools')
       Runner.run('rm', '-f', 'get-pip.py')
     end
 


### PR DESCRIPTION
This does not impact the version of pip that is installed as a dependency, only the version of pip that is used to install other dependencies, like pipenv.

The most recent version of pip is failing to install pipenv, so we pin to the previous version which worked.