### PR TITLE
Update bosh version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/
 RUN mv /usr/bin/composer.phar /usr/bin/composer
 
 # download the bosh2 CLI
-RUN curl -L https://github.com/cloudfoundry/bosh-cli/releases/download/v5.5.1/bosh-cli-5.5.1-linux-amd64 -o /usr/local/bin/bosh2 \
-  && [ 34e9898c244655ccbce2dc657b7d1df52e487cfd = $(shasum -a 1 /usr/local/bin/bosh2 | cut -d' ' -f1) ] \
+RUN curl -L https://github.com/cloudfoundry/bosh-cli/releases/download/v7.1.3/bosh-cli-7.1.3-linux-amd64 -o /usr/local/bin/bosh2 \
+  && [ 901f5fedf406c063be521660ae5f7ccd34e034d3f734e0522138bc5bf71f4e80 = $(shasum -a 256 /usr/local/bin/bosh2 | cut -d' ' -f1) ] \
   && chmod +x /usr/local/bin/bosh2 \
   && ln -s /usr/local/bin/bosh2 /usr/local/bin/bosh
 


### PR DESCRIPTION
This should resolve failures we've seen related to connecting to the bosh director: `  Performing request GET 'https://10.0.0.6:25555/info':` ([example](https://buildpacks.ci.cf-app.com/teams/main/pipelines/staticfile-buildpack/jobs/specs-edge-integration-develop-cflinuxfs3/builds/34))