### PR TITLE
Update Rubygems CLI url to use github releases

### DIFF
--- a/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
@@ -1,30 +1,42 @@
-require "./base"
-require "xml"
+require "./github_releases.cr"
 
 module Depwatcher
-  class RubygemsCli < Base
-    class Release
+  class RubygemsCli < GithubReleases
+    class GithubRelease
       JSON.mapping(
-        ref: String,
-        url: String,
+        tag_name: String,
+        draft: Bool,
+        prerelease: Bool,
+        assets: Array(GithubAsset),
       )
-      def initialize(@ref : String, @url : String)
+      def ref
+        version = tag_name.gsub(/^release-/, "").gsub(/-/, ".")
+        if version =~ /^\d+\.\d+$/
+          version += ".0"
+        end
+        version
       end
     end
 
-    def check() : Array(Internal)
-      response = client.get("https://rubygems.org/pages/download").body
-      doc = XML.parse_html(response)
-      links = doc.xpath("//a[contains(@class,'download__format')][text()='tgz']")
-      raise "Could not parse rubygems download website" unless links.is_a?(XML::NodeSet)
-      links.map do |a|
-        v = a["href"].gsub(/.*\/rubygems\-(.*)\.tgz$/, "\\1")
-        Internal.new(v)
-      end
+    def check : Array(Internal)
+      repo = "rubygems/rubygems"
+      allow_prerelease = false
+      releases(repo).reject do |r|
+        (r.prerelease && !allow_prerelease) || r.draft || ((r.ref.match /^(?!v).*$/ )|| r.ref.includes?("bundler"))
+      end.map do |r|
+        Internal.new(r.ref) if r.ref != ""
+      end.compact.sort_by { |i| Semver.new(i.ref) }
     end
 
-    def in(ref : String) : Release
-      return Release.new(ref, "https://rubygems.org/rubygems/rubygems-#{ref}.tgz")
+    def in(ref : String, dir : String) : Release
+      repo = "rubygems/rubygems"
+      ext = ".tar.gz"
+      super(repo, ref, dir)
+    end
+
+    private def releases(repo : String) : Array(GithubRelease)
+      res = client.get("https://api.github.com/repos/#{repo}/releases").body
+      Array(GithubRelease).from_json(res)
     end
   end
 end

--- a/dockerfiles/depwatcher/src/in.cr
+++ b/dockerfiles/depwatcher/src/in.cr
@@ -23,7 +23,7 @@ when "miniconda"
 when "rubygems"
   version = Depwatcher::Rubygems.new.in(source["name"].to_s, version["ref"].to_s)
 when "rubygems_cli"
-  version = Depwatcher::RubygemsCli.new.in(version["ref"].to_s)
+  version = Depwatcher::RubygemsCli.new.in(version["ref"].to_s, dir)
 when "pypi"
   version = Depwatcher::Pypi.new.in(source["name"].to_s, version["ref"].to_s)
 when "ruby"


### PR DESCRIPTION
Moving from Rubygems hosted files (failing right now, not reliable) to Rubygems GitHub repository releases.