### PR TITLE
Add hatch-vcs dependency to pipenv

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -88,6 +88,7 @@ module DependencyBuild
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'invoke')
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'flit_core')
           Runner.run('pip3', 'download', '--no-binary', ':all:', 'hatchling')
+          Runner.run('pip3', 'download', '--no-binary', ':all:', 'hatch-vcs')
           Runner.run('tar', 'zcvf', old_file_path, '.')
         end
       end


### PR DESCRIPTION
Another pipenv dependency that must be explicitly vendored.