### PR TITLE
Fix .NetCore BP dependencies update strategy

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -62,7 +62,7 @@ dependencies:
           - line: 6.0.X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_latest_released
+        removal_strategy: remove_all
     versions_to_keep: 1
     any_stack: true
   dotnet-runtime:
@@ -75,7 +75,7 @@ dependencies:
           - line: 6.0.X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_latest_released
+        removal_strategy: remove_all
     versions_to_keep: 1
     any_stack: true
   dotnet-aspnetcore:
@@ -88,7 +88,7 @@ dependencies:
           - line: 6.0.X
             deprecation_date: 2024-11-08
             link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: keep_latest_released
+        removal_strategy: remove_all
     versions_to_keep: 1
     any_stack: true
   glide:


### PR DESCRIPTION
Since we only keep the latest available version of every dep for `.NetCore Buildpack` the update strategy in the file is updated.

Also, I added some automation to automatically update the `runtime_to_sdks` entry in the `manifest.yml` with the latest versions.
