### PR TITLE
ruby tasks on fs4: install ruby before task

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/build.sh
+++ b/tasks/build-binary-new-cflinuxfs4/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v ruby &> /dev/null; then
+  echo "[task] Installing ruby..."
+  apt update
+  apt install -y ruby
+fi
+
+echo "[task] Running builder.rb..."
+ruby buildpacks-ci/tasks/build-binary-new-cflinuxfs4/build.rb

--- a/tasks/build-binary-new-cflinuxfs4/build.yml
+++ b/tasks/build-binary-new-cflinuxfs4/build.yml
@@ -23,10 +23,7 @@ outputs:
   - name: builds-artifacts
   - name: dep-metadata
 run:
-  path: bash
-  args:
-    - -cl
-    - buildpacks-ci/tasks/build-binary-new-cflinuxfs4/build.rb
+  path: buildpacks-ci/tasks/build-binary-new-cflinuxfs4/build.sh
 params:
   STACK:
   SKIP_COMMIT:


### PR DESCRIPTION
as cflinuxfs4 1.0 does not come with ruby.

E.g. failed build https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-nginx-static-1.23.x/builds/8