### PR TITLE
Install Ruby 2.7 for all dependency builds in build-binary-new

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -26,6 +26,7 @@ module DependencyBuild
       Runner.run('apt', 'update')
       Runner.run('apt', 'install', '-y', 'ruby2.7', 'ruby2.7-dev')
     end
+
     def setup_python
       Runner.run('apt', 'update')
       Runner.run('apt', 'install', '-y', 'curl', 'python3.8', 'python3.8-distutils', 'python3.8-dev')
@@ -653,9 +654,10 @@ class Builder
 
     filename_prefix = "#{source_input.name}_#{source_input.version}"
 
+    DependencyBuild.setup_ruby
+
     case source_input.name
     when 'bundler'
-      DependencyBuild.setup_ruby
       binary_builder.build(source_input)
       out_data.merge!(
           artifact_output.move_dependency(


### PR DESCRIPTION
Related to #208, bundler is used in more than one dependency build. This installs ruby 2.7 for all builds.