### PR TITLE
Stop building deprecated go deps

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -46,15 +46,6 @@ dependencies:
       - 'extension: .phar'
     any_stack: true
     versions_to_keep: 2
-  dep:
-    buildpacks:
-      go:
-        lines:
-          - line: latest
-    source_type: github_releases
-    source_params:
-      - 'repo: golang/dep'
-      - 'fetch_source: true'
   dotnet-sdk:
     buildpacks:
       dotnet-core:
@@ -97,16 +88,6 @@ dependencies:
     versions_to_keep: 1
     any_stack: true
     skip_lines_cflinuxfs4: [ '3.1.X' ]
-  glide:
-    buildpacks:
-      go:
-        lines:
-          - line: latest
-    source_type: github_releases
-    source_params:
-      - 'repo: Masterminds/glide'
-      - 'fetch_source: true'
-    versions_to_keep: 2
   go:
     buildpacks:
       go:
@@ -120,16 +101,6 @@ dependencies:
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html
         removal_strategy: keep_latest_released
-    versions_to_keep: 2
-  godep:
-    buildpacks:
-      go:
-        lines:
-          - line: latest
-    source_type: github_releases
-    source_params:
-      - 'repo: tools/godep'
-      - 'fetch_source: true'
     versions_to_keep: 2
   httpd:
     buildpacks:


### PR DESCRIPTION
These depencencies were added in #178 to build against the new stack (cflinuxfs4). After that process is done, are not longer needed in the dependency-builds pipeline since they are deprecated (no new versions will be released).