### PR TITLE
usn: allow 2 launchpad bug url patterns

### DIFF
--- a/lib/usn-release-notes.rb
+++ b/lib/usn-release-notes.rb
@@ -35,6 +35,8 @@ class UsnReleaseNotes
         cves << cve
       elsif (lp = line.match(%r{.*href="(?<uri>.*launchpad\.net/bugs.*)">(?<text>.*)</li}))
         lps << lp
+      elsif (lp = line.match(%r{.*href="(?<uri>.*bugs\.launchpad\.net/.*)">(?<text>.*)</li}))
+        lps << lp
       end
     end
 


### PR DESCRIPTION
- launchpad.net/bugs.*
- bugs.launchpad.net/.*

See https://github.com/cloudfoundry/buildpacks-ci/issues/254