### PR TITLE
rootfs test opsfile: only change what's required

### DIFF
--- a/tasks/overwrite-rootfs-release/run.sh
+++ b/tasks/overwrite-rootfs-release/run.sh
@@ -8,10 +8,6 @@ echo "Overwriting BOSH release $STACK"
 
 release_dir=rootfs-release
 version="212.0.$(date +"%s")"
-ubuntu_yymm="18.04"
-if [ "${STACK}" = "cflinuxfs4" ]; then
-  ubuntu_yymm="22.04"
-fi
 
 pushd $release_dir
   for name in $( bosh2 blobs | grep -- "rootfs/$STACK-*" | awk '{print $1}' ); do
@@ -35,15 +31,6 @@ cat <<EOF > ${release_dir}/use-dev-release-opsfile.yml
   value:
     name: $STACK
     version: ${version}
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks
-  value:
-    - name: $STACK
-      description: Cloud Foundry Linux-based filesystem (Ubuntu ${ubuntu_yymm})
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses
-  value:
-    - $STACK:/var/vcap/packages/$STACK/rootfs.tar
 EOF
 
 echo "rsyncing $release_dir to ${release_dir}-artifacts"


### PR DESCRIPTION
for cflinuxfs3:
cc.stacks and rep.preloaded_rootfses in this ops file are the same as in cf-deployment/cf-deployment.yml.

For cflinuxfs4:
This was simply overriding the default values in cf-d with cflinuxfs4.
But with the introduction of `add-cflinuxfs4.yml` in cf-d, we can use that to add the new stack of cflinuxfs4.