### PR TITLE
Add nodejs cflinuxfs4 support

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -363,8 +363,8 @@ dependencies:
     any_stack: true
     versions_to_keep: 2
 cflinuxfs4_build_dependencies: [ 'node', 'libunwind', 'libgdiplus' ]
-cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore' ]
-cflinuxfs4_buildpacks: [ 'dotnet-core' ]
+cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'yarn' ]
+cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs']
 build_stacks: [ 'cflinuxfs4' , 'cflinuxfs3' ]
 windows_stacks: [ 'windows2016', 'windows' ]
 deprecated_stacks: [ 'cflinuxfs2' ]


### PR DESCRIPTION
# Changes

- Add function to `tasks/build-binary-new-cflinuxfs4/builder.rb`:
  - Add `download_with_follow_redirects`: This function allows to download the artifact when the URI contains a redirect (Yarn dependency).
  - Add `build_yarn`: This function handles the build logic for `Yarn`