### PR TITLE
update-dep: rm .net logic related to removed metadata

### DIFF
--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -316,40 +316,6 @@ if buildpack_name == 'r'
   end
 end
 
-#
-# Special Dotnet Stuff
-# * The .NET Core buildpack has a .NET Core dependency in the manifest.
-#   Replace the version with the one in the manifest.
-if !rebuilt && buildpack_name == 'dotnet-core'
-  runtime_7_version = ""
-  sdk_7_version = ""
-  runtime_6_version = ""
-  sdk_6_version = ""
-  manifest["dependencies"].map do |dep|
-    case dep["name"]
-    when "dotnet-runtime"
-      if dep["version"].start_with?("7.")
-        runtime_7_version = dep["version"]
-      elsif dep["version"].start_with?("6.")
-        runtime_6_version = dep["version"]
-      end
-    when "dotnet-sdk"
-      if dep["version"].start_with?("7.")
-        sdk_7_version = dep["version"]
-      elsif dep["version"].start_with?("6.")
-        sdk_6_version = dep["version"]
-      end
-    end
-  end
-  # Update the 3.X runtime version
-  manifest['runtime_to_sdks'][0]["runtime_version"] = runtime_7_version
-  manifest['runtime_to_sdks'][0]["sdks"] = [sdk_7_version]
-
-  # Update the 6.X runtime version
-  manifest['runtime_to_sdks'][1]["runtime_version"] = runtime_6_version
-  manifest['runtime_to_sdks'][1]["sdks"] = [sdk_6_version]
-end
-
 Dir.chdir('artifacts') do
   GitClient.set_global_config('user.email', 'cf-buildpacks-eng@pivotal.io')
   GitClient.set_global_config('user.name', 'CF Buildpacks Team CI Server')


### PR DESCRIPTION
I noticed that dependency-builds of dotnet sdk, runtime etc are failing to update buildpacks (e.g.
https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/update-dotnet-sdk-6.0.x-dotnet-core/builds/16)

Intercepting the containers, error shows
`run.rb:345:in  <main>: undefined method '[]' for nil:NilClass (NoMethodError)`

Looks like field `runtime_to_sdks` was removed in https://github.com/cloudfoundry/dotnet-core-buildpack/pull/734