### PR TITLE
Revert "buildpack pipeln: don't overload CI w/ changes to .github

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -118,7 +118,6 @@ resources: #####################################################################
       ignore_paths:
         - VERSION
         - CHANGELOG
-        - .github
 
   - name: cf-deployment
     type: git


### PR DESCRIPTION
This reverts commit 863b0e2d1d8c969e5957135a81baed3cf7b196f9. (https://github.com/cloudfoundry/buildpacks-ci/pull/224)

This is causing issues like https://buildpacks.ci.cf-app.com/teams/main/pipelines/go-buildpack/jobs/buildpack-to-master/builds/104 the top commit didn't go thru CI.