### PR TITLE
remove stale creds input from lastpass

### DIFF
--- a/lib/buildpacks-ci-configuration.rb
+++ b/lib/buildpacks-ci-configuration.rb
@@ -19,10 +19,6 @@ class BuildpacksCIConfiguration
     ENV.fetch('LPASS_BOSH_RELEASE_PRIVATE_KEYS_FILE', 'Shared-CF\ Buildpacks/buildpack-bosh-release-repos-private-keys.yml')
   end
 
-  def bosh_release_private_keys_filename_2
-    ENV.fetch('LPASS_BOSH_RELEASE_PRIVATE_KEYS_FILE_2', 'Shared-CF\ Buildpacks/buildpack-bosh-release-repos-private-keys-2.yml')
-  end
-
   def bosh_release_private_keys_filename_lts
     ENV.fetch('LPASS_BOSH_RELEASE_PRIVATE_KEYS_FILE_LTS', 'Shared-CF\ Buildpacks/buildpack-bosh-release-repos-private-keys-lts.yml')
   end

--- a/lib/buildpacks-ci-pipeline-update-command.rb
+++ b/lib/buildpacks-ci-pipeline-update-command.rb
@@ -27,7 +27,6 @@ class BuildpacksCIPipelineUpdateCommand
       buildpacks_configuration.git_repos_private_keys_two_filename,
       buildpacks_configuration.git_repos_private_keys_three_filename,
       buildpacks_configuration.bosh_release_private_keys_filename,
-      buildpacks_configuration.bosh_release_private_keys_filename_2,
       buildpacks_configuration.bosh_release_private_keys_filename_lts,
     ].map { |name| "lpass show #{name} --notes"}.join(' && ')
 


### PR DESCRIPTION
This private-keys-2.yml only contain(ed) a deploy key for R buildpack bosh release, which is not viable and used.
See this [private link](https://github.com/pivotal-cf/tanzu-buildpacks/issues/196) for details