### PR TITLE
rm non-existent lpass keys that crashed update command

### DIFF
--- a/lib/buildpacks-ci-configuration.rb
+++ b/lib/buildpacks-ci-configuration.rb
@@ -3,10 +3,6 @@ class BuildpacksCIConfiguration
     ENV.fetch('LPASS_CONCOURSE_PRIVATE_FILE', 'Shared-CF\ Buildpacks/concourse-private.yml')
   end
 
-  def deployments_buildpacks_filename
-    ENV.fetch('LPASS_DEPLOYMENTS_BUILDPACKS_FILE',  'Shared-CF\ Buildpacks/deployments-buildpacks.yml')
-  end
-
   def repos_private_keys_filename
     ENV.fetch('LPASS_REPOS_PRIVATE_KEYS_FILE', 'Shared-CF\ Buildpacks/buildpack-repos-private-keys.yml')
   end

--- a/lib/buildpacks-ci-pipeline-update-command.rb
+++ b/lib/buildpacks-ci-pipeline-update-command.rb
@@ -20,7 +20,6 @@ class BuildpacksCIPipelineUpdateCommand
 
     secrets_cmd = [
       buildpacks_configuration.concourse_private_filename,
-      buildpacks_configuration.deployments_buildpacks_filename,
       buildpacks_configuration.repos_private_keys_filename,
       buildpacks_configuration.cnb_repos_private_keys_filename,
       buildpacks_configuration.git_repos_private_keys_filename,


### PR DESCRIPTION
When there are non-existent lpass keys, the lpass command generation
[here](https://github.com/cloudfoundry/buildpacks-ci/blob/f1b3ce50c6a1bd1d51c5a091efbcc53ad44895e4/lib/buildpacks-ci-pipeline-update-command.rb#L31) gets messed up as multiple commands are connected via `&&`.

This was deleted according to this issue: [Private link](https://github.com/pivotal-cf/tanzu-buildpacks/issues/153)