### PR TITLE
Migrate feature-eng CI back into this repo.

### DIFF
--- a/bin/update-pipelines.sh
+++ b/bin/update-pipelines.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && cd .. && pwd)"
+readonly ROOT_DIR
+
+function main() {
+  local include
+  include=""
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+
+      --include|-i)
+        include="${2}"
+        shift 2
+        ;;
+
+      "")
+        shift 1
+        ;;
+
+      *)
+        usage
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  team::check
+  pipelines::update "${include}"
+}
+
+function usage() {
+  cat <<-USAGE
+update-pipelines.sh [OPTIONS]
+
+OPTIONS
+  --help, -h                prints the command usage
+  --include, -i <pipeline>  specifies a fragment of a pipeline to match
+
+USAGE
+}
+
+function team::check() {
+  if ! string::contains "$(yq eval .targets.buildpacks.team ~/.flyrc )" "feature-eng" ; then
+    echo "Refusing to update pipelines. Please log in as the 'feature-eng' team using:"
+    echo -e "\n  fly -t buildpacks login -n feature-eng\n"
+    exit 1
+  fi
+  return
+}
+
+function pipelines::update() {
+  local include
+  include="${1}"
+
+  local basic_pipelines
+  basic_pipelines=(
+    ci-images
+    interrupt-bot
+    slack-invitations
+  )
+
+  for name in "${basic_pipelines[@]}"; do
+    pipeline::update::basic "${name}" "${include}"
+  done
+}
+
+function string::contains() {
+  local string substring
+  string="${1}"
+  substring="${2}"
+
+  grep -qi "${substring}" <(echo "${string}")
+}
+
+function pipeline::update::basic() {
+  local name include
+  name="${1}"
+  include="${2}"
+
+  if string::contains "${name}" "${include}"; then
+    echo "=== UPDATING ${name} ==="
+    fly --target buildpacks \
+      set-pipeline \
+        --pipeline "${name}" \
+        --config "${ROOT_DIR}/pipelines/${name}.yml"
+    echo
+  fi
+}
+
+main "$@"

--- a/dockerfiles/docker.Dockerfile
+++ b/dockerfiles/docker.Dockerfile
@@ -1,0 +1,18 @@
+FROM cfbuildpacks/feature-eng-ci:minimal
+
+RUN apt-get -qqy update \
+  && apt-get -qqy install \
+    apt-transport-https \
+    ca-certificates \
+    gnupg-agent \
+    software-properties-common \
+  && apt-get -qqy clean \
+  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+  && add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+  && apt-get -qqy install \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    iproute2 \
+  && apt-get -qqy clean

--- a/dockerfiles/gcloud.Dockerfile
+++ b/dockerfiles/gcloud.Dockerfile
@@ -1,0 +1,9 @@
+FROM cfbuildpacks/feature-eng-ci:minimal
+
+# Add the Cloud SDK distribution URI as a package source
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl --silent https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+  && apt-get -qqy update \
+  && apt-get -qqy install \
+    google-cloud-sdk \
+  && apt-get clean

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,0 +1,25 @@
+FROM cfbuildpacks/feature-eng-ci:minimal
+
+RUN \
+  apt-get -qqy update \
+  && apt-get -qqy install --fix-missing \
+    runit \
+  && apt-get -qqy clean
+
+RUN mkdir -p /home/testuser \
+  && groupadd -r testuser -g 433 \
+  && useradd -u 431 -r -g testuser \
+    -d /home/testuser \
+    -s /usr/sbin/nologin \
+    -c "Docker image test user" \
+    testuser
+
+ARG GO_VERSION=1.14
+RUN curl "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" \
+    --silent \
+    --location \
+    --output "/usr/local/go${GO_VERSION}.tar.gz" \
+  && tar xzf "/usr/local/go${GO_VERSION}.tar.gz" -C /usr/local \
+  && rm "/usr/local/go${GO_VERSION}.tar.gz"
+
+ENV PATH="/usr/local/go/bin:${PATH}"

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:bionic
+
+RUN \
+  apt-get update && \
+  apt-get -qqy install --fix-missing \
+    build-essential \
+    curl \
+    gnupg \
+    vim \
+    git \
+  && \
+  apt-get clean
+
+# install jq
+ARG JQ_VERSION=1.6
+RUN curl "https://github.com/stedolan/jq/releases/download/jq-$JQ_VERSION/jq-linux64" \
+    --silent \
+    --location \
+    --output /usr/local/bin/jq \
+  && chmod +x /usr/local/bin/jq

--- a/pipelines/brats.yml.erb
+++ b/pipelines/brats.yml.erb
@@ -47,13 +47,6 @@ resources:
       uri: {{buildpacks-ci-git-uri-public}}
       branch: {{buildpacks-ci-git-uri-public-branch}}
 
-  - name: feature-eng-ci
-    type: git
-    icon: github-circle
-    source:
-      uri: https://github.com/cloudfoundry/buildpacks-feature-eng-ci
-      branch: master
-
   - name: env-repo
     type: git
     source:
@@ -138,7 +131,6 @@ jobs:
         - in_parallel:
           - get: buildpacks-ci
           - get: env-repo
-          - get: feature-eng-ci
           - get: buildpack
             resource: buildpack-<%= language %>
           - get: nightly-trigger
@@ -146,9 +138,9 @@ jobs:
 <% if stacks[language].include?('windows')%>
           - get: cf-deployment
         - task: redeploy
-          file: feature-eng-ci/tasks/cf/redeploy/task.yml
+          file: buildpacks-ci/tasks/cf/redeploy/task.yml
           input_mapping:
-            ci: feature-eng-ci
+            ci: buildpacks-ci
             lock: cf-toolsmiths-environment
           params:
             DEPLOY_WINDOWS_CELL: true
@@ -158,12 +150,12 @@ jobs:
           - do:
             - task: create-cf-space
               attempts: 5
-              file: feature-eng-ci/tasks/cf/create-space/task.yml
+              file: buildpacks-ci/tasks/cf/create-space/task.yml
               params:
                 DOMAIN: cf-app.com
                 ORG: pivotal
               input_mapping:
-                ci: feature-eng-ci
+                ci: buildpacks-ci
                 lock: cf-toolsmiths-environment
             - task: run-brats-<%= stack %>
               file: buildpacks-ci/tasks/run-bp-brats/task.yml

--- a/pipelines/ci-images.yml
+++ b/pipelines/ci-images.yml
@@ -1,0 +1,167 @@
+---
+resources:
+- name: ci
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+
+- name: ubuntu-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: ubuntu
+    tag: bionic
+
+- name: minimal-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: minimal
+    username: ((dockerhub-account.username))
+    password: ((dockerhub-account.password))
+
+- name: gcloud-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: gcloud
+    username: ((dockerhub-account.username))
+    password: ((dockerhub-account.password))
+
+- name: go-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: go
+    username: ((dockerhub-account.username))
+    password: ((dockerhub-account.password))
+
+- name: docker-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: docker
+    username: ((dockerhub-account.username))
+    password: ((dockerhub-account.password))
+
+- name: minimal-dockerfile
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+    paths:
+    - dockerfiles/minimal.Dockerfile
+
+- name: go-dockerfile
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+    paths:
+    - dockerfiles/go.Dockerfile
+
+- name: docker-dockerfile
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+    paths:
+    - dockerfiles/docker.Dockerfile
+
+- name: gcloud-dockerfile
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+    paths:
+    - dockerfiles/gcloud.Dockerfile
+
+jobs:
+- name: build-minimal-image
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: ubuntu-image
+      trigger: true
+    - get: minimal-dockerfile
+      trigger: true
+  - task: build
+    file: ci/tasks/build-image/task.yml
+    privileged: true
+    input_mapping:
+      source: minimal-dockerfile
+    params:
+      DOCKERFILE: source/dockerfiles/minimal.Dockerfile
+  - put: minimal-image
+    params:
+      image: image/image.tar
+
+- name: build-go-image
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: minimal-image
+      trigger: true
+      passed: [build-minimal-image]
+    - get: go-dockerfile
+      trigger: true
+  - task: build
+    file: ci/tasks/build-image/task.yml
+    privileged: true
+    input_mapping:
+      source: go-dockerfile
+    params:
+      DOCKERFILE: source/dockerfiles/go.Dockerfile
+  - put: go-image
+    params:
+      image: image/image.tar
+
+- name: build-docker-image
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: minimal-image
+      trigger: true
+      passed: [build-minimal-image]
+    - get: docker-dockerfile
+      trigger: true
+  - task: build
+    file: ci/tasks/build-image/task.yml
+    privileged: true
+    input_mapping:
+      source: docker-dockerfile
+    params:
+      DOCKERFILE: source/dockerfiles/docker.Dockerfile
+  - put: docker-image
+    params:
+      image: image/image.tar
+
+- name: build-gcloud-image
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: minimal-image
+      trigger: true
+      passed: [build-minimal-image]
+    - get: gcloud-dockerfile
+      trigger: true
+  - task: build
+    file: ci/tasks/build-image/task.yml
+    privileged: true
+    input_mapping:
+      source: gcloud-dockerfile
+    params:
+      DOCKERFILE: source/dockerfiles/gcloud.Dockerfile
+  - put: gcloud-image
+    params:
+      image: image/image.tar

--- a/pipelines/interrupt-bot.yml
+++ b/pipelines/interrupt-bot.yml
@@ -1,0 +1,62 @@
+---
+resources:
+  - name: ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/cloudfoundry/buildpacks-ci
+      branch: master
+      paths:
+        - tasks/interrupt-bot/*
+        - util/*
+
+  - name: alpine
+    type: registry-image
+    icon: docker
+    source:
+      repository: alpine
+      tag: latest
+      username: ((dockerhub-account.username))
+      password: ((dockerhub-account.password))
+
+  - name: image
+    type: registry-image
+    icon: docker
+    source:
+      tag: latest
+      repository: gcr.io/cf-buildpacks/slack-delegate-bot
+      username: _json_key
+      password: ((cloud-runner-service-account-key))
+
+jobs:
+  - name: build-and-push
+    plan:
+      - in_parallel:
+          - get: ci
+            trigger: true
+          - get: alpine
+            trigger: true
+      - task: build
+        file: ci/tasks/build-image/task.yml
+        privileged: true
+        input_mapping:
+          source: ci
+        params:
+          CONTEXT: source/tasks/interrupt-bot/build
+      - put: image
+        params:
+          image: image/image.tar
+
+  - name: deploy
+    plan:
+      - in_parallel:
+          - get: ci
+          - get: image
+            passed: [ build-and-push ]
+            trigger: true
+      - task: deploy
+        file: ci/tasks/interrupt-bot/deploy/task.yml
+        params:
+          SLACK_TOKEN: ((interrupt-bot-slack-token))
+          PAIRIST_PASSWORD: ((pairist-account.password))
+          SERVICE_ACCOUNT_KEY: ((cloud-runner-service-account-key))

--- a/pipelines/slack-invitations.yml
+++ b/pipelines/slack-invitations.yml
@@ -1,0 +1,62 @@
+---
+resources:
+  - name: ci
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/cloudfoundry/buildpacks-ci
+      branch: master
+      paths:
+        - tasks/slack-invitations/*
+        - tasks/build-image/*
+        - util/*
+
+  - name: alpine
+    type: registry-image
+    icon: docker
+    source:
+      repository: alpine
+      tag: latest
+      username: ((dockerhub-account.username))
+      password: ((dockerhub-account.password))
+
+  - name: image
+    type: registry-image
+    icon: docker
+    source:
+      tag: latest
+      repository: gcr.io/cf-buildpacks/slack-invitations
+      username: _json_key
+      password: ((cloud-runner-service-account-key))
+
+jobs:
+  - name: build-and-push
+    plan:
+      - in_parallel:
+          - get: ci
+            trigger: true
+          - get: alpine
+            trigger: true
+      - task: build
+        file: ci/tasks/build-image/task.yml
+        privileged: true
+        input_mapping:
+          source: ci
+        params:
+          CONTEXT: source/tasks/slack-invitations/build
+      - put: image
+        params:
+          image: image/image.tar
+
+  - name: deploy
+    plan:
+      - in_parallel:
+          - get: ci
+          - get: image
+            passed: [ build-and-push ]
+            trigger: true
+      - task: deploy
+        file: ci/tasks/slack-invitations/deploy/task.yml
+        params:
+          SERVICE_ACCOUNT_KEY: ((cloud-runner-service-account-key))
+          INVITE_URL: ((slack-invite-url))

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -101,13 +101,6 @@ resource_types:
 resources: ############################################################################################################
 ## Git ##
 
-  - name: feature-eng-ci
-    type: git
-    #icon: github-circle
-    source:
-      uri: https://github.com/cloudfoundry/buildpacks-feature-eng-ci
-      branch: master
-
   - name: buildpack-develop
     type: git
     webhook_token: ob0aigh3
@@ -626,7 +619,6 @@ jobs: ##########################################################################
           params:
             action: claim
         - get: buildpacks-ci
-        - get: feature-eng-ci
         - get: env-repo
         - get: buildpack
           resource: buildpack-develop
@@ -637,9 +629,9 @@ jobs: ##########################################################################
           resource: buildpack-develop
         - get: cf-deployment
       - task: redeploy
-        file: feature-eng-ci/tasks/cf/redeploy/task.yml
+        file: buildpacks-ci/tasks/cf/redeploy/task.yml
         input_mapping:
-          ci: feature-eng-ci
+          ci: buildpacks-ci
           lock: environment
         params:
           SCALE_DIEGO_CELLS: true
@@ -652,9 +644,9 @@ jobs: ##########################################################################
       - do:
         - task: create-cf-space
           attempts: 5
-          file: feature-eng-ci/tasks/cf/create-space/task.yml
+          file: buildpacks-ci/tasks/cf/create-space/task.yml
           input_mapping:
-            ci: feature-eng-ci
+            ci: buildpacks-ci
             lock: environment
           params:
             DOMAIN: 'cf-app.com'
@@ -693,7 +685,6 @@ jobs: ##########################################################################
           params:
             action: claim
         - get: buildpacks-ci
-        - get: feature-eng-ci
         - get: env-repo
         - get: buildpack
           resource: buildpack-develop
@@ -702,9 +693,9 @@ jobs: ##########################################################################
           - specs-unit-develop
         - get: cf-deployment
       - task: redeploy
-        file: feature-eng-ci/tasks/cf/redeploy/task.yml
+        file: buildpacks-ci/tasks/cf/redeploy/task.yml
         input_mapping:
-          ci: feature-eng-ci
+          ci: buildpacks-ci
           lock: environment
         params:
 <% if buildpacks[language]['stacks'].include?('cflinuxfs4')%>
@@ -718,12 +709,12 @@ jobs: ##########################################################################
       - do:
         - task: create-cf-space
           attempts: 5
-          file: feature-eng-ci/tasks/cf/create-space/task.yml
+          file: buildpacks-ci/tasks/cf/create-space/task.yml
           params:
             DOMAIN: 'cf-app.com'
             ORG: pivotal
           input_mapping:
-            ci: feature-eng-ci
+            ci: buildpacks-ci
             lock: environment
 <% if buildpacks[language]['stacks'].include?('cflinuxfs4')%>
         - task: configure-test

--- a/tasks/build-image/task.yml
+++ b/tasks/build-image/task.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+inputs:
+- name: source
+
+outputs:
+- name: image
+
+params:
+  CONTEXT:
+  DOCKERFILE:
+
+run:
+  path: build

--- a/tasks/cf/create-space/task.sh
+++ b/tasks/cf/create-space/task.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+readonly LOCK_DIR="${PWD}/lock"
+readonly SPACE_DIR="${PWD}/space"
+
+#shellcheck source=../../../util/print.sh
+source "${PWD}/ci/util/print.sh"
+
+function main() {
+  util::print::title "[task] executing"
+
+  space::setup
+  cf::authenticate
+  cf::space::create
+}
+
+function space::setup() {
+  util::print::info "[task] * creating space login script"
+
+  cat <<LOGIN > "${SPACE_DIR}/login"
+#!/bin/bash
+set +x
+LOGIN
+  chmod 755 "${SPACE_DIR}/login"
+}
+
+function cf::authenticate() {
+  util::print::info "[task] * authenticating with CF environment"
+
+  local lock name target
+  lock="$(cat "${LOCK_DIR}/name")"
+  name="${lock//[[:digit:]]/}"
+  target="api.${name}.${DOMAIN}"
+
+  cf api "${target}" --skip-ssl-validation
+
+  echo "cf api \"${target}\" --skip-ssl-validation" >> "${SPACE_DIR}/login"
+
+  local password
+  eval "$(bbl print-env --metadata-file "lock/metadata")"
+  password="$(credhub get --name "/bosh-${name}/cf/cf_admin_password" --output-json | jq -r .value)"
+
+  cf auth admin "${password}"
+
+  echo "echo \"Logging in to ${target}\"" >> "${SPACE_DIR}/login"
+  echo "cf auth admin \"${password}\"" >> "${SPACE_DIR}/login"
+}
+
+function cf::space::create() {
+  util::print::info "[task] * creating CF space"
+
+  local space
+  space="$(openssl rand -base64 32 | base64 | head -c 8 | awk '{print tolower($0)}')"
+
+  cf create-org "${ORG}"
+  cf create-space "${space}" -o "${ORG}"
+
+  echo "echo \"Targetting ${ORG} org and ${space} space\"" >> "${SPACE_DIR}/login"
+  echo "cf target -o \"${ORG}\" -s \"${space}\"" >> "${SPACE_DIR}/login"
+
+  echo "${space}" > "${SPACE_DIR}/name"
+  echo "export SPACE=${space}" > "${SPACE_DIR}/variables"
+}
+
+main "${@}"

--- a/tasks/cf/create-space/task.yml
+++ b/tasks/cf/create-space/task.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cfbuildpacks/ci
+    tag: latest
+
+inputs:
+- name: ci
+- name: lock
+
+outputs:
+- name: space
+
+run:
+  path: ci/tasks/cf/create-space/task.sh
+
+params:
+  DOMAIN:
+  ORG:

--- a/tasks/cf/redeploy/operations/scale-api-and-diego-cells.yml
+++ b/tasks/cf/redeploy/operations/scale-api-and-diego-cells.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=api/instances
+  value: 3
+
+- type: replace
+  path: /instance_groups/name=diego-cell/instances
+  value: 3

--- a/tasks/cf/redeploy/task.sh
+++ b/tasks/cf/redeploy/task.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+TASKDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly TASKDIR
+TMPDIR=$(mktemp -d)
+
+#shellcheck source=../../../util/print.sh
+source "${PWD}/ci/util/print.sh"
+
+function main() {
+  util::print::title "[task] executing"
+
+  cfd::checkout
+  director::login
+  stemcell::windows::upload
+  releases::windows::upload
+  cf::deploy
+}
+
+function cfd::checkout() {
+  local version
+  version="$(jq -r '.["cf-deployment_version"]' < "${PWD}/lock/metadata")"
+  echo "Toolsmith env is on cf-deployment version ${version}"
+
+	pushd "${PWD}/cf-deployment" > /dev/null
+		echo "Checking out cf-deployment version ${version}"
+		git checkout "${version}"
+	popd > /dev/null
+}
+
+function director::login() {
+	util::print::info "[task] * logging into bosh director"
+
+	eval "$(bbl print-env --metadata-file "${PWD}/lock/metadata")"
+}
+
+function stemcell::windows::upload() {
+  if [[ -z "${DEPLOY_WINDOWS_CELL}" ]]; then
+    return
+  fi
+
+	util::print::info "[task] * uploading windows stemcell"
+	bosh upload-stemcell https://bosh.io/d/stemcells/bosh-google-kvm-windows2019-go_agent
+}
+
+function releases::windows::upload() {
+  if [[ -z "${DEPLOY_WINDOWS_CELL}" ]]; then
+    return
+  fi
+
+	util::print::info "[task] * uploading uncompiled releases for windows vms"
+	grep url "${PWD}/cf-deployment/operations/experimental/use-compiled-releases-windows.yml" \
+    | xargs -I{} echo {} \
+    | cut -d" " -f2 \
+    | xargs -I{} bosh upload-release {} --fix
+}
+
+function cf::deploy() {
+	util::print::info "[task] * deploying"
+
+	local name
+	name="$(cat "${PWD}/lock/name")"
+
+	pushd "${PWD}/cf-deployment" > /dev/null
+    local operations arguments
+    operations=(
+      "${PWD}/operations/experimental/fast-deploy-with-downtime-and-danger.yml" \
+      "${PWD}/operations/use-compiled-releases.yml" \
+      "${PWD}/operations/scale-to-one-az.yml" \
+      "${PWD}/operations/disable-dynamic-asgs.yml" \
+    )
+
+    if [[ -n "${ADD_CFLINUXFS4_STACK}" ]]; then
+      operations+=(
+        "${PWD}/operations/experimental/add-cflinuxfs4.yml"
+      )
+      util::print::info "[task] * added cflinuxfs4 opsfiles to deploy command"
+    fi
+
+    if [[ -n "${DEPLOY_WINDOWS_CELL}" ]]; then
+      operations+=(
+        "${PWD}/operations/windows2019-cell.yml" \
+        "${PWD}/operations/use-latest-windows2019-stemcell.yml" \
+        "${PWD}/operations/use-online-windows2019fs.yml" \
+        "${PWD}/operations/experimental/use-compiled-releases-windows.yml"
+      )
+    fi
+
+    if [[ -n "${SCALE_DIEGO_CELLS}" ]]; then
+      operations+=(
+        "${TASKDIR}/operations/scale-api-and-diego-cells.yml"
+      )
+    fi
+
+    arguments=()
+    for operation in "${operations[@]}"; do
+      arguments+=(-o "${operation}")
+    done
+
+    util::print::info "[task] * starting deploy command"
+		bosh -n -d cf deploy "${PWD}/cf-deployment.yml" \
+			-v system_domain="${name}.cf-app.com" \
+      "${arguments[@]}"
+    util::print::info "[task] * deploy successful"
+	popd > /dev/null
+}
+
+main "${@}"

--- a/tasks/cf/redeploy/task.yml
+++ b/tasks/cf/redeploy/task.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cfbuildpacks/ci
+    tag: latest
+
+inputs:
+  - name: ci
+  - name: cf-deployment
+  - name: lock
+
+run:
+  path: ci/tasks/cf/redeploy/task.sh
+
+params:
+  DEPLOY_WINDOWS_CELL:
+  SCALE_DIEGO_CELLS:
+  ADD_CFLINUXFS4_STACK:

--- a/tasks/interrupt-bot/build/Dockerfile
+++ b/tasks/interrupt-bot/build/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:latest
+
+RUN apk add --no-progress --no-cache \
+  tzdata \
+  curl \
+  zip
+
+ARG DELEGATEBOT_VERSION=0.11.0
+RUN curl \
+  https://github.com/dpb587/slack-delegate-bot/releases/download/v$DELEGATEBOT_VERSION/slack-delegate-bot-linux.zip \
+    --silent \
+    --location \
+    --output /tmp/delegatebot.zip \
+  && unzip /tmp/delegatebot.zip slack-delegate-bot \
+  && mv slack-delegate-bot /bin/delegatebot \
+  && chmod +x /bin/delegatebot \
+  && rm /tmp/delegatebot.zip
+
+COPY config.yml /etc/config.yml
+
+CMD delegatebot --config /etc/config.yml run

--- a/tasks/interrupt-bot/build/config.yml
+++ b/tasks/interrupt-bot/build/config.yml
@@ -1,0 +1,40 @@
+---
+delegatebot:
+  watch:
+  - target: { channel: &buildpacks CULAS8ACD }
+  - target: { channel: &dotnet-core CUD6SEE7L }
+  - target: { channel: &go CUEGB5FD1 }
+  - target: { channel: &httpd CURGW4XNY }
+  - target: { channel: &nginx CUFT85E9X }
+  - target: { channel: &nodejs CUD6R3CPL }
+  - target: { channel: &php CUD6TBJAE }
+  - target: { channel: &python CUD6UTCJW }
+  - target: { channel: &r-language CUD6ZGUMQ }
+  - target: { channel: &ruby CURGNPSTE }
+  - target: { channel: &core-dev C011S6EL49L }
+
+  delegate:
+    if:
+      when:
+      - hours: { tz: America/New_York, start: 09:00, end: 17:00 }
+      - day: { tz: America/New_York, days: [ Mon, Tue, Wed, Thu, Fri ] }
+
+      then:
+        literalmap:
+          from:
+            pairist:
+              team: cfbuildpacks
+              role: Interrupt
+              password: $PAIRIST_PASSWORD
+
+          users:
+            Arjun: UBP6RMANS
+            Forest: UUA8LQ3QR
+            Frankie: U018JRSUMR7
+            Josh: UV777N3J8
+            Ryan: UU7GFH87L
+            Sophie: U0148H0EUTH
+            Tim: UULCH0VUM
+
+  options:
+    empty_message: "Sorry, no interrupt is available right now. Perhaps try again later if you don't get a response sooner."

--- a/tasks/interrupt-bot/deploy/task.sh
+++ b/tasks/interrupt-bot/deploy/task.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+#shellcheck source=../../../util/print.sh
+source "${PWD}/ci/util/print.sh"
+
+function main() {
+  util::print::title "[task] executing"
+
+  gcloud::authenticate
+  gcloud::run::deploy
+}
+
+function gcloud::authenticate() {
+  util::print::info "[task] * authenticating with gcp"
+
+  gcloud auth activate-service-account \
+    --key-file <(echo "${SERVICE_ACCOUNT_KEY}")
+}
+
+function gcloud::run::deploy() {
+  util::print::info "[task] * deploying interrupt-bot"
+
+  local project
+  project="$(echo "${SERVICE_ACCOUNT_KEY}" | jq -r .project_id)"
+
+  gcloud run deploy interrupt-bot \
+    --image gcr.io/cf-buildpacks/slack-delegate-bot:latest \
+    --max-instances 1 \
+    --memory "128Mi" \
+    --platform managed \
+    --set-env-vars "SLACK_TOKEN=${SLACK_TOKEN},PAIRIST_PASSWORD=${PAIRIST_PASSWORD}" \
+    --allow-unauthenticated \
+    --project "${project}" \
+    --region us-central1
+}
+
+main "${@}"

--- a/tasks/interrupt-bot/deploy/task.yml
+++ b/tasks/interrupt-bot/deploy/task.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: gcloud
+
+inputs:
+- name: ci
+
+params:
+  SLACK_TOKEN:
+  PAIRIST_PASSWORD:
+  SERVICE_ACCOUNT_KEY:
+
+run:
+  path: ci/tasks/interrupt-bot/deploy/task.sh

--- a/tasks/slack-invitations/build/Dockerfile
+++ b/tasks/slack-invitations/build/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:latest
+
+RUN apk add --no-progress --no-cache curl
+
+ARG GO_VERSION=1.14
+RUN curl \
+  https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz \
+    --silent \
+    --location \
+    --output /tmp/go$GO_VERSION.linux-amd64.tar.gz \
+  && tar -C /usr/local -xzf /tmp/go$GO_VERSION.linux-amd64.tar.gz \
+  && rm /tmp/go$GO_VERSION.linux-amd64.tar.gz \
+  && mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+ENV PATH=$PATH:/usr/local/go/bin
+
+COPY * /tmp/
+
+RUN go build -o /usr/local/bin/slack-invitations /tmp/main.go
+
+CMD slack-invitations

--- a/tasks/slack-invitations/build/go.mod
+++ b/tasks/slack-invitations/build/go.mod
@@ -1,0 +1,3 @@
+module slack-invitations
+
+go 1.13

--- a/tasks/slack-invitations/build/main.go
+++ b/tasks/slack-invitations/build/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			http.Redirect(w, req, os.Getenv("INVITE_URL"), http.StatusTemporaryRedirect)
+		}),
+	}
+
+	log.Fatal(server.ListenAndServe())
+}

--- a/tasks/slack-invitations/deploy/task.sh
+++ b/tasks/slack-invitations/deploy/task.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+#shellcheck source=../../../util/print.sh
+source "${PWD}/ci/util/print.sh"
+
+function main() {
+  util::print::title "[task] executing"
+
+  gcloud::authenticate
+  gcloud::project::configure
+  gcloud::run::deploy
+}
+
+function gcloud::authenticate() {
+  util::print::info "[task] * authenticating with gcp"
+
+  gcloud auth activate-service-account \
+    --key-file <(echo "${SERVICE_ACCOUNT_KEY}")
+}
+
+function gcloud::project::configure() {
+  util::print::info "[task] * configuring project"
+
+  local project
+  project="$(echo "${SERVICE_ACCOUNT_KEY}" | jq -r .project_id)"
+  gcloud config set project "${project}"
+}
+
+function gcloud::run::deploy() {
+  util::print::info "[task] * deploying slack-invitations"
+
+  gcloud run deploy "slack-invitations" \
+    --image gcr.io/cf-buildpacks/slack-invitations:latest \
+    --max-instances 1 \
+    --memory "128Mi" \
+    --platform managed \
+    --set-env-vars "INVITE_URL=${INVITE_URL}" \
+    --allow-unauthenticated \
+    --region us-central1
+}
+
+main "${@}"

--- a/tasks/slack-invitations/deploy/task.yml
+++ b/tasks/slack-invitations/deploy/task.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cfbuildpacks/feature-eng-ci
+    tag: gcloud
+
+inputs:
+- name: ci
+
+params:
+  INVITE_URL:
+  SERVICE_ACCOUNT_KEY:
+  DOMAIN: slack.paketo.io
+
+run:
+  path: ci/tasks/slack-invitations/deploy/task.sh

--- a/util/docker.sh
+++ b/util/docker.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+# shellcheck source=./print.sh
+source "$(dirname "${BASH_SOURCE[0]}")/print.sh"
+
+readonly LOG_FILE="${LOG_FILE:-/tmp/docker.log}"
+readonly SKIP_PRIVILEGED="${SKIP_PRIVILEGED:-false}"
+readonly PID_FILE=/tmp/docker.pid
+readonly SCRATCH_DIR=/scratch/docker
+
+function util::docker::start() {
+  util::print::title "[docker] boot sequence"
+
+  if docker info >/dev/null 2>&1; then
+    util::print::warn "[docker] daemon already running"
+    return
+  fi
+
+  util::docker::privileges::elevate
+  util::docker::scratch::allocate
+  util::docker::daemon::start
+}
+
+function util::docker::stop() {
+  util::print::title "[docker] shutdown sequence"
+
+  util::docker::daemon::stop
+  util::docker::scratch::deallocate
+}
+
+function util::docker::privileges::elevate() {
+  if [[ "${SKIP_PRIVILEGED}" != "false" ]]; then
+    return
+  fi
+
+  util::print::info "[docker] * elevating privileges"
+  util::docker::cgroups::sanitize
+
+  # check for /proc/sys being mounted readonly, as systemd does
+  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+    mount -o remount,rw /proc/sys
+  fi
+}
+
+function util::docker::cgroups::sanitize() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  # shellcheck disable=SC2162,SC2034
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    # shellcheck disable=SC2002
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd; then
+    mkdir -p /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+  fi
+}
+
+function util::docker::devicecontrol::permit() {
+  local devices_mount_info
+  devices_mount_info="$(grep devices < /proc/self/cgroup)"
+
+  if [ -z "$devices_mount_info" ]; then
+    # cgroups not set up; must not be in a container
+    return
+  fi
+
+  local devices_subsystems
+  devices_subsystems="$(echo "$devices_mount_info" | cut -d: -f2)"
+
+  local devices_subdir
+  devices_subdir="$(echo "$devices_mount_info" | cut -d: -f3)"
+
+  if [ "$devices_subdir" = "/" ]; then
+    # we're in the root devices cgroup; must not be in a container
+    return
+  fi
+
+  cgroup_dir=/tmp/devices-cgroup
+
+  if [ ! -e ${cgroup_dir} ]; then
+    # mount our container's devices subsystem somewhere
+    mkdir ${cgroup_dir}
+  fi
+
+  if ! mountpoint -q ${cgroup_dir}; then
+    if ! mount -t cgroup -o "$devices_subsystems" none ${cgroup_dir}; then
+      return 1
+    fi
+  fi
+
+  # permit our cgroup to do everything with all devices
+  # ignore failure in case something has already done this; echo appears to
+  # return EINVAL, possibly because devices this affects are already in use
+  echo a > "${cgroup_dir}${devices_subdir}/devices.allow" || true
+}
+
+function util::docker::scratch::allocate() {
+  util::print::info "[docker] * allocating scratch disk"
+
+  mkdir -p "${SCRATCH_DIR}"
+
+  if command -v mkfs.btrfs > /dev/null; then
+    util::docker::devicecontrol::permit
+
+    local loopdevice dockerroot
+    rand="${RANDOM}"
+    loopdevice="/dev/loop${rand}"
+    dockerroot="/tmp/docker-root-${rand}"
+
+    if [[ ! -e "${loopdevice}" ]]; then
+      util::print::info "[docker]   * creating 20GB scratch file"
+
+      dd if=/dev/zero of="${dockerroot}" bs=1024 count=20971520 > /dev/null 2>&1
+
+      util::print::info "[docker]   * creating block device"
+      mknod "${loopdevice}" b 7 "${rand}"
+      losetup "${loopdevice}" "${dockerroot}"
+    fi
+
+    util::print::info "[docker]   * creating btrfs filesystem"
+    mkfs.btrfs "${dockerroot}" > /dev/null
+
+    util::print::info "[docker]   * mounting filesystem"
+    mount "${dockerroot}" "${SCRATCH_DIR}"
+
+    mkdir -p /etc/docker
+    echo '{ "storage-driver": "btrfs" }' > /etc/docker/daemon.json
+  fi
+}
+
+function util::docker::scratch::deallocate() {
+  util::print::info "[docker] * deallocating scratch disk"
+
+  util::print::info "[docker]   * unmounting filesystem"
+  while [[ "$(grep "${SCRATCH_DIR}" < /proc/mounts)" != "" ]]; do
+    if ! umount -A "${SCRATCH_DIR}" > /dev/null 2>&1; then
+      sleep 1
+    fi
+  done
+
+  util::print::info "[docker]   * removing block device"
+  shopt -s nullglob
+    local path
+    for device in /dev/loop*; do
+      path="$(echo "${device}" | grep "loop[[:digit:]]" || true)"
+      if [[ "${path}" != "" && -e "${path}" ]]; then
+        rm "${path}"
+      fi
+    done
+  shopt -u nullglob
+
+  util::print::info "[docker]   * deleting 20GB scratch file"
+  find /tmp -type f -name 'docker-root-*' -delete
+}
+
+function util::docker::daemon::start() {
+  util::print::printf "[docker] * starting daemon "
+
+  local mtu
+  mtu="$(cat "/sys/class/net/$(ip route get 8.8.8.8 | awk '{ print $5 }')/mtu")"
+
+  dockerd \
+    --data-root "${SCRATCH_DIR}" \
+    --mtu "${mtu}" \
+    > "$LOG_FILE" \
+    2>&1 \
+    &
+  echo "${!}" > "${PID_FILE}"
+
+  until docker info >/dev/null 2>&1; do
+    util::print::printf "*"
+    sleep 1
+  done
+
+  util::print::info " done"
+}
+
+function util::docker::daemon::stop() {
+  if [[ -e "${PID_FILE}" ]]; then
+    util::print::info "[docker] * stopping daemon"
+
+    kill "$(cat "${PID_FILE}")"
+  fi
+}

--- a/util/print.sh
+++ b/util/print.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+function util::print::title() {
+  local blue reset message
+  blue="\033[0;34m"
+  reset="\033[0;39m"
+  message="${1}"
+
+  echo -e "\n${blue}${message}${reset}" >&2
+}
+
+function util::print::info() {
+  local message
+  message="${1}"
+
+  echo -e "${message}" >&2
+}
+
+function util::print::error() {
+  local message red reset
+  message="${1}"
+  red="\033[0;31m"
+  reset="\033[0;39m"
+
+  echo -e "${red}${message}${reset}" >&2
+  exit 1
+}
+
+function util::print::success() {
+  local message green reset
+  message="${1}"
+  green="\033[0;32m"
+  reset="\033[0;39m"
+
+  echo -e "${green}${message}${reset}" >&2
+  exit 0
+}
+
+function util::print::warn() {
+  local message yellow reset
+  message="${1}"
+  yellow="\033[0;33m"
+  reset="\033[0;39m"
+
+  echo -e "${yellow}${message}${reset}" >&2
+  exit 0
+}
+
+function util::print::printf() {
+  local message
+  message="${1}"
+
+  printf "%s" "${message}"
+}


### PR DESCRIPTION
This PR migrates the CI from https://github.com/cloudfoundry/buildpacks-feature-eng-ci to this repo.

Once this PR is merged, we should re-run `./bin/update-pipelines` and merge [the PR that deprecates `buildpacks-feature-eng-ci`](https://github.com/cloudfoundry/buildpacks-feature-eng-ci/pull/10).

Some things to note:

* Some of the dockerfiles and pipelines to build docker images were not copied over, as they weren't being used
* The `cfbuildpacks/feature-eng-ci` docker images continue to be be hosted at that name. We can refactor this later.
* there are now two scripts to update pipelines - `./bin/update-pipelines` (the existing ruby script) and `./bin/update-pipelines.sh` (the script from feature-eng CI). This is confusing, and we should fix it, but for now I wanted to prioritize deprecating the feature-eng repo before refactoring this repo.