### PR TITLE
Build Nginx dependencies for cflinuxfs4

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -179,6 +179,7 @@ dependencies:
           - line: 1.19.X
           - line: 1.21.X
     versions_to_keep: 2
+    skip_lines_cflinuxfs4: [ '1.13.X' ]
   nginx-static:
     buildpacks:
       php:

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -173,13 +173,9 @@ dependencies:
     buildpacks:
       nginx:
         lines:
-          - line: 1.13.X
-          - line: 1.15.X
-          - line: 1.17.X
           - line: 1.19.X
           - line: 1.21.X
     versions_to_keep: 2
-    skip_lines_cflinuxfs4: [ '1.13.X' ]
   nginx-static:
     buildpacks:
       php:
@@ -355,9 +351,9 @@ dependencies:
       - 'extension: .tar.gz'
     any_stack: true
     versions_to_keep: 2
-cflinuxfs4_build_dependencies: [ 'libunwind', 'libgdiplus', 'node', 'pipenv', 'python', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby' ]
-cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'pipenv', 'python', 'yarn', 'pip', 'setuptools', 'miniconda3-py39', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'bundler', 'rubygems' ]
-cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs', 'python', 'go', 'ruby' ]
+cflinuxfs4_build_dependencies: [ 'libunwind', 'libgdiplus', 'node', 'pipenv', 'python', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'nginx', 'nginx-static', 'openresty' ]
+cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'pipenv', 'python', 'yarn', 'pip', 'setuptools', 'miniconda3-py39', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'bundler', 'rubygems', 'nginx', 'nginx-static', 'openresty' ]
+cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs', 'python', 'go', 'ruby', 'nginx' ]
 build_stacks: [ 'cflinuxfs4' , 'cflinuxfs3' ]
 windows_stacks: [ 'windows2016', 'windows' ]
 deprecated_stacks: [ 'cflinuxfs2' ]

--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -130,32 +130,64 @@ end
 module DependencyBuildHelper
   class << self
     def build_nginx_helper(source_input, custom_options, static=false)
+      public_gpg_key_urls = %w[http://nginx.org/keys/nginx_signing.key http://nginx.org/keys/mdounin.key http://nginx.org/keys/maxim.key http://nginx.org/keys/sb.key http://nginx.org/keys/thresh.key]
+      GPGHelper.verify_gpg_signature(source_input.url, "#{source_input.url}.asc", public_gpg_key_urls)
+
       artifacts = "#{Dir.pwd}/artifacts"
       destdir = Dir.mktmpdir
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
-          Runner.run('wget', source_input.url)
-          # TODO validate pgp
-          Runner.run('tar', 'xf', "nginx-#{source_input.version}.tar.gz")
-          base_nginx_options = %w[--prefix=/ --error-log-path=stderr --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --without-http_uwsgi_module --without-http_scgi_module --with-pcre --with-pcre-jit --with-debug]
+            Runner.run('wget', source_input.url)
+            Runner.run('tar', 'xf', "nginx-#{source_input.version}.tar.gz")
+            base_nginx_options = %w[--prefix=/ --error-log-path=stderr --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --without-http_uwsgi_module --without-http_scgi_module --with-pcre --with-pcre-jit --with-debug]
 
-          Dir.chdir("nginx-#{source_input.version}") do
-            options = ['./configure'] + base_nginx_options + custom_options
-            Runner.run(*options)
-            Runner.run('make')
-            system({ 'DEBIAN_FRONTEND' => 'noninteractive', 'DESTDIR' => "#{destdir}/nginx" }, 'make install')
-            raise 'Could not run make install' unless $CHILD_STATUS.success?
+            Dir.chdir("nginx-#{source_input.version}") do
+              options = ['./configure'] + base_nginx_options + custom_options
+              Runner.run(*options)
+              Runner.run('make')
+              system({ 'DEBIAN_FRONTEND' => 'noninteractive', 'DESTDIR' => "#{destdir}/nginx" }, 'make install')
+              raise 'Could not run make install' unless $CHILD_STATUS.success?
 
-            Dir.chdir(destdir) do
-              Runner.run('rm', '-Rf', './nginx/html', './nginx/conf')
-              Runner.run('mkdir', 'nginx/conf')
-              if static
-                Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{source_input.version}.tgz", 'nginx')
-              else
-                Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{source_input.version}.tgz", '.')
+              Dir.chdir(destdir) do
+                Runner.run('rm', '-Rf', './nginx/html', './nginx/conf')
+                Runner.run('mkdir', 'nginx/conf')
+                if static
+                  Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{source_input.version}.tgz", 'nginx')
+                else
+                  Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{source_input.version}.tgz", '.')
+                end
               end
             end
+        end
+      end
+    end
+  end
+end
+
+module GPGHelper
+  class << self
+    def verify_gpg_signature(file_url, signature_url, public_key_url)
+
+      ## Check if gpg package is installed
+      unless system('which gpg > /dev/null')
+        Runner.run('apt-get', 'update')
+        Runner.run('apt-get', 'install', '-y', 'gpg')
+      end
+
+      ## Verify gpg signature
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          if public_key_url.is_a?(Array)
+            public_key_url.each do |key_url|
+              Runner.run('wget', key_url)
+              Runner.run('gpg', '--import', File.basename(key_url))
+            end
+          else
+            Runner.run('wget', public_key_url)
           end
+          Runner.run('wget', file_url)
+          Runner.run('wget', signature_url)
+          Runner.run('gpg', '--verify', File.basename(signature_url), File.basename(file_url))
         end
       end
     end

--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -532,6 +532,123 @@ class DependencyBuild
     merge_out_data(old_filepath, filename_prefix)
   end
 
+  def build_nginx
+
+    nginx_options = [
+      '--with-cc-opt=-fPIC -pie',
+      '--with-ld-opt=-fPIC -pie -z now',
+      '--with-compat',
+      '--with-stream=dynamic',
+      '--with-http_sub_module',
+    ]
+
+    build_nginx_helper(nginx_options)
+
+    old_filepath = "artifacts/#{@source_input.name}-#{@source_input.version}.tgz"
+    Archive.strip_top_level_directory_from_tar(old_filepath)
+    filename_prefix = "#{@filename_prefix}_linux_x64_#{@stack}"
+    merge_out_data(old_filepath, filename_prefix)
+  end
+
+  def build_nginx_static
+
+    nginx_static_options = [
+      '--with-cc-opt=-fPIE -pie',
+      '--with-ld-opt=-fPIE -pie -z now',
+    ]
+
+    build_nginx_helper(nginx_static_options, true)
+
+    old_filepath = "artifacts/nginx-#{@source_input.version}.tgz"
+    Archive.strip_top_level_directory_from_tar(old_filepath)
+    filename_prefix = "#{@filename_prefix}_linux_x64_#{@stack}"
+    merge_out_data(old_filepath, filename_prefix)
+
+  end
+
+  def build_nginx_helper(custom_options, static=false)
+    artifacts = "#{Dir.pwd}/artifacts"
+    destdir = Dir.mktmpdir
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Runner.run('wget', @source_input.url)
+        # TODO validate pgp
+        Runner.run('tar', 'xf', "nginx-#{@source_input.version}.tar.gz")
+        base_nginx_options = %w[--prefix=/ --error-log-path=stderr --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_stub_status_module --without-http_uwsgi_module --without-http_scgi_module --with-pcre --with-pcre-jit --with-debug]
+
+        Dir.chdir("nginx-#{@source_input.version}") do
+          options = ['./configure'] + base_nginx_options + custom_options
+          Runner.run(*options)
+          Runner.run('make')
+          system({ 'DEBIAN_FRONTEND' => 'noninteractive', 'DESTDIR' => "#{destdir}/nginx" }, 'make install')
+          raise 'Could not run make install' unless $CHILD_STATUS.success?
+
+          Dir.chdir(destdir) do
+            Runner.run('rm', '-Rf', './nginx/html', './nginx/conf')
+            Runner.run('mkdir', 'nginx/conf')
+            if static
+              Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{@source_input.version}.tgz", 'nginx')
+            else
+              Runner.run('tar', 'zcvf', "#{artifacts}/nginx-#{@source_input.version}.tgz", '.')
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def build_openresty
+    artifacts = "#{Dir.pwd}/artifacts"
+    destdir = Dir.mktmpdir
+
+
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Runner.run('wget', @source_input.url)
+        # TODO validate pgp
+        Runner.run('tar', 'xf', "#{@source_input.name}-#{@source_input.version}.tar.gz")
+        Dir.chdir("#{@source_input.name}-#{@source_input.version}") do
+          Runner.run(
+            './configure',
+            "--prefix=#{destdir}/openresty",
+            '-j2',
+            '--error-log-path=stderr',
+            '--with-http_ssl_module',
+            '--with-http_realip_module',
+            '--with-http_gunzip_module',
+            '--with-http_gzip_static_module',
+            '--with-http_auth_request_module',
+            '--with-http_random_index_module',
+            '--with-http_secure_link_module',
+            '--with-http_stub_status_module',
+            '--without-http_uwsgi_module',
+            '--without-http_scgi_module',
+            '--with-pcre',
+            '--with-pcre-jit',
+            '--with-cc-opt=-fPIC -pie',
+            '--with-ld-opt=-fPIC -pie -z now',
+            '--with-compat',
+            '--with-stream=dynamic',
+            )
+          Runner.run('make', '-j2')
+          system({ 'DEBIAN_FRONTEND' => 'noninteractive' }, 'make install')
+          raise 'Could not run make install' unless $CHILD_STATUS.success?
+
+          Dir.chdir("#{destdir}/openresty") do
+            Runner.run('rm', '-Rf', './nginx/html', './nginx/conf')
+            Runner.run('mkdir', './nginx/conf')
+            Runner.run('rm', './bin/openresty')
+            Runner.run('tar', 'zcvf', "#{artifacts}/openresty-#{@source_input.version}.tgz", '.')
+          end
+        end
+      end
+    end
+
+    old_filepath = "artifacts/#{@source_input.name}-#{@source_input.version}.tgz"
+    filename_prefix = "#{@filename_prefix}_linux_x64_#{@stack}"
+    merge_out_data(old_filepath, filename_prefix)
+  end
+
   class Utils
 
     def self.setup_python

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -605,7 +605,6 @@ module Archive
   end
 end
 
-
 class Builder
   def execute(binary_builder, stack, source_input, build_input, build_output, artifact_output, dep_metadata_output, php_extensions_dir = __dir__, skip_commit = false)
     cnb_list = [


### PR DESCRIPTION
# Notes

- `openresty` has so many lines right now and we should support only the latest 2. This applies to cflinuxfs4 since deleting 3 version lines from cflinuxfs3 could impact some customers.
- `nginx-static` is added to `builder.rb` even though is not a direct dependency of the Nginx Buildpack but it shares the build logic with `nginx`