### PR TITLE
type docker-image fails with error

### DIFF
--- a/tasks/get-buildpack-github-release-notes/task.yml
+++ b/tasks/get-buildpack-github-release-notes/task.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cfbuildpacks/ci
 inputs:


### PR DESCRIPTION
It errors with "no versions of image available" even when tag is specified.

E.g. error see [private job](https://buildpacks-private.ci.cf-app.com/teams/core-deps/pipelines/tas/jobs/publish-r-offline-buildpack-release/builds/40)

Replace with "registry-image" which works fine.