### PR TITLE
dotnet bp: scale up lts test env

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -14,6 +14,7 @@
     'stacks' => %w(cflinuxfs3 cflinuxfs4),
     'product_slug' => 'dotnet-core-buildpack',
     'non_lts_pivnet' => true,
+    'compute_instance_count' => 3
   },
   'go' => {
     'stacks' => %w(cflinuxfs3 cflinuxfs4),


### PR DESCRIPTION
See test runs like https://buildpacks.ci.cf-app.com/teams/main/pipelines/dotnet-core-buildpack/jobs/specs-lts-integration-develop/builds/1145.
Scale env to make the test less flaky.