### PR TITLE
Change the node version to latest in Ruby and .Net Core buildpacks

### DIFF
--- a/dockerfiles/depwatcher/README.md
+++ b/dockerfiles/depwatcher/README.md
@@ -11,9 +11,9 @@ The various depwatchers in this resource (in `src`) are written in Crystal, as a
 `crystal spec --no-debug`
 
 ### Notes
-* You may need to install dependencies via `crystal deps` before running tests.
-* You may need to set `export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"` if crystal fails link against `libssl`.
 
+- You may need to install dependencies via `crystal deps` before running tests.
+- You may need to set `export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"` if crystal fails link against `libssl`.
 
 ## Building/Pushing
 
@@ -24,12 +24,18 @@ The various depwatchers in this resource (in `src`) are written in Crystal, as a
 ## Example run
 
 ```
+## HWC
 $ echo '{"source":{"type":"github_releases","name":"hwc","repo":"cloudfoundry/hwc","extension":"exe"}}' | crystal src/check.cr
   {"source":{"type":"github_releases","name":"hwc","repo":"cloudfoundry/hwc","extension":"exe"}}
   [{"ref":"1.0.0"},{"ref":"1.0.1"},{"ref":"2.0.0"}]
 
 $ echo '{"source":{"type":"github_releases","name":"hwc","repo":"cloudfoundry/hwc","extension":"exe"},"version":{"ref":"2.0.0"}}' | crystal src/in.cr -- /tmp
-{"source":{"type":"github_releases","name":"hwc","repo":"cloudfoundry/hwc","extension":"exe"},"version":{"ref":"2.0.0"}}
+  {"source":{"type":"github_releases","name":"hwc","repo":"cloudfoundry/hwc","extension":"exe"},"version":{"ref":"2.0.0"}}
 {"ref":"2.0.0","url":"https://github.com/cloudfoundry/hwc/releases/download/2.0.0/hwc.exe","sha256":"1bad9c61262702404653f4d043d79082e8a181ee33e2c1e11db3eb346e7fcd33"}
 {"version":{"ref":"2.0.0"}}
+
+## Node
+$ echo '{"source":{"type":"node", "version_filter":"node-lts"}}' | crystal src/check.cr
+  {"source":{"type":"node","version_filter":"node-lts"}}
+  [{"ref":"16.0.0"},{"ref":"16.1.0"},{"ref":"16.2.0"},{"ref":"16.3.0"},{"ref":"16.4.0"},{"ref":"16.4.1"},{"ref":"16.4.2"},{"ref":"16.5.0"},{"ref":"16.6.0"},{"ref":"16.6.1"},{"ref":"16.6.2"},{"ref":"16.7.0"},{"ref":"16.8.0"},{"ref":"16.9.0"},{"ref":"16.9.1"},{"ref":"16.10.0"},{"ref":"16.11.0"},{"ref":"16.11.1"},{"ref":"16.12.0"},{"ref":"16.13.0"},{"ref":"16.13.1"},{"ref":"16.13.2"},{"ref":"16.14.0"},{"ref":"16.14.1"},{"ref":"16.14.2"},{"ref":"16.15.0"}]
 ```

--- a/dockerfiles/depwatcher/releases.xml
+++ b/dockerfiles/depwatcher/releases.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Releases | Node.js</title>
+
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com"/>
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com"/>
+
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&amp;display=fallback"/>
+  <link rel="stylesheet" href="/static/css/styles.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/styles/a11y-dark.min.css" integrity="sha512-Vj6gPCk8EZlqnoveEyuGyYaWZ1+jyjMPg8g4shwyyNlRQl6d3L9At02ZHQr5K6s5duZl/+YKMnM3/8pDhoUphg==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+
+  <meta name="author" content="Node.js"/>
+  <meta name="robots" content="index, follow"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."/>
+
+  <link rel="apple-touch-icon" href="/static/images/favicons/apple-touch-icon.png" sizes="180x180"/>
+  <link rel="icon" href="/static/images/favicons/favicon-32x32.png" sizes="32x32" type="image/png"/>
+  <link rel="icon" href="/static/images/favicons/favicon-16x16.png" sizes="16x16" type="image/png"/>
+  <link rel="manifest" href="/static/images/favicons/manifest.json"/>
+  <link rel="mask-icon" href="/static/images/favicons/safari-pinned-tab.svg" color="#43853d"/>
+  <link rel="shortcut icon" href="/static/images/favicons/favicon.ico"/>
+  <meta name="theme-color" content="#333"/>
+
+  <meta property="og:site_name" content="Node.js"/>
+  <meta property="og:title" content="Releases | Node.js"/>
+  <meta property="og:image" content="https://nodejs.org/static/images/logo-hexagon-card.png"/>
+  <meta property="og:image:type" content="image/png"/>
+  <meta property="og:image:width" content="224"/>
+  <meta property="og:image:height" content="256"/>
+  <meta property="og:description" content="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."/>
+
+  <meta name="twitter:card" content="summary"/>
+  <meta name="twitter:site" content="@nodejs"/>
+  <meta name="twitter:title" content="Releases | Node.js"/>
+  <meta name="twitter:image" content="https://nodejs.org/static/images/logo-hexagon-card.png"/>
+  <meta name="twitter:image:alt" content="The Node.js Hexagon Logo"/>
+
+  <link rel="canonical" href="https://nodejs.org/en/about/releases/"/>
+  <link rel="alternate" href="/en/feed/blog.xml" title="Node.js Blog" type="application/rss+xml"/>
+  <link rel="alternate" href="/en/feed/releases.xml" title="Node.js Blog: Releases" type="application/rss+xml"/>
+  <link rel="alternate" href="/en/feed/vulnerability.xml" title="Node.js Blog: Vulnerability Reports" type="application/rss+xml"/>
+
+  <script src="/static/js/themeSwitcher.js"/>
+</head>
+
+<body>
+  <header>
+    <div class="container">
+  
+      <a href="/en/" id="logo">
+        <img src="/static/images/logo.svg" alt="Node.js" width="122" height="75"/>
+      </a>
+  
+      <nav aria-label="primary">
+        <ul class="list-divider-pipe">
+          <li>
+            <a href="/en/">Home</a>
+          </li>
+  
+            <li class="active">
+                <a href="/en/about/">About</a>
+            </li>
+            <li>
+                <a href="/en/download/">Downloads</a>
+            </li>
+            <li>
+                <a href="/en/docs/">Docs</a>
+            </li>
+            <li>
+                <a href="/en/get-involved/">Get Involved</a>
+            </li>
+            <li>
+                <a href="https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security">Security</a>
+            </li>
+            <li>
+                <a href="https://openjsf.org/certification">Certification</a>
+            </li>
+            <li>
+                <a href="/en/blog/">News</a>
+            </li>
+        </ul>
+      </nav>
+  
+      <div class="switchers">
+        <button class="dark-theme-switcher" type="button" title="Toggle dark/light mode" aria-label="Toggle dark/light mode"/>
+        <button class="lang-picker-toggler" type="button" aria-controls="lang-picker" aria-expanded="false">
+          <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="22" height="25" aria-hidden="true" focusable="false" viewbox="0 0 512 593.282">
+            <path fill="none" d="m12045.7 24348.4-9327.4 3292V7339.5l9327.4 3017.7v13991.2" style="fill:#000;fill-opacity:0;fill-rule:nonzero;stroke-width:500;stroke:#fff" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m11821.8 24358.6 9684.5 3291.9V7349.6l-9684.5 3017.7v13991.3M299.602 3785.7 11821.8 7626.2v16734.6L299.602 20520.3V3785.7" class="header-background-fill" style="fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m17072.1 3532.9 1633-2686.599L19566.2 3342ZM4217.4 18592.5c-61.2 60.1 79.7-491.1 275.8-689.4 347.7-350.8 619.3-396 763.9-401.8 320-12.8 714.9 79.7 949.4 178 226.9 96.8 624.5 299.8 775 595.9m3049.5-6271.9c-90.8 33-1969.4 811.2-2235.7 938.7-217.9 104.8-752.2 330.7-1003.6 433.3 708.1 1091.8 1155.1 1915.7 1214.6 2041.2 110.1 229.6 859.6 1696.2 877.1 1786.5 17 91.5 38.3 429.5 21.8 509.8-16.5 81.9-291.3-75.5-664.4-202-373.7-126-1083.9-587.9-1358.2-645.8-275.3-57.4-1155.1-390.7-1605.3-540.1-450.2-149.4-1301.8-409.3-1652.1-503.9-350.8-94.6-657-102.1-853.2-161.6 0 0 26.1-274.8 78.2-357.2 51.5-82.4 237.1-284.4 452.9-340.8 215.8-56.8 573-34 735.7 3.2 162.6 37.8 444.3 175.4 482.1 235.5 38.2 61.1-19.7 249.3 44.6 306.2 64.9 56.3 922.3 256.7 1246 354.5 323.7 99.5 1562.8 526.3 1730.8 504.5-53.2-176.5-1049.9-2150.7-1370.9-2739.7-321.1-588.9-2186.3-3179.8-2583.4-3636.4-301.4-347.1-1031.8-1235.3-1284.8-1435.7 63.8-17.6 516.1 21.2 598.5 72.2 513.5 316.3 1368.8 1381 1644.2 1705.3 818.6 960 1537.8 1968.4 2108.1 2833.8h.6c111.1-46.3 1009.4-778.2 1243.8-940.4 234.4-162.1 1159.4-678.2 1359.8-763.8 200.4-86.7 970.6-441.8 1003-321.6 32.4 121.2-139.3 829.8-230.2 864.3" style="fill:#fff;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M5690 2220c180-110 350-200 540-290 380-190 810-390 1220-540 560-210 1120-380 1680-510 310-70 650-130 980-180 30 0 920-110 1100-110h900c350 30 680 50 1030 100 280 40 590 90 890 160 220 50 450 100 670 170 210 60 450 140 680 220 150 50 310 120 470 180 130 60 290 130 440 190 180 80 390 190 590 290 160 80 340 180 510 280 130 70 430 300 590 300 180 0 300-160 300-300 0-290-390-380-570-510-190-130-420-230-620-340-400-210-810-390-1200-540-510-190-1070-370-1570-490-190-40-380-90-570-120-100-20-1140-180-1430-180h-1320c-350 30-720 70-1070 120-310 50-640 110-950 180-240 50-500 120-730 190-400 110-790 250-1170 400-690 260-1410 600-2090 1050-120 80-130 160-130 250 0 150 110 290 290 290 160 0 480-230 540-260m6430 22180V7600c-10-50-30-100-70-150-20-30-60-70-90-80C11710 7270 450 3490 300 3490c-120 0-230 80-290 210 0 10-10 20-10 40v16810c20 50 30 120 70 160 80 110 220 130 310 160 170 60 11260 3780 11420 3780 100 0 320-70 320-250zm-610-16550L610 4220v16080l10900 3630V7850" style="fill:#fff;fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M21810 27620V7390c-10-230-170-330-320-330-130 0-1070 320-1230 370-1260 390-2530 780-3780 1170-280 90-570 180-840 270-240 70-500 150-740 230-1070 330-2160 660-3230 1020-40 10-140 150-140 180v14130c20 50 40 110 90 150 80 90 3510 1230 4860 1680 360 130 4870 1680 5010 1680 180 0 320-130 320-320zm-610-19850-9070 2820v13550l9070 3080V7770" style="fill:#fff;fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M24112.1 3532.9 11995 7395l50.7 16813 12066.4-3840.5V3532.9" style="fill:#fff;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m17289.8 19408.1 1561.1-472.9L21695 8685l-1603.5 486.5-576.1 2104.3-3313.8 1004.4L15489 10566l-1604 486.6zm713.7-2713.6-1189.3-2874.6 2186.5-662.8z" class="header-background-fill" style="fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+          </svg>
+          <span class="sr-only">Toggle Language</span>
+        </button>
+      </div>
+  
+      <ul id="lang-picker" class="lang-picker hidden">
+          <li>
+            <button data-lang="ar" title="Arabic">العربية</button>
+          </li>
+          <li>
+            <button data-lang="ca" title="Catalan">Catalan</button>
+          </li>
+          <li>
+            <button data-lang="de" title="German">Deutsch</button>
+          </li>
+          <li>
+            <button data-lang="en" title="English">English</button>
+          </li>
+          <li>
+            <button data-lang="es" title="Spanish">Español</button>
+          </li>
+          <li>
+            <button data-lang="fa" title="Persian">زبان فارسی</button>
+          </li>
+          <li>
+            <button data-lang="fr" title="French">Français</button>
+          </li>
+          <li>
+            <button data-lang="gl" title="Galician">Galego</button>
+          </li>
+          <li>
+            <button data-lang="it" title="Italian">Italiano</button>
+          </li>
+          <li>
+            <button data-lang="ja" title="Japanese">日本語</button>
+          </li>
+          <li>
+            <button data-lang="ko" title="Korean">한국어</button>
+          </li>
+          <li>
+            <button data-lang="pt-br" title="Portuguese, Brazilian">Português do Brasil</button>
+          </li>
+          <li>
+            <button data-lang="ro" title="Romanian">limba română</button>
+          </li>
+          <li>
+            <button data-lang="ru" title="Russian">Русский</button>
+          </li>
+          <li>
+            <button data-lang="tr" title="Turkish">Türkçe</button>
+          </li>
+          <li>
+            <button data-lang="uk" title="Ukrainian">Українська</button>
+          </li>
+          <li>
+            <button data-lang="zh-cn" title="Simplified Chinese">简体中文</button>
+          </li>
+          <li>
+            <button data-lang="zh-tw" title="Traditional Chinese">繁體中文</button>
+          </li>
+      </ul>
+  
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="container has-side-nav">
+
+      <nav aria-label="secondary">
+        <ul>
+                <li>
+                      <a href="/en/about/">About</a>
+                </li>
+                <li>
+                      <a href="/en/about/governance/">Governance</a>
+                </li>
+                <li>
+                      <a href="/en/about/community/">Community</a>
+                </li>
+                <li>
+                      <a href="/en/about/working-groups/">Working Groups</a>
+                </li>
+                <li class="active">
+                      <a href="/en/about/releases/">Releases</a>
+                </li>
+                <li>
+                      <a href="/en/about/resources/">Resources</a>
+                </li>
+                <li>
+                      <a href="/en/about/trademark/">Trademark</a>
+                </li>
+                <li>
+                      <a href="/en/about/privacy/">Privacy Policy</a>
+                </li>
+        </ul>
+      </nav>
+
+      <article dir="auto">
+        <h1 id="header-releases">Releases<a id="releases" class="anchor" href="#releases" aria-labelledby="header-releases"/></h1><p>Major Node.js versions enter <em>Current</em> release status for six months, which gives library authors time to add support for them.
+After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to <em>Active LTS</em> status and are ready for general use.
+<em>LTS</em> release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months.
+Production applications should only use <em>Active LTS</em> or <em>Maintenance LTS</em> releases.</p>
+ <input type="hidden" id="editOnGitHubUrl" value="https://github.com/nodejs/nodejs.org/edit/main/locale/en/about/releases.md"/> 
+
+        <p>
+          <img src="https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true" alt="Releases" width="760" height="396"/>
+        </p>
+
+        
+    <table class="release-schedule">
+      <thead>
+        <tr><th>Release</th>
+<th>Status</th>
+<th>Codename</th>
+<th>Initial Release</th>
+<th>Active LTS Start</th>
+<th>Maintenance LTS Start</th>
+<th>End-of-life</th>
+</tr>
+      </thead>
+      <tbody>
+        <tr>
+        <td><a href="https://nodejs.org/download/release/latest-v14.x/">v14</a></td>
+        <td>Maintenance LTS</td>
+        <td><a href="https://nodejs.org/download/release/latest-fermium/">Fermium</a></td>
+        <td>2020-04-21</td>
+        <td>2020-10-27</td>
+        <td>2021-10-19</td>
+        <td>2023-04-30</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v16.x/">v16</a></td>
+        <td>Active LTS</td>
+        <td><a href="https://nodejs.org/download/release/latest-gallium/">Gallium</a></td>
+        <td>2021-04-20</td>
+        <td>2021-10-26</td>
+        <td>2022-10-18</td>
+        <td>2024-04-30</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v17.x/">v17</a></td>
+        <td>Current</td>
+        <td/>
+        <td>2021-10-19</td>
+        <td/>
+        <td>2022-04-01</td>
+        <td>2022-06-01</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v18.x/">v18</a></td>
+        <td>Current</td>
+        <td/>
+        <td>2022-04-19</td>
+        <td>2022-10-25</td>
+        <td>2023-10-18</td>
+        <td>2025-04-30</td>
+      </tr><tr>
+        <td>v19</td>
+        <td>Pending</td>
+        <td/>
+        <td>2022-10-18</td>
+        <td/>
+        <td>2023-04-01</td>
+        <td>2023-06-01</td>
+      </tr><tr>
+        <td>v20</td>
+        <td>Pending</td>
+        <td/>
+        <td>2023-04-18</td>
+        <td>2023-10-24</td>
+        <td>2024-10-22</td>
+        <td>2026-04-30</td>
+      </tr>
+      </tbody>
+    </table>
+  
+
+        <p>
+          <small>Dates are subject to change.</small>
+        </p>
+
+      </article>
+
+    </div>
+  </main>
+
+  <a href="#" id="scroll-to-top">↑ <span>Scroll to top</span></a>
+  
+  <footer>
+  
+    <div class="container">
+      <div class="openjsfoundation-footer">
+        <div class="issue-link-container">
+          <a class="openjsfoundation-logo" href="https://openjsf.org/">
+            <img src="/static/images/openjs_foundation-logo.svg" alt="OpenJS Foundation" width="120" height="38"/>
+          </a>
+        </div>
+      <p>© OpenJS Foundation. All Rights Reserved. Portions of this site originally © Joyent.</p>
+      <p>Node.js is a trademark of the OpenJS Foundation. Please review the <a href="https://trademark-list.openjsf.org">Trademark List</a> and <a href="https://trademark-policy.openjsf.org">Trademark Guidelines</a> of the <a href="https://openjsf.org">OpenJS
+          Foundation</a>.</p>
+      <p>
+        <a href="https://raw.githubusercontent.com/nodejs/node/master/LICENSE">Node.js Project Licensing
+          Information</a>.
+      </p>
+      </div>
+  
+      <div class="help">
+        <ul>
+          <li><a id="editOnGitHubLink" href="#">Edit On GitHub</a></li>
+          <li><a href="https://github.com/nodejs/node/issues">Report Node.js issue</a></li>
+          <li><a href="https://github.com/nodejs/nodejs.org/issues">Report website issue</a></li>
+          <li><a href="https://github.com/nodejs/help/issues">Get Help</a></li>
+          <li>
+            <a href="https://github.com/nodejs/nodejs.org/blob/master/CONTRIBUTING.md">Contributing For Nodejs.org</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  
+  </footer>
+  
+  <script src="/static/js/main.js" async="" defer="defer"/>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js" integrity="sha512-BNc7saQYlxCL10lykUYhFBcnzdKMnjx5fp5s5wPucDyZ7rKNwCoqJh1GwEAIhuePEK4WM9askJBRsu7ma0Rzvg==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+  <script><![CDATA[hljs.highlightAll();]]></script>
+</body>
+</html>

--- a/dockerfiles/depwatcher/spec/depwatcher/node_lts_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/node_lts_spec.cr
@@ -1,0 +1,48 @@
+require "spec2"
+require "../../src/depwatcher/node_lts"
+
+Spec2.describe Depwatcher::NodeLTS do
+  let(client) { HTTPClientMock.new }
+  subject { described_class.new.tap { |s| s.client = client } }
+
+  describe "#check" do
+    before do
+      client.stub_get("https://nodejs.org/en/about/releases/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_lts_info_page.html"))
+      )
+
+      client.stub_get("https://nodejs.org/dist/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
+      )
+    end
+    it "returns the right number of releases" do
+      expect(subject.check.size).to eq 26
+    end
+
+    it "returns real releases sorted" do
+      expect(subject.check.map(&.ref)).to eq ["16.0.0", "16.1.0", "16.2.0", "16.3.0", "16.4.0", "16.4.1", "16.4.2", "16.5.0", "16.6.0", "16.6.1", "16.6.2", "16.7.0", "16.8.0", "16.9.0", "16.9.1", "16.10.0", "16.11.0", "16.11.1", "16.12.0", "16.13.0", "16.13.1", "16.13.2", "16.14.0", "16.14.1", "16.14.2", "16.15.0"]
+    end
+  end
+
+  describe "#in" do
+    let(version) { "6.1.0" }
+    before do
+      client.stub_get("https://nodejs.org/dist/v#{version}/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_v6.1.0.html"))
+      )
+      client.stub_get("https://nodejs.org/dist/v#{version}/SHASUMS256.txt",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_shasum256.txt"))
+      )
+    end
+    it "returns real releases sorted" do
+      obj = subject.in("6.1.0")
+      expect(obj.ref).to eq "6.1.0"
+      expect(obj.url).to eq "https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz"
+      expect(obj.sha256).to eq "9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3"
+    end
+  end
+end

--- a/dockerfiles/depwatcher/spec/fixtures/node_lts_info_page.html
+++ b/dockerfiles/depwatcher/spec/fixtures/node_lts_info_page.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Releases | Node.js</title>
+
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&display=fallback">
+  <link rel="stylesheet" href="/static/css/styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/styles/a11y-dark.min.css" integrity="sha512-Vj6gPCk8EZlqnoveEyuGyYaWZ1+jyjMPg8g4shwyyNlRQl6d3L9At02ZHQr5K6s5duZl/+YKMnM3/8pDhoUphg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+  <meta name="author" content="Node.js">
+  <meta name="robots" content="index, follow">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.">
+
+  <link rel="apple-touch-icon" href="/static/images/favicons/apple-touch-icon.png" sizes="180x180">
+  <link rel="icon" href="/static/images/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
+  <link rel="icon" href="/static/images/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
+  <link rel="manifest" href="/static/images/favicons/manifest.json">
+  <link rel="mask-icon" href="/static/images/favicons/safari-pinned-tab.svg" color="#43853d">
+  <link rel="shortcut icon" href="/static/images/favicons/favicon.ico">
+  <meta name="theme-color" content="#333">
+
+  <meta property="og:site_name" content="Node.js">
+  <meta property="og:title" content="Releases | Node.js">
+  <meta property="og:image" content="https://nodejs.org/static/images/logo-hexagon-card.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="224">
+  <meta property="og:image:height" content="256">
+  <meta property="og:description" content="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@nodejs">
+  <meta name="twitter:title" content="Releases | Node.js">
+  <meta name="twitter:image" content="https://nodejs.org/static/images/logo-hexagon-card.png">
+  <meta name="twitter:image:alt" content="The Node.js Hexagon Logo">
+
+  <link rel="canonical" href="https://nodejs.org/en/about/releases/">
+  <link rel="alternate" href="/en/feed/blog.xml" title="Node.js Blog" type="application/rss+xml">
+  <link rel="alternate" href="/en/feed/releases.xml" title="Node.js Blog: Releases" type="application/rss+xml">
+  <link rel="alternate" href="/en/feed/vulnerability.xml" title="Node.js Blog: Vulnerability Reports" type="application/rss+xml">
+
+  <script src="/static/js/themeSwitcher.js"></script>
+</head>
+
+<body>
+  <header>
+    <div class="container">
+  
+      <a href="/en/" id="logo">
+        <img src="/static/images/logo.svg" alt="Node.js" width="122" height="75">
+      </a>
+  
+      <nav aria-label="primary">
+        <ul class="list-divider-pipe">
+          <li >
+            <a href="/en/">Home</a>
+          </li>
+  
+            <li class="active">
+                <a href="/en/about/">About</a>
+            </li>
+            <li >
+                <a href="/en/download/">Downloads</a>
+            </li>
+            <li >
+                <a href="/en/docs/">Docs</a>
+            </li>
+            <li >
+                <a href="/en/get-involved/">Get Involved</a>
+            </li>
+            <li >
+                <a href="https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security">Security</a>
+            </li>
+            <li >
+                <a href="https://openjsf.org/certification">Certification</a>
+            </li>
+            <li >
+                <a href="/en/blog/">News</a>
+            </li>
+        </ul>
+      </nav>
+  
+      <div class="switchers">
+        <button class="dark-theme-switcher" type="button" title="Toggle dark/light mode" aria-label="Toggle dark/light mode"></button>
+        <button class="lang-picker-toggler" type="button" aria-controls="lang-picker" aria-expanded="false">
+          <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="22" height="25" aria-hidden="true" focusable="false" viewBox="0 0 512 593.282">
+            <path fill="none" d="m12045.7 24348.4-9327.4 3292V7339.5l9327.4 3017.7v13991.2" style="fill:#000;fill-opacity:0;fill-rule:nonzero;stroke-width:500;stroke:#fff" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m11821.8 24358.6 9684.5 3291.9V7349.6l-9684.5 3017.7v13991.3M299.602 3785.7 11821.8 7626.2v16734.6L299.602 20520.3V3785.7" class="header-background-fill" style="fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m17072.1 3532.9 1633-2686.599L19566.2 3342ZM4217.4 18592.5c-61.2 60.1 79.7-491.1 275.8-689.4 347.7-350.8 619.3-396 763.9-401.8 320-12.8 714.9 79.7 949.4 178 226.9 96.8 624.5 299.8 775 595.9m3049.5-6271.9c-90.8 33-1969.4 811.2-2235.7 938.7-217.9 104.8-752.2 330.7-1003.6 433.3 708.1 1091.8 1155.1 1915.7 1214.6 2041.2 110.1 229.6 859.6 1696.2 877.1 1786.5 17 91.5 38.3 429.5 21.8 509.8-16.5 81.9-291.3-75.5-664.4-202-373.7-126-1083.9-587.9-1358.2-645.8-275.3-57.4-1155.1-390.7-1605.3-540.1-450.2-149.4-1301.8-409.3-1652.1-503.9-350.8-94.6-657-102.1-853.2-161.6 0 0 26.1-274.8 78.2-357.2 51.5-82.4 237.1-284.4 452.9-340.8 215.8-56.8 573-34 735.7 3.2 162.6 37.8 444.3 175.4 482.1 235.5 38.2 61.1-19.7 249.3 44.6 306.2 64.9 56.3 922.3 256.7 1246 354.5 323.7 99.5 1562.8 526.3 1730.8 504.5-53.2-176.5-1049.9-2150.7-1370.9-2739.7-321.1-588.9-2186.3-3179.8-2583.4-3636.4-301.4-347.1-1031.8-1235.3-1284.8-1435.7 63.8-17.6 516.1 21.2 598.5 72.2 513.5 316.3 1368.8 1381 1644.2 1705.3 818.6 960 1537.8 1968.4 2108.1 2833.8h.6c111.1-46.3 1009.4-778.2 1243.8-940.4 234.4-162.1 1159.4-678.2 1359.8-763.8 200.4-86.7 970.6-441.8 1003-321.6 32.4 121.2-139.3 829.8-230.2 864.3" style="fill:#fff;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M5690 2220c180-110 350-200 540-290 380-190 810-390 1220-540 560-210 1120-380 1680-510 310-70 650-130 980-180 30 0 920-110 1100-110h900c350 30 680 50 1030 100 280 40 590 90 890 160 220 50 450 100 670 170 210 60 450 140 680 220 150 50 310 120 470 180 130 60 290 130 440 190 180 80 390 190 590 290 160 80 340 180 510 280 130 70 430 300 590 300 180 0 300-160 300-300 0-290-390-380-570-510-190-130-420-230-620-340-400-210-810-390-1200-540-510-190-1070-370-1570-490-190-40-380-90-570-120-100-20-1140-180-1430-180h-1320c-350 30-720 70-1070 120-310 50-640 110-950 180-240 50-500 120-730 190-400 110-790 250-1170 400-690 260-1410 600-2090 1050-120 80-130 160-130 250 0 150 110 290 290 290 160 0 480-230 540-260m6430 22180V7600c-10-50-30-100-70-150-20-30-60-70-90-80C11710 7270 450 3490 300 3490c-120 0-230 80-290 210 0 10-10 20-10 40v16810c20 50 30 120 70 160 80 110 220 130 310 160 170 60 11260 3780 11420 3780 100 0 320-70 320-250zm-610-16550L610 4220v16080l10900 3630V7850" style="fill:#fff;fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M21810 27620V7390c-10-230-170-330-320-330-130 0-1070 320-1230 370-1260 390-2530 780-3780 1170-280 90-570 180-840 270-240 70-500 150-740 230-1070 330-2160 660-3230 1020-40 10-140 150-140 180v14130c20 50 40 110 90 150 80 90 3510 1230 4860 1680 360 130 4870 1680 5010 1680 180 0 320-130 320-320zm-610-19850-9070 2820v13550l9070 3080V7770" style="fill:#fff;fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="M24112.1 3532.9 11995 7395l50.7 16813 12066.4-3840.5V3532.9" style="fill:#fff;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+            <path d="m17289.8 19408.1 1561.1-472.9L21695 8685l-1603.5 486.5-576.1 2104.3-3313.8 1004.4L15489 10566l-1604 486.6zm713.7-2713.6-1189.3-2874.6 2186.5-662.8z" class="header-background-fill" style="fill-opacity:1;fill-rule:evenodd;stroke:none" transform="matrix(.02123 0 0 -.02123 0 593.282)"/>
+          </svg>
+          <span class="sr-only">Toggle Language</span>
+        </button>
+      </div>
+  
+      <ul id="lang-picker" class="lang-picker hidden">
+          <li>
+            <button data-lang="ar" title="Arabic">العربية</button>
+          </li>
+          <li>
+            <button data-lang="ca" title="Catalan">Catalan</button>
+          </li>
+          <li>
+            <button data-lang="de" title="German">Deutsch</button>
+          </li>
+          <li>
+            <button data-lang="en" title="English">English</button>
+          </li>
+          <li>
+            <button data-lang="es" title="Spanish">Español</button>
+          </li>
+          <li>
+            <button data-lang="fa" title="Persian">زبان فارسی</button>
+          </li>
+          <li>
+            <button data-lang="fr" title="French">Français</button>
+          </li>
+          <li>
+            <button data-lang="gl" title="Galician">Galego</button>
+          </li>
+          <li>
+            <button data-lang="it" title="Italian">Italiano</button>
+          </li>
+          <li>
+            <button data-lang="ja" title="Japanese">日本語</button>
+          </li>
+          <li>
+            <button data-lang="ko" title="Korean">한국어</button>
+          </li>
+          <li>
+            <button data-lang="pt-br" title="Portuguese, Brazilian">Português do Brasil</button>
+          </li>
+          <li>
+            <button data-lang="ro" title="Romanian">limba română</button>
+          </li>
+          <li>
+            <button data-lang="ru" title="Russian">Русский</button>
+          </li>
+          <li>
+            <button data-lang="tr" title="Turkish">Türkçe</button>
+          </li>
+          <li>
+            <button data-lang="uk" title="Ukrainian">Українська</button>
+          </li>
+          <li>
+            <button data-lang="zh-cn" title="Simplified Chinese">简体中文</button>
+          </li>
+          <li>
+            <button data-lang="zh-tw" title="Traditional Chinese">繁體中文</button>
+          </li>
+      </ul>
+  
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="container has-side-nav">
+
+      <nav aria-label="secondary">
+        <ul>
+                <li >
+                      <a href="/en/about/">About</a>
+                </li>
+                <li >
+                      <a href="/en/about/governance/">Governance</a>
+                </li>
+                <li >
+                      <a href="/en/about/community/">Community</a>
+                </li>
+                <li >
+                      <a href="/en/about/working-groups/">Working Groups</a>
+                </li>
+                <li  class="active" >
+                      <a href="/en/about/releases/">Releases</a>
+                </li>
+                <li >
+                      <a href="/en/about/resources/">Resources</a>
+                </li>
+                <li >
+                      <a href="/en/about/trademark/">Trademark</a>
+                </li>
+                <li >
+                      <a href="/en/about/privacy/">Privacy Policy</a>
+                </li>
+        </ul>
+      </nav>
+
+      <article dir="auto">
+        <h1 id="header-releases">Releases<a id="releases" class="anchor" href="#releases" aria-labelledby="header-releases"></a></h1><p>Major Node.js versions enter <em>Current</em> release status for six months, which gives library authors time to add support for them.
+After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to <em>Active LTS</em> status and are ready for general use.
+<em>LTS</em> release status is &quot;long-term support&quot;, which typically guarantees that critical bugs will be fixed for a total of 30 months.
+Production applications should only use <em>Active LTS</em> or <em>Maintenance LTS</em> releases.</p>
+ <input type = "hidden" id = "editOnGitHubUrl" value="https://github.com/nodejs/nodejs.org/edit/main/locale/en/about/releases.md"/> 
+
+        <p>
+          <img src="https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true" alt="Releases" width="760" height="396">
+        </p>
+
+        
+    <table class="release-schedule">
+      <thead>
+        <tr><th>Release</th>
+<th>Status</th>
+<th>Codename</th>
+<th>Initial Release</th>
+<th>Active LTS Start</th>
+<th>Maintenance LTS Start</th>
+<th>End-of-life</th>
+</tr>
+      </thead>
+      <tbody>
+        <tr>
+        <td><a href="https://nodejs.org/download/release/latest-v14.x/">v14</a></td>
+        <td>Maintenance LTS</td>
+        <td><a href="https://nodejs.org/download/release/latest-fermium/">Fermium</a></td>
+        <td>2020-04-21</td>
+        <td>2020-10-27</td>
+        <td>2021-10-19</td>
+        <td>2023-04-30</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v16.x/">v16</a></td>
+        <td>Active LTS</td>
+        <td><a href="https://nodejs.org/download/release/latest-gallium/">Gallium</a></td>
+        <td>2021-04-20</td>
+        <td>2021-10-26</td>
+        <td>2022-10-18</td>
+        <td>2024-04-30</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v17.x/">v17</a></td>
+        <td>Current</td>
+        <td></td>
+        <td>2021-10-19</td>
+        <td></td>
+        <td>2022-04-01</td>
+        <td>2022-06-01</td>
+      </tr><tr>
+        <td><a href="https://nodejs.org/download/release/latest-v18.x/">v18</a></td>
+        <td>Current</td>
+        <td></td>
+        <td>2022-04-19</td>
+        <td>2022-10-25</td>
+        <td>2023-10-18</td>
+        <td>2025-04-30</td>
+      </tr><tr>
+        <td>v19</td>
+        <td>Pending</td>
+        <td></td>
+        <td>2022-10-18</td>
+        <td></td>
+        <td>2023-04-01</td>
+        <td>2023-06-01</td>
+      </tr><tr>
+        <td>v20</td>
+        <td>Pending</td>
+        <td></td>
+        <td>2023-04-18</td>
+        <td>2023-10-24</td>
+        <td>2024-10-22</td>
+        <td>2026-04-30</td>
+      </tr>
+      </tbody>
+    </table>
+  
+
+        <p>
+          <small>Dates are subject to change.</small>
+        </p>
+
+      </article>
+
+    </div>
+  </main>
+
+  <a href="#" id="scroll-to-top">&uarr; <span>Scroll to top</span></a>
+  
+  <footer >
+  
+    <div class="container">
+      <div class="openjsfoundation-footer">
+        <div class="issue-link-container">
+          <a class="openjsfoundation-logo" href="https://openjsf.org/">
+            <img src="/static/images/openjs_foundation-logo.svg" alt="OpenJS Foundation" width="120" height="38">
+          </a>
+        </div>
+      <p>© OpenJS Foundation. All Rights Reserved. Portions of this site originally © Joyent.</p>
+      <p>Node.js is a trademark of the OpenJS Foundation. Please review the <a
+          href="https://trademark-list.openjsf.org">Trademark List</a> and <a
+          href="https://trademark-policy.openjsf.org">Trademark Guidelines</a> of the <a href="https://openjsf.org">OpenJS
+          Foundation</a>.</p>
+      <p>
+        <a href="https://raw.githubusercontent.com/nodejs/node/master/LICENSE">Node.js Project Licensing
+          Information</a>.
+      </p>
+      </div>
+  
+      <div class="help">
+        <ul>
+          <li><a id="editOnGitHubLink" href="#">Edit On GitHub</a></li>
+          <li><a href="https://github.com/nodejs/node/issues">Report Node.js issue</a></li>
+          <li><a href="https://github.com/nodejs/nodejs.org/issues">Report website issue</a></li>
+          <li><a href="https://github.com/nodejs/help/issues">Get Help</a></li>
+          <li>
+            <a href="https://github.com/nodejs/nodejs.org/blob/master/CONTRIBUTING.md">Contributing For Nodejs.org</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  
+  </footer>
+  
+  <script src="/static/js/main.js" async defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js" integrity="sha512-BNc7saQYlxCL10lykUYhFBcnzdKMnjx5fp5s5wPucDyZ7rKNwCoqJh1GwEAIhuePEK4WM9askJBRsu7ma0Rzvg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script>hljs.highlightAll();</script>
+</body>
+</html>

--- a/dockerfiles/depwatcher/src/check.cr
+++ b/dockerfiles/depwatcher/src/check.cr
@@ -16,7 +16,7 @@ when "github_releases"
 when "github_tags"
   versions = Depwatcher::GithubTags.new.check(source["repo"].to_s, source["tag_regex"].to_s)
 when "jruby"
-  versions = Depwatcher::JRuby.new.check()
+  versions = Depwatcher::JRuby.new.check
 when "miniconda"
   versions = Depwatcher::Miniconda.new.check(source["python_version"].to_s)
 when "rubygems"
@@ -38,9 +38,12 @@ when "r"
 when "npm"
   versions = Depwatcher::Npm.new.check(source["name"].to_s)
 when "node"
-  versions = Depwatcher::Node.new.check
-when "node-lts"
-  versions = Depwatcher::NodeLTS.new.check
+  version_filter = source["version_filter"]?
+  if version_filter && source["version_filter"].to_s == "node-lts"
+    versions = Depwatcher::NodeLTS.new.check
+  else
+    versions = Depwatcher::Node.new.check
+  end
 when "nginx"
   versions = Depwatcher::Nginx.new.check
 when "openresty"
@@ -66,14 +69,14 @@ when "plumber"
 when "shiny"
   versions = Depwatcher::CRAN.new.check("shiny")
 when "icu"
-  versions = Depwatcher::Icu.new.check()
+  versions = Depwatcher::Icu.new.check
 else
   raise "Unkown type: #{source["type"]}"
 end
 
 # Filter out irrelevant versions
 version_filter = source["version_filter"]?
-if version_filter
+if version_filter && source["version_filter"].to_s != "node-lts"
   filter = SemverFilter.new(version_filter.to_s)
   versions.select! do |v|
     filter.match(Semver.new(v.ref))

--- a/dockerfiles/depwatcher/src/check.cr
+++ b/dockerfiles/depwatcher/src/check.cr
@@ -39,6 +39,8 @@ when "npm"
   versions = Depwatcher::Npm.new.check(source["name"].to_s)
 when "node"
   versions = Depwatcher::Node.new.check
+when "node-lts"
+  versions = Depwatcher::NodeLTS.new.check
 when "nginx"
   versions = Depwatcher::Nginx.new.check
 when "openresty"

--- a/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
@@ -1,0 +1,83 @@
+require "./base"
+require "./semver"
+
+module Depwatcher
+  class NodeLTS < Base
+    class Dist
+      JSON.mapping(
+        shasum: String,
+        tarball: String,
+      )
+    end
+
+    class Version
+      JSON.mapping(
+        name: String,
+        version: String,
+        dist: Dist,
+      )
+    end
+
+    class External
+      JSON.mapping(
+        versions: Hash(String, Version),
+      )
+    end
+
+    class Release
+      JSON.mapping(
+        ref: String,
+        url: String,
+        sha256: String,
+      )
+
+      def initialize(@ref, @url, @sha256)
+      end
+    end
+
+    def check : Array(Internal)
+      version_numbers().map do |v|
+        Internal.new(v)
+      end.sort_by { |i| Semver.new(i.ref) }
+    end
+
+    def in(ref : String) : Release
+      Release.new(ref, url(ref), shasum256(ref))
+    end
+
+    private def getLTSLine : String
+      response = HTTP::Client.get("https://nodejs.org/en/about/releases/")
+      doc = XML.parse_html(response.body)
+      list = doc.xpath_nodes("//table[@class='release-schedule']")[0].children[3]
+      lts_version = list.children
+        .select() { |item| item.children && item.children.size > 3 && item.children[3].text == "Active LTS" }
+        .map() { |item| item.children[1].text }[0]
+      return lts_version.sub(/^v/, "")
+    end
+
+    private def url(version : String) : String
+      "https://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
+    end
+
+    private def shasum256(version : String) : String
+      response = client.get("https://nodejs.org/dist/v#{version}/SHASUMS256.txt").body
+      response.lines.select() { |line|
+        line.ends_with?("node-v#{version}.tar.gz")
+      }.first.split(2).first
+    end
+
+    private def version_numbers : Array(String)
+      latest_lts = getLTSLine()
+      response = client.get("https://nodejs.org/dist/").body
+      html = XML.parse_html(response).children[1].children[3].children[3]
+      return html.children.select() { |child|
+        child.type.element_node?
+      }.map() { |c| c["href"] }.select() { |link|
+        link.starts_with?("v") && link.ends_with?("/")
+      }.map() { |link| link.[1...-1] }.select() { |v|
+        semver = Semver.new(v)
+        semver.major == latest_lts.to_i
+      }
+    end
+  end
+end

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -244,9 +244,13 @@ dependencies:
       ruby:
         lines:
           - line: latest
+            deprecation_date: ""
+            link: https://github.com/nodejs/Release
       dotnet-core:
         lines:
           - line: latest
+            deprecation_date: ""
+            link: https://github.com/nodejs/Release
     source_type: node
     copy-stacks:
       - bionic

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -243,12 +243,12 @@ dependencies:
         removal_strategy: keep_latest_released
       ruby:
         lines:
-          - line: latest
+          - line: node-lts
             deprecation_date: ""
             link: https://github.com/nodejs/Release
       dotnet-core:
         lines:
-          - line: latest
+          - line: node-lts
             deprecation_date: ""
             link: https://github.com/nodejs/Release
     source_type: node

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -243,14 +243,10 @@ dependencies:
         removal_strategy: keep_latest_released
       ruby:
         lines:
-          - line: 16.X.X
-            deprecation_date: 2024-04-30
-            link: https://github.com/nodejs/Release
+          - line: latest
       dotnet-core:
         lines:
-          - line: 16.X.X
-            deprecation_date: 2024-04-30
-            link: https://github.com/nodejs/Release
+          - line: latest
     source_type: node
     copy-stacks:
       - bionic

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -327,6 +327,15 @@ jobs:
         outputs:
           - name: all-monitored-deps
   <% end %>
+  <% if dep_name.downcase == 'node' && line.downcase == 'node-lts' %>
+    - task: create-tracker-story
+      file: buildpacks-ci/tasks/build-binary-new/create_node_lts.yml
+      params:
+        TRACKER_PROJECT_ID: '{{cf-buildpacks-rel-eng-tracker-id}}'
+        TRACKER_REQUESTER_ID: '{{cf-buildpacks-requester-id}}'
+        TRACKER_API_TOKEN: {{pivotal-tracker-api-token}}
+        BUILDPACKS: <%= dep['buildpacks'].select{ |_, bp_data| bp_uses_line?(bp_data,line) }.keys.join(' ') %>
+  <% else %>
     - task: create-tracker-story
       file: buildpacks-ci/tasks/build-binary-new/create.yml
       params:
@@ -334,6 +343,7 @@ jobs:
         TRACKER_REQUESTER_ID: '{{cf-buildpacks-requester-id}}'
         TRACKER_API_TOKEN: {{pivotal-tracker-api-token}}
         BUILDPACKS: <%= dep['buildpacks'].select{ |_, bp_data| bp_uses_line?(bp_data,line) }.keys.join(' ') %>
+  <% end %>
     - put: builds
       params:
         repository: builds-artifacts

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -137,7 +137,7 @@ resource_types:
 - name: depwatcher
   type: docker-image
   source:
-    repository: coredeps/depwatcher
+    repository: cfbuildpacks/depwatcher
 - name: slack-notification
   type: docker-image
   source:

--- a/tasks/build-binary-new/create_node_lts.rb
+++ b/tasks/build-binary-new/create_node_lts.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'json'
+require 'yaml'
+require 'tracker_api'
+
+BUILDPACKS = ENV['BUILDPACKS']
+                 .split(' ')
+                 .compact
+                 .map {|bp|
+                   if bp.include? "-cnb"
+                     bp
+                   else
+                     "#{bp}-buildpack"
+                   end
+                 }
+
+buildpacks_ci_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+require_relative "#{buildpacks_ci_dir}/lib/git-client"
+
+data = JSON.parse(open('source/data.json').read)
+name = data.dig('source', 'name')
+version = data.dig('version', 'ref')
+
+tracker_client = TrackerApi::Client.new(token: ENV['TRACKER_API_TOKEN'])
+buildpack_project = tracker_client.project(ENV['TRACKER_PROJECT_ID'])
+
+if File.file?('all-monitored-deps/data.json')
+  all_monitored_deps = JSON.parse(open('all-monitored-deps/data.json').read)
+  data['packages'] = all_monitored_deps
+end
+
+story_params = {
+    name: "Build and/or Include new Node LTS version: #{name} #{version}",
+    description: "A new LTS version of node has been found. Make sure that the Node Buildpack contains it and that the Ruby and .NET Core Buildpacks are updated by automation\n"+
+    "```\n#{data.to_yaml}\n```\n",
+    estimate: 0,
+    labels: (['deps', name] + BUILDPACKS).uniq,
+    requested_by_id: ENV['TRACKER_REQUESTER_ID'].to_i,
+    owner_ids: [ENV['TRACKER_REQUESTER_ID'].to_i]
+}
+
+story = buildpack_project.create_story(story_params)
+
+puts "Created tracker story #{story.id}"
+
+system('rsync -a builds/ builds-artifacts/')
+raise('Could not copy builds to builds artifacts') unless $?.success?
+Dir.chdir('builds-artifacts') do
+  GitClient.set_global_config('user.email', 'cf-buildpacks-eng@pivotal.io')
+  GitClient.set_global_config('user.name', 'CF Buildpacks Team CI Server')
+
+  version = data.dig('version', 'ref')
+  FileUtils.mkdir_p("binary-builds-new/#{data.dig('source', 'name')}")
+  File.write("binary-builds-new/#{data.dig('source', 'name')}/#{version}.json", {tracker_story_id: story.id}.to_json)
+
+  GitClient.add_file("binary-builds-new/#{data.dig('source', 'name')}/#{version}.json")
+  GitClient.safe_commit("Create Tracker Story #{data.dig('source', 'name')} - #{version}")
+end

--- a/tasks/build-binary-new/create_node_lts.yml
+++ b/tasks/build-binary-new/create_node_lts.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/ci
+inputs:
+  - name: buildpacks-ci
+  - name: source
+  - name: builds
+  - name: all-monitored-deps
+    optional: true
+outputs:
+  - name: builds-artifacts
+run:
+  path: bash
+  args:
+    - -cl
+    - gem install tracker_api && buildpacks-ci/tasks/build-binary-new/create_node_lts.rb
+params:
+  TRACKER_API_TOKEN:
+  TRACKER_PROJECT_ID:
+  TRACKER_REQUESTER_ID:
+  BUILDPACKS:


### PR DESCRIPTION
Changes:

- Update to `depwatcher`: A new feature has been added that gets the major line from the LTS version of Node and then gets all the versions that have that major line. Although the way to do this is to parse the HTML of the NodeJS page, which is not ideal, no solution was found at the moment to perform this task.
- Added new functionality for creating Node LTS-specific stories in `tasks/build-binary-new`.
- Update `dockerhub` link to depwatcher: The `dockerhub` was pointing to a docker image owned by `coredeps`. Since the process of updating this image is not clear, I proceed to change it to `cfbuildpacks/depwatcher` which we have full access to make changes and push them to `dockerhub`.
- Add a different example to `dockerfiles/depwatcher/README.md`.