### PR TITLE
build R on cflinuxfs4 and test in the pipeline

### DIFF
--- a/pipelines/config/dependency-builds-cflinuxfs4.yml
+++ b/pipelines/config/dependency-builds-cflinuxfs4.yml
@@ -1,67 +1,20 @@
 ---
 dependencies:
-  bower:
+  r:
     buildpacks:
-      dotnet-core:
-        lines:
-          - line: latest
-    source_type: npm
-    any_stack: true
+      r:
+        lines: #! final release for each minor version is every spring ( just before next minor version release )
+          - line: 3.6.X
+          - line: 4.2.X
+        removal_strategy: keep_latest_released
+    monitored_deps:
+      - rserve
+      - forecast
+      - shiny
+      - plumber
     versions_to_keep: 2
-  dotnet-sdk:
-    buildpacks:
-      dotnet-core:
-        lines:
-          - line: 3.1.X
-            deprecation_date: 2022-12-03
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-          - line: 6.0.X
-            deprecation_date: 2024-11-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: remove_all
-    versions_to_keep: 1
-    any_stack: true
-    skip_lines_cfllinuxfs4: ['3.1.X']
-  dotnet-runtime:
-    buildpacks:
-      dotnet-core:
-        lines:
-          - line: 3.1.X
-            deprecation_date: 2022-12-03
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-            skip_stacks: ['cflinuxfs4']
-          - line: 6.0.X
-            deprecation_date: 2024-11-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: remove_all
-    versions_to_keep: 1
-    any_stack: true
-    skip_lines_cfllinuxfs4: ['3.1.X']
-  dotnet-aspnetcore:
-    buildpacks:
-      dotnet-core:
-        lines:
-          - line: 3.1.X
-            deprecation_date: 2022-12-03
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-            skip_stacks: ['cflinuxfs4']
-          - line: 6.0.X
-            deprecation_date: 2024-11-08
-            link: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-        removal_strategy: remove_all
-    versions_to_keep: 1
-    any_stack: true
-    skip_lines_cfllinuxfs4: ['3.1.X']
-  node:
-    buildpacks:
-      dotnet-core:
-        lines:
-          - line: node-lts
-            deprecation_date: ""
-            link: https://github.com/nodejs/Release
-    source_type: node
-    versions_to_keep: 2
-cflinuxfs4_dependencies: [ 'node', 'libunwind', 'libgdiplus' ]
+
+cflinuxfs4_dependencies: [ 'r']
 build_stacks: [ 'cflinuxfs4' ]
 windows_stacks: [ 'windows2016', 'windows' ]
 deprecated_stacks: [ 'cflinuxfs2' ]

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -300,6 +300,8 @@ dependencies:
       - shiny
       - plumber
     versions_to_keep: 2
+    #! R doesn't publish EOL dates but 3.6 hasn’t made a release in 3 years and community feedback suggests 3.x contains known security issues
+    skip_lines_cflinuxfs4: ['3.6.X']
   ruby:
     buildpacks:
       ruby:
@@ -351,9 +353,9 @@ dependencies:
       - 'extension: .tar.gz'
     any_stack: true
     versions_to_keep: 2
-cflinuxfs4_build_dependencies: [ 'libunwind', 'libgdiplus', 'node', 'pipenv', 'python', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'nginx', 'nginx-static', 'openresty' ]
-cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'pipenv', 'python', 'yarn', 'pip', 'setuptools', 'miniconda3-py39', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'bundler', 'rubygems', 'nginx', 'nginx-static', 'openresty' ]
-cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs', 'python', 'go', 'ruby', 'nginx' ]
+cflinuxfs4_build_dependencies: [ 'libunwind', 'libgdiplus', 'node', 'pipenv', 'python', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'nginx', 'nginx-static', 'openresty', 'r' ]
+cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'pipenv', 'python', 'yarn', 'pip', 'setuptools', 'miniconda3-py39', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'bundler', 'rubygems', 'nginx', 'nginx-static', 'openresty', 'r' ]
+cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs', 'python', 'go', 'ruby', 'nginx', 'r' ]
 build_stacks: [ 'cflinuxfs4' , 'cflinuxfs3' ]
 windows_stacks: [ 'windows2016', 'windows' ]
 deprecated_stacks: [ 'cflinuxfs2' ]

--- a/pipelines/dependency-builds-cflinuxfs4.yml.erb
+++ b/pipelines/dependency-builds-cflinuxfs4.yml.erb
@@ -184,7 +184,7 @@ resources:
 <%
   skipped_version_lines = dep['skip_lines_cfllinuxfs4'] ? dep['skip_lines_cfllinuxfs4'] : []
   lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version_lines(bp['lines'])}
-  lines.push('latest') unless lines.include?('latest') || dep_name.include?('dotnet') || dep_name.include?('node')
+  lines.push('latest') unless lines.include?('latest') || dep_name.include?('r')
   lines = lines - skipped_version_lines
   lines.each do |line|
 %>

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -50,7 +50,7 @@
     'non_lts_pivnet' => true,
   },
   'r' => {
-    'stacks' => %w(cflinuxfs3),
+    'stacks' => %w(cflinuxfs3 cflinuxfs4),
     'product_slug' => 'r-buildpack',
     'skip_brats' => true,
     'non_lts' => true,


### PR DESCRIPTION
- 3.6 line is not built for cflinuxfs4. R doesn't publish EOL dates but 3.6 hasn’t made a release in 3 years and community feedback suggests 3.x contains known security issues.
See [conversation](https://cloudfoundry.slack.com/archives/C02HWMDUQ/p1653035710423729?thread_ts=1652948507.406579&cid=C02HWMDUQ)

- build logic mostly follows the old code in build-binary-new task

- Adds stack testing and release to the buildpack pipeline

- Also checked-in is the current state of the test pipeline (dependency-builds-cflinuxfs4)

- Test build: https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds-cflinuxfs4/jobs/build-r-4.2.x/builds/5
   Production build: https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-r-4.2.x/builds/16

Issue: https://github.com/cloudfoundry/r-buildpack-release/issues/2

Co-authored-by: Rob Dimsdale-Zucker <rdimsdale@vmware.com>
cc @robdimsdale 