### PR TITLE
Update Python and Go Buildpack to only keep 1 of each patch version (latest)

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -100,8 +100,8 @@ dependencies:
           - line: 1.19.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html
-        removal_strategy: keep_latest_released
-    versions_to_keep: 2
+        removal_strategy: remove_all
+    versions_to_keep: 1
   httpd:
     buildpacks:
       php:
@@ -289,8 +289,8 @@ dependencies:
           - line: 3.10.X
             deprecation_date: 2026-10-04
             link: https://www.python.org/dev/peps/pep-0619/
-        removal_strategy: keep_latest_released
-    versions_to_keep: 2
+        removal_strategy: remove_all
+    versions_to_keep: 1
   r:
     buildpacks:
       r:


### PR DESCRIPTION
Go Buildpack and Python Buildpack exceeded the maximum size allowed by CF for uploading a Buildpack (1GB) so I decided to apply the same tactic used in Dotnet Core Buildpack, removing versions of the dependencies to have only the latest version (latest patch).