### PR TITLE
update dep task: make it more resilient

### DIFF
--- a/tasks/update-buildpack-dependency/dependencies.rb
+++ b/tasks/update-buildpack-dependency/dependencies.rb
@@ -46,7 +46,7 @@ class Dependencies
   # [1,2,3], [1,2,3] => true
   # [1], [1,2] => true
   def dep_includes_at_least_these_stacks?(manifest_stacks)
-    (manifest_stacks - @dep['cf_stacks']).empty?
+    manifest_stacks.nil? or (manifest_stacks - @dep['cf_stacks']).empty?
   end
 
   def same_dependency_line?(stacks, version, dep_name)


### PR DESCRIPTION
The immediate reason here is that the released ruby buildpack manifest has a little error where it has a [hanging ruby dep entry without a stack](https://github.com/cloudfoundry/ruby-buildpack/blob/v1.10.0/manifest.yml#L92).

This task when comparing the dependencies in released buildpack with the incoming dependency ends up in a situation subtracting from nil.

Except for this task, such stackless entries are inert and does not affect the buildpack.

See also https://github.com/cloudfoundry/ruby-buildpack/pull/780