### PR TITLE
Include flit_core in pip dependency.

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -63,6 +63,7 @@ module DependencyBuild
           Runner.run('tar', 'zxf', "pip-#{source_input.version}.tar.gz")
           Runner.run('/usr/local/bin/pip3', 'download', '--no-binary', ':all:', 'setuptools')
           Runner.run('/usr/local/bin/pip3', 'download', '--no-binary', ':all:', 'wheel')
+          Runner.run('/usr/local/bin/pip3', 'download', '--no-binary', ':all:', 'flit_core')
           Runner.run('tar', 'zcvf', file_path, '.')
         end
       end


### PR DESCRIPTION
This PR adds `flit_core` as an included dependency. This is required for pip v23.x.

This should resolve test failures in python buildpack:
* https://github.com/cloudfoundry/python-buildpack/pull/746
* https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-lts-integration-develop/builds/1188#L63e036f9:378

 See also: https://github.com/paketo-buildpacks/pip/pull/392