### PR TITLE
Migrate core-deps CI back into this repo.

### DIFF
--- a/bin/update-pipelines-main-team
+++ b/bin/update-pipelines-main-team
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && cd .. && pwd)"
+target="buildpacks"
+filter=
+
+login() {
+  fly -t "$target" login -n main -b
+}
+
+check_login_status() {
+  current_team="$(yq r ~/.flyrc targets.buildpacks.team)"
+  if [[ "${current_team}" != "main" ]]; then
+    login
+  fi
+
+  fly -t "$target" status >/dev/null 2>&1 || login
+}
+
+set_pipelines() {
+  for pipeline_dir in "$REPO_ROOT"/pipelines/*; do
+    pipeline_name="$(basename "${pipeline_dir%.yml}")"
+    if [[ $filter != "" ]] && [[ ! $pipeline_name =~ $filter ]]; then
+      continue
+    fi
+
+    echo "Setting $pipeline_name"
+    pipeline_config="$(ytt -f "$pipeline_dir")"
+    fly -t "$target" set-pipeline -p "$pipeline_name" -c <(echo "$pipeline_config")
+  done
+}
+
+main() {
+  if [ "$#" -eq 1 ]; then
+    filter="$1"
+  fi
+
+  check_login_status
+  set_pipelines
+}
+
+main "$@"

--- a/dockerfiles/core-deps-ci.Dockerfile
+++ b/dockerfiles/core-deps-ci.Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:bionic
+
+ENV LANG="C.UTF-8"
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG GO_VERSION=1.19.3
+ARG GO_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
+ARG BOSH_VERSION=7.1.3
+ARG BBL_VERSION=8.4.111
+ARG CREDHUB_VERSION=2.9.10
+ARG OM_VERSION=7.1.1
+ARG PACK_VERSION=0.24.0
+
+RUN apt-get -qqy update \
+  && apt-get -qqy install \
+    build-essential \
+    curl
+
+RUN curl -sL "https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key" | apt-key add - \
+  && echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+
+RUN apt-get -qqy update \
+  && apt-get -qqy install \
+    cf8-cli \
+    git \
+    jq \
+    unzip \
+    vim \
+    zip
+
+RUN git config --global user.email "buildpacks-releng@pivotal.io"
+RUN git config --global user.name "Buildpacks Releng CI"
+
+RUN curl -sL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz \
+  && [ ${GO_SHA256} = $(shasum -a 256 /tmp/go.tar.gz | cut -d' ' -f1) ] \
+  && tar -C /usr/local -xf /tmp/go.tar.gz \
+  && rm /tmp/go.tar.gz
+
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
+  && chmod +x /usr/local/bin/yj
+
+RUN curl -sL -o /usr/local/bin/fly "https://buildpacks.ci.cf-app.com/api/v1/cli?arch=amd64&platform=linux" \
+  && chmod +x /usr/local/bin/fly
+
+RUN curl -sL -o /usr/local/bin/bosh https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_VERSION}/bosh-cli-${BOSH_VERSION}-linux-amd64 \
+  && chmod +x /usr/local/bin/bosh
+
+RUN curl -sL -o /usr/local/bin/bbl https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${BBL_VERSION}/bbl-v${BBL_VERSION}_linux_x86-64 \
+  && chmod +x /usr/local/bin/bbl
+
+RUN curl -sL https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_VERSION}/credhub-linux-${CREDHUB_VERSION}.tgz \
+  | tar -C /usr/local/bin -xz
+
+RUN curl -sL -o /usr/local/bin/om https://github.com/pivotal-cf/om/releases/download/${OM_VERSION}/om-linux-${OM_VERSION} \
+  && chmod +x /usr/local/bin/om
+
+RUN curl -sL https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz \
+  | tar -C /usr/local/bin -xz
+
+RUN curl -sSL https://get.docker.com/ | sh
+
+RUN curl -s https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip \
+  && unzip -d /tmp /tmp/awscliv2.zip \
+  && /tmp/aws/install \
+  && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# Create testuser
+RUN mkdir -p /home/testuser && \
+  groupadd -r testuser -g 433 && \
+  useradd -u 431 -r -g testuser -d /home/testuser -s /usr/sbin/nologin -c "Docker image test user" testuser
+
+RUN apt-get -qqy clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -1,0 +1,48 @@
+#@data/values
+---
+#@ default_stacks = ['cflinuxfs3']
+
+supported_languages:
+- name: binary
+  stacks: #@ default_stacks + ["cflinuxfs4", "windows2016", "windows"]
+- name: dotnet-core
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: go
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: java
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: nginx
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: nodejs
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: php
+  stacks: #@ default_stacks + ["cflinuxfs4"] 
+- name: python
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: r
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: ruby
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: staticfile
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+supported_languages_without_java:
+- name: binary
+  stacks: #@ default_stacks + ["cflinuxfs4", "windows2016", "windows"]
+- name: dotnet-core
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: go
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: nginx
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: nodejs
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: php
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: python
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: r
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: ruby
+  stacks: #@ default_stacks + ["cflinuxfs4"]
+- name: staticfile
+  stacks: #@ default_stacks + ["cflinuxfs4"]

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -1,0 +1,431 @@
+#@ load("@ytt:data", "data")
+#@yaml/text-templated-strings
+
+---
+resource_types:
+- name: pivnet
+  type: docker-image
+  source:
+    repository: pivotalcf/pivnet-resource
+    tag: latest-final
+
+- name: toolsmiths-envs
+  type: docker-image
+  source:
+    repository: cftoolsmiths/toolsmiths-envs-resource
+
+
+resources:
+- name: core-deps-ci
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/core-deps-ci.git
+    private_key: ((core-deps-ci-deploy-key.private_key))
+
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks
+
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    branch: main
+
+- name: cf-acceptance-tests
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests
+    branch: main
+
+- name: cf-deployment-env
+  type: toolsmiths-envs
+  source:
+    api_token: ((toolsmiths-api-token))
+    hostname: environments.toolsmiths.cf-app.com
+    pool_name: cf-deployment
+
+- name: java-pivnet-production
+  type: pivnet
+  source:
+    api_token: ((pivnet-refresh-token))
+    product_slug: java-buildpack
+
+#@ for language in data.values.supported_languages_without_java:
+  #@ for stack in language.stacks:
+- name: #@ language.name + "-buildpack-"+ stack
+  type: s3
+  source:
+    bucket: buildpack-release-candidates
+    regexp: #@  "{}/{}_buildpack-{}-v(.*).zip".format(language.name, language.name, stack)
+    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+  #@ end
+#@ end
+
+#@ for language in data.values.supported_languages:
+- name: #@ language.name + "-buildpack-release"
+  type: git
+  source:
+    uri: #@ "git@github.com:cloudfoundry/" + language.name + "-buildpack-release.git"
+    private_key: #@ "((" + language.name + "-buildpack-release-deploy-key.private_key))"
+    branch: master
+
+- name: #@ language.name + "-buildpack-release-github-release"
+  type: github-release
+  source:
+    user: cloudfoundry
+    repository: #@ language.name + "-buildpack-release"
+    access_token: ((buildpacks-github-token))
+
+- name: #@ language.name + "-buildpack-release-rc"
+  type: s3
+  source:
+    bucket: buildpack-release-rcs
+    regexp: #@  "{}/{}-buildpack-release-(.*).tgz".format(language.name, language.name)
+    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+
+- name: #@ language.name + "-buildpack-release-trigger"
+  type: s3
+  source:
+    bucket: buildpack-release-triggers
+    versioned_file: #@ language.name + "-buildpack"
+    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+#@ end
+
+- name: weekday-mornings
+  type: time
+  source:
+    start: 3AM
+    stop: 4AM
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    location: America/New_York
+
+- name: shared-buildpack-release-trigger
+  type: s3
+  source:
+    bucket: shared-buildpack-release-triggers
+    versioned_file: non-java
+    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+
+- name: shared-java-buildpack-release-trigger
+  type: s3
+  source:
+    bucket: shared-buildpack-release-triggers
+    versioned_file: java
+    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+
+
+jobs:
+- name: claim-cf-deployment-env
+  public: true
+  serial: true
+  plan:
+  - get: weekday-mornings
+    trigger: true
+  - put: cf-deployment-env
+    params:
+      action: claim
+
+#@ for language in data.values.supported_languages:
+- name: #@ "create-" + language.name + "-buildpack-dev-release"
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: core-deps-ci
+    - get: cf-deployment-env
+      trigger: true
+      passed: [claim-cf-deployment-env]
+    - get: release
+      resource: #@ language.name + "-buildpack-release"
+  #@ if language.name == "java":
+    - get: buildpack-stack0
+      resource: java-pivnet-production
+      params:
+        globs:
+        - java-buildpack-v*.zip
+  #@ else:
+    #@ for stack in language.stacks:
+    - get: #@ "buildpack-stack" + str(language.stacks.index(stack))
+      resource: #@ language.name + "-buildpack-" + stack
+    #@ end
+  #@ end
+  - task: create-buildpack-dev-release
+    file: core-deps-ci/tasks/cf-release/create-buildpack-dev-release/task.yml
+    params:
+      AWS_ACCESS_KEY_ID: ((pivotal-buildpacks-s3-access-key))
+      AWS_SECRET_ACCESS_KEY: ((pivotal-buildpacks-s3-secret-key))
+  - put: #@ language.name + "-buildpack-release"
+    params:
+      repository: release
+      rebase: true
+  - put: #@ language.name + "-buildpack-release-rc"
+    params:
+      file: release-tarball/*
+#@ end
+
+- name: deploy
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: core-deps-ci
+    - get: cf-deployment-concourse-tasks
+    - get: cf-deployment
+    - get: cf-deployment-env
+      trigger: true
+      passed:
+#@ for language in data.values.supported_languages:
+      - #@ "create-" + language.name + "-buildpack-dev-release"
+#@ end
+#@ for language in data.values.supported_languages:
+    - get: #@ language.name + "-buildpack-release-rc"
+      passed:
+      - #@ "create-" + language.name + "-buildpack-dev-release"
+#@ end
+  - in_parallel:
+#@ for language in data.values.supported_languages:
+    - task: #@ "create-" + language.name + "-buildpack-release-ops-file"
+      file: core-deps-ci/tasks/cf-release/create-buildpack-release-ops-file/task.yml
+      input_mapping:
+        buildpack-release-tarball: #@ language.name + "-buildpack-release-rc"
+      output_mapping:
+        ops-file: #@ language.name + "-buildpack-ops-file"
+    - task: #@ "upload-" + language.name + "-buildpack-release"
+      file: core-deps-ci/tasks/cf-release/upload-bosh-release/task.yml
+      input_mapping:
+        release-tarball: #@ language.name + "-buildpack-release-rc"
+        toolsmiths-env: cf-deployment-env
+#@ end
+  - task: checkout-same-cf-deployment-as-env
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: coredeps/core-deps-ci
+      inputs:
+      - name: cf-deployment
+      - name: cf-deployment-env
+      outputs:
+      - name: cf-deployment
+      run:
+        dir: ""
+        path: bash
+        args:
+        - -c
+        - |
+          #!/bin/bash
+          version="$(jq -r '.["cf-deployment_version"]' < cf-deployment-env/metadata)"
+          echo "Toolsmith env is on cf-deployment version ${version}"
+          pushd cf-deployment
+            echo "Checking out cf-deployment version ${version}"
+            git checkout "${version}"
+          popd
+  - task: get-cf-deployment-ops-files
+    file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+    input_mapping:
+      base-ops-files: cf-deployment
+      new-ops-files: cf-deployment
+    params:
+      BASE_OPS_FILE_DIR: operations
+#@ for language in data.values.supported_languages:
+  - task: #@ "add-" + language.name + "-buildpack-release-ops-file"
+    file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+    input_mapping:
+      base-ops-files: collected-ops-files
+      new-ops-files: #@ language.name + "-buildpack-ops-file"
+    params:
+      BASE_OPS_FILE_DIR: operations
+      NEW_OPS_FILES: #@ "bump-" + language.name + "-buildpack.yml"
+#@ end
+#@ buildpack_ops_file_paths = []
+#@ for language in data.values.supported_languages:
+#@   buildpack_ops_file_paths.append("operations/bump-" + language.name + "-buildpack.yml")
+#@ end
+  - task: bosh-deploy
+    file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
+    input_mapping:
+      toolsmiths-env: cf-deployment-env
+      ops-files: collected-ops-files
+    params:
+      OPS_FILES: |
+        operations/experimental/fast-deploy-with-downtime-and-danger.yml
+        operations/use-compiled-releases.yml
+        operations/scale-to-one-az.yml
+        operations/test/scale-to-one-az-addon-parallel-cats.yml
+        (@= "\n".join(buildpack_ops_file_paths) @)
+  - task: open-asgs-for-credhub
+    file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+    attempts: 10
+    input_mapping:
+      toolsmiths-env: cf-deployment-env
+    params:
+      INSTANCE_GROUP_NAME: credhub
+      SECURITY_GROUP_NAME: credhub
+  - task: open-asgs-for-uaa
+    file: cf-deployment-concourse-tasks/open-asgs-for-bosh-instance-group/task.yml
+    input_mapping:
+      toolsmiths-env: cf-deployment-env
+    params:
+      INSTANCE_GROUP_NAME: uaa
+      SECURITY_GROUP_NAME: uaa
+  - task: enable-docker-and-tasks
+    file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
+    input_mapping:
+      toolsmiths-env: cf-deployment-env
+    params:
+      ENABLED_FEATURE_FLAGS: |
+        diego_docker
+        task_creation
+        service_instance_sharing
+
+- name: cats
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: core-deps-ci
+    - get: cf-deployment-concourse-tasks
+    - get: cf-acceptance-tests
+    - get: cf-deployment-env
+      passed: [deploy]
+      trigger: true
+#@ for language in data.values.supported_languages:
+    - get: #@ language.name + "-buildpack-release-rc"
+      passed: [deploy]
+#@ end
+  - task: create-cats-integration-config
+    file: core-deps-ci/tasks/cf-release/create-cats-integration-config/task.yml
+    input_mapping:
+      toolsmiths-env: cf-deployment-env
+  - task: run-cats
+    file: cf-deployment-concourse-tasks/run-cats/task.yml
+    attempts: 3
+    input_mapping:
+      integration-config: cats-integration-config
+      toolsmiths-env: cf-deployment-env
+    params:
+      CONFIG_FILE_PATH: integration-config.json
+
+- name: unclaim-cf-deployment-env
+  public: true
+  serial: true
+  plan:
+  - get: cf-deployment-env
+    passed: [cats]
+    trigger: true
+  - put: cf-deployment-env
+    params:
+      action: unclaim
+      env_file: cf-deployment-env/metadata
+
+- name: ship-it
+  public: true
+  serial: true
+  plan:
+  - get: core-deps-ci
+  - task: write-buildpack-release-trigger-file
+    file: core-deps-ci/tasks/cf-release/write-buildpack-release-trigger-file/task.yml
+  - put: shared-buildpack-release-trigger
+    params:
+      file: buildpack-release-trigger-file/file
+
+- name: ship-it-java
+  public: true
+  serial: true
+  plan:
+  - get: core-deps-ci
+  - task: write-buildpack-release-trigger-file
+    file: core-deps-ci/tasks/cf-release/write-buildpack-release-trigger-file/task.yml
+  - put: shared-java-buildpack-release-trigger
+    params:
+      file: buildpack-release-trigger-file/file
+
+#@ for language in data.values.supported_languages:
+- name: #@ "update-" + language.name + "-buildpack-release-trigger"
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: core-deps-ci
+    - get: buildpack-release-tarball
+      resource: #@ language.name + "-buildpack-release-rc"
+      passed: [cats]
+    - get: buildpack-release-trigger
+      resource: #@ language.name + "-buildpack-release-trigger"
+  #@ if language.name == "java":
+    - get: shared-java-buildpack-release-trigger
+      trigger: true
+  #@ else:
+    - get: shared-buildpack-release-trigger
+      trigger: true
+  #@ end
+  - task: update-buildpack-release-trigger
+    file: core-deps-ci/tasks/cf-release/update-buildpack-release-trigger/task.yml
+    params:
+      AWS_ACCESS_KEY_ID: ((pivotal-offline-buildpacks-s3-access-key))
+      AWS_SECRET_ACCESS_KEY: ((pivotal-offline-buildpacks-s3-secret-key))
+      BUCKET: buildpack-release-triggers
+
+- name: #@ "publish-" + language.name + "-buildpack-release"
+  old_name: #@ "update-" + language.name + "-buildpack-bosh-release"
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: core-deps-ci
+    - get: release
+      resource: #@ language.name + "-buildpack-release"
+    - get: buildpack-release-tarball
+      resource: #@ language.name + "-buildpack-release-rc"
+      passed:
+      - #@ "update-" + language.name + "-buildpack-release-trigger"
+    - get: #@ language.name + "-buildpack-release-trigger"
+      trigger: true
+  - task: finalize-release
+    file: core-deps-ci/tasks/cf-release/finalize-buildpack-release/task.yml
+    params:
+      AWS_ACCESS_KEY_ID: ((pivotal-buildpacks-s3-access-key))
+      AWS_SECRET_ACCESS_KEY: ((pivotal-buildpacks-s3-secret-key))
+  - put: #@ language.name + "-buildpack-release"
+    params:
+      repository: release
+      rebase: true
+      tag: version/version
+  - put: #@ language.name + "-buildpack-release-github-release"
+    params:
+      name: version/version
+      tag: version/version
+#@ end
+
+
+groups:
+- name: test
+  jobs:
+  - claim-cf-deployment-env
+#@ for language in data.values.supported_languages:
+  - #@ "create-" + language.name + "-buildpack-dev-release"
+#@ end
+  - deploy
+  - cats
+  - unclaim-cf-deployment-env
+
+- name: ship-it
+  jobs:
+  - ship-it
+  - ship-it-java
+
+- name: publish
+  jobs:
+#@ for language in data.values.supported_languages:
+  - #@ "update-" + language.name + "-buildpack-release-trigger"
+  - #@ "publish-" + language.name + "-buildpack-release"
+#@ end

--- a/pipelines/cflinuxfs3.yml
+++ b/pipelines/cflinuxfs3.yml
@@ -1,0 +1,706 @@
+#@ buildpacks = ["binary", "dotnet-core", "go", "java", "nodejs", "php", "python", "ruby", "staticfile"]
+
+#@ def failure_alert():
+  put: failure-alert
+  params:
+    text: "$BUILD_PIPELINE_NAME $BUILD_JOB_NAME job on Concourse failed! \n Check: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+    channel: "#buildpacks-firehose"
+    username: concourse
+    icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+#@ end
+
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+- name: bosh-deployment
+  type: docker-image
+  source:
+    repository: cloudfoundry/bosh-deployment-resource
+
+resources:
+#@ for buildpack in buildpacks:
+- name: #@ buildpack + "-buildpack-release"
+  type: git
+  source:
+    branch: master
+    uri: #@ "https://github.com/cloudfoundry/{}-buildpack-release.git".format(buildpack)
+#@ end
+
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+    tag_filter: v8.*
+
+- name: cf-acceptance-tests
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
+    branch: main
+
+- name: cf-deployment-concourse-tasks-latest
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+
+- name: bbl-state
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/buildpacks-envs
+    branch: master
+    private_key: ((buildpacks-envs-deploy-key.private_key))
+
+- name: bosh-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/bosh-deployment.git
+    branch: master
+
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    tag: v21.11.0
+
+- name: buildpacks-ci
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+
+- name: cflinuxfs3
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs3.git
+    private_key: ((cflinuxfs3-deploy-key.private_key))
+
+- name: cflinuxfs3-github-tags
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs3.git
+    private_key: ((cflinuxfs3-deploy-key.private_key))
+    tag_filter: "*"
+
+- name: cflinuxfs3-build-trigger
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs3.git
+    private_key: ((cflinuxfs3-deploy-key.private_key))
+    ignore_paths:
+    - receipt.cflinuxfs3.x86_64
+    - receipt.cflinuxfs3m.x86_64
+    - cflinuxfs3/cnb
+    - README.md
+    - .gitignore
+
+- name: new-cves
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ new-cve-notifications/ubuntu18.04.yml ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
+
+- name: receipt-diff
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ receipt.cflinuxfs3.x86_64 ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    tag_filter: "newpackages_cflinuxfs3_*"
+
+- name: public-robots
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
+
+- name: cflinuxfs3-release
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs3-release.git
+    private_key: ((cflinuxfs3-release-deploy-key.private_key))
+
+- name: capi-release
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/capi-release
+    branch: main
+
+- name: stack-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/cflinuxfs3-(.*).tar.gz
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: receipt-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/receipt.cflinuxfs3.x86_64-(.*)
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: cflinuxfs3-cf-deployment
+  type: bosh-deployment
+  source:
+    deployment: cf
+    skip_check: true
+
+- name: cflinuxfs3-rootfs-smoke-test-deployment
+  type: bosh-deployment
+  source:
+    skip_check: true
+    deployment: rootfs-smoke-test
+
+- name: gcp-stemcell
+  type: bosh-io-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-jammy-go_agent
+
+- name: cflinuxfs3-image
+  type: docker-image
+  source:
+    repository: cloudfoundry/cflinuxfs3
+    username: ((cfbuildpacks-dockerhub-user.username))
+    password: ((cfbuildpacks-dockerhub-user.password))
+    email: cf-buildpacks-eng@pivotal.io
+
+- name: cflinuxfs3-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs3
+    access_token: ((buildpacks-github-token))
+
+- name: cflinuxfs3-release-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs3-release
+    access_token: ((buildpacks-github-token))
+
+- name: version
+  type: semver
+  source:
+    bucket: pivotal-buildpacks
+    key: versions/stack-cflinuxfs3
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: ((concourse-job-failure-notifications-slack-webhook))
+
+jobs:
+- name: build-rootfs
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+    - get: buildpacks-ci
+    - get: new-cves
+      trigger: true
+    - get: rootfs
+      resource: cflinuxfs3
+    - get: cflinuxfs3-build-trigger
+      trigger: true
+    - get: version
+      params: { pre: rc }
+    - get: public-robots
+  - do:
+    - task: make-rootfs
+      file: buildpacks-ci/tasks/make-rootfs/task.yml
+      privileged: true
+      params:
+        STACK: cflinuxfs3
+    - put: stack-s3
+      params:
+        file: rootfs-artifacts/cflinuxfs3-*.tar.gz
+    - put: receipt-s3
+      params:
+        file: receipt-artifacts/receipt.cflinuxfs3.x86_64-*
+    - task: generate-receipt-diff
+      file: buildpacks-ci/tasks/generate-rootfs-receipt-diff/task.yml
+      params:
+        STACK: cflinuxfs3
+    - put: public-robots
+      params:
+        repository: public-robots-artifacts
+        rebase: true
+        tag: git-tags/TAG
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
+
+- name: bbl-up
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+      passed: [ build-rootfs ]
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: bbl-config
+      resource: bbl-state
+    - get: bosh-deployment
+    - get: buildpacks-ci
+    - get: receipt-diff
+      trigger: true
+    - get: new-cves
+      passed: [ build-rootfs ]
+    - get: stack-s3
+      passed: [ build-rootfs ]
+    - get: version
+      passed: [ build-rootfs ]
+    - get: receipt-s3
+      passed: [ build-rootfs ]
+    - get: rootfs
+      resource: cflinuxfs3
+      passed: [ build-rootfs ]
+  - task: bbl-up
+    file: cf-deployment-concourse-tasks/bbl-up/task.yml
+    params:
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_ZONE: us-east1-c
+      BBL_GCP_REGION: us-east1
+      BBL_IAAS: gcp
+      BBL_LB_CERT: ((cflinuxfs3-lb-cert.certificate))
+      BBL_LB_KEY: ((cflinuxfs3-lb-cert.private_key))
+      LB_DOMAIN: cflinuxfs3.buildpacks-gcp.ci.cf-app.com
+      BBL_ENV_NAME: cflinuxfs3
+      BBL_STATE_DIR: cflinuxfs3
+    input_mapping:
+      ops-files: bosh-deployment
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+  - task: add-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/add-gcp-parent-dns-record/task.yml
+    params:
+      ENV_NAME: cflinuxfs3
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+
+- name: deploy
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - do:
+    - in_parallel:
+      - get: new-cves
+        passed: [ bbl-up ]
+      - get: stack-s3
+        passed: [ bbl-up ]
+      - get: version
+        passed: [ bbl-up ]
+        trigger: true
+      - get: receipt-s3
+        passed: [ bbl-up ]
+      - get: rootfs
+        resource: cflinuxfs3
+        passed: [ bbl-up ]
+      - get: previous-rootfs-release
+        resource: cflinuxfs3-github-tags
+        passed: [ bbl-up ]
+      - get: rootfs-release
+        resource: cflinuxfs3-release
+      - get: buildpacks-ci
+      - get: capi-release
+      - get: bbl-state
+      - get: cf-deployment
+      - get: gcp-stemcell
+      - get: cf-deployment-concourse-tasks
+      - get: bosh-deployment
+#@ for buildpack in buildpacks:
+      - get: #@ buildpack + "-buildpack-release"
+#@ end
+    - in_parallel:
+      - task: create-deployment-source-config
+        file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+        params:
+          ENV_NAME: cflinuxfs3
+      - task: overwrite-rootfs-release
+        file: buildpacks-ci/tasks/overwrite-rootfs-release/task.yml
+        params:
+          STACK: cflinuxfs3
+      - task: create-capi-release-with-rootfs
+        file: buildpacks-ci/tasks/create-capi-release-with-rootfs/task.yml
+        params:
+          STACK: cflinuxfs3
+      - task: use-new-buildpack-bosh-releases
+        file: buildpacks-ci/tasks/use-new-buildpack-bosh-releases/task.yml
+        params:
+          ACCESS_KEY_ID: ((pivotal-offline-buildpacks-s3-access-key))
+          SECRET_ACCESS_KEY: ((pivotal-offline-buildpacks-s3-secret-key))
+    - put: cflinuxfs3-rootfs-smoke-test-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: rootfs-release-artifacts/manifests/manifest.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs3/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+    - task: run-rootfs-smoke-test
+      file: buildpacks-ci/tasks/run-rootfs-smoke-test/task.yml
+      params:
+        ENV_NAME: cflinuxfs3
+    - put: cflinuxfs3-cf-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: cf-deployment/cf-deployment.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs3/*.tgz
+        - capi-release-artifacts/dev_releases/capi/*.tgz
+        - built-buildpacks-artifacts/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+        ops_files:
+        - cf-deployment/operations/experimental/fast-deploy-with-downtime-and-danger.yml
+        - cf-deployment/operations/use-latest-stemcell.yml
+        - cf-deployment/operations/use-compiled-releases.yml
+        - buildpacks-opsfile/use-latest-buildpack-releases.yml
+        - buildpacks-ci/deployments/operations/cflinuxfs3-rootfs-certs-as-list.yml
+        - rootfs-release-artifacts/use-dev-release-opsfile.yml
+        - capi-release-artifacts/use-dev-release-opsfile.yml
+        - capi-release-artifacts/use-rootfs-as-default-stack.yml
+        vars:
+          system_domain: cflinuxfs3.buildpacks-gcp.ci.cf-app.com
+    on_failure: #@ failure_alert()
+
+- name: cats
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+      passed: [ deploy ]
+    - get: cf-acceptance-tests
+    - get: new-cves
+      passed: [ deploy ]
+    - get: stack-s3
+      passed: [ deploy ]
+    - get: version
+      passed: [ deploy ]
+      trigger: true
+    - get: receipt-s3
+      passed: [ deploy ]
+    - get: rootfs
+      resource: cflinuxfs3
+      passed: [ deploy ]
+  - do:
+    - task: get-cf-creds
+      file: buildpacks-ci/tasks/get-cf-creds/task.yml
+      params:
+        ENV_NAME: cflinuxfs3
+    - task: write-cats-config
+      file: buildpacks-ci/tasks/write-cats-config/task.yml
+      params:
+        APPS_DOMAIN: cflinuxfs3.buildpacks-gcp.ci.cf-app.com
+        DIEGO_DOCKER_ON: true
+        STACKS: cflinuxfs3
+    - task: cats
+      attempts: 3
+      file: cf-deployment-concourse-tasks/run-cats/task.yml
+      params:
+        NODES: 12
+        CONFIG_FILE_PATH: integration_config.json
+        SKIP_REGEXP: "Specifying a specific Stack"
+        FLAKE_ATTEMPTS: 3
+    on_failure: #@ failure_alert()
+
+- name: check-for-race-condition
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: version
+      passed: [ cats ]
+      trigger: true
+    - get: latest-version
+      resource: version
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+      passed: [ cats ]
+    - get: new-cves
+      passed: [ cats ]
+    - get: stack-s3
+      passed: [ cats ]
+    - get: receipt-s3
+      passed: [ cats ]
+    - get: rootfs
+      resource: cflinuxfs3
+      passed: [ cats ]
+  - task: check-for-rootfs-race-condition
+    file: buildpacks-ci/tasks/check-for-rootfs-race-condition/task.yml
+
+- name: delete-deployment
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [ check-for-race-condition ]
+      trigger: true
+    - get: bbl-state
+    - get: buildpacks-ci
+  - task: create-deployment-source-config
+    file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+    params:
+      ENV_NAME: cflinuxfs3
+  - put: cflinuxfs3-rootfs-smoke-test-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+  - put: cflinuxfs3-cf-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+
+- name: bbl-destroy
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: version
+      passed: [ delete-deployment ]
+      trigger: true
+  - task: remove-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/remove-gcp-parent-dns-record/task.yml
+    params:
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      ENV_NAME: cflinuxfs3
+  - task: bbl-destroy
+    file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+    params:
+      BBL_STATE_DIR: cflinuxfs3
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+
+- name: release-cflinuxfs3
+  serial: true
+  serial_groups: [ cflinuxfs3 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: new-cves
+      passed: [ check-for-race-condition ]
+    - get: stack-s3
+      passed: [ check-for-race-condition ]
+    - get: receipt-s3
+      passed: [ check-for-race-condition ]
+    - get: rootfs
+      resource: cflinuxfs3
+      passed: [ check-for-race-condition ]
+    - get: version
+      trigger: true
+      passed: [ check-for-race-condition ]
+      params: { bump: final }
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+      passed: [ check-for-race-condition ]
+  - do:
+    - task: update-receipt
+      file: buildpacks-ci/tasks/update-rootfs-receipt/task.yml
+      params:
+        STACK: cflinuxfs3
+    - task: update-filename
+      file: buildpacks-ci/tasks/update-rootfs-filename/task.yml
+      params:
+        STACK: cflinuxfs3
+    - put: cflinuxfs3
+      params:
+        repository: new-rootfs-commit
+        tag: version/number
+        rebase: true
+    - put: stack-s3
+      params:
+        from: rootfs-archive/cflinuxfs3-(.*).tar.gz
+        to: /rootfs/
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
+
+- name: reset-minor-version-to-rc
+  serial: true
+  public: true
+  plan:
+  - get: version
+    trigger: true
+    passed: [ release-cflinuxfs3 ]
+    params: {bump: minor, pre: rc}
+  - put: version
+    params: {file: version/number}
+
+- name: upload-to-github
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: previous-rootfs-release
+      resource: cflinuxfs3-github-tags
+      passed: [ release-cflinuxfs3 ]
+    - get: rootfs
+      resource: cflinuxfs3
+      passed: [ release-cflinuxfs3 ]
+    - get: new-cves
+      passed: [ release-cflinuxfs3 ]
+    - get: stack-s3
+      passed: [ release-cflinuxfs3 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs3 ]
+  - do:
+    - task: generate-release-notes
+      file: buildpacks-ci/tasks/generate-rootfs-release-notes/task.yml
+      params:
+        STACK: cflinuxfs3
+    - put: cflinuxfs3-github-release
+      params:
+        name: version/number
+        tag: version/number
+        body: release-body/body
+        globs:
+          - stack-s3/cflinuxfs3-*.tar.gz
+    - put: new-cves
+      params:
+        repository: new-cves-artifacts
+        rebase: true
+    on_failure: #@ failure_alert()
+
+- name: finalize-security-notices
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+      resource: buildpacks-ci
+    - get: version
+      trigger: true
+      passed: [ upload-to-github ]
+  - do:
+    - task: finalize-security-notices
+      file: buildpacks-ci/tasks/finalize-security-notice-stories/task.yml
+      attempts: 20
+      params:
+        TRACKER_PROJECT_ID: 2537714
+        TRACKER_REQUESTER_ID: 1431988
+        TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+        STACK: cflinuxfs3
+
+- name: upload-to-docker
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: stack-s3
+      passed: [ release-cflinuxfs3 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs3 ]
+  - do:
+    - task: rename
+      file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
+      params:
+        STACK: cflinuxfs3
+    - in_parallel:
+      - put: cflinuxfs3-image
+        params:
+          skip_download: true
+          import_file: docker-s3/cflinuxfs3.tar.gz
+          tag: version/number
+          tag_as_latest: true
+    on_failure: #@ failure_alert()
+
+- name: create-cflinuxfs3-release
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: blob
+      resource: stack-s3
+      passed: [ release-cflinuxfs3 ]
+      trigger: true
+    - get: version
+      passed: [ release-cflinuxfs3 ]
+    - get: release
+      resource: cflinuxfs3-release
+  - do:
+    - task: create-cflinuxfs3-release
+      file: buildpacks-ci/tasks/rootfs/create-release/task.yml
+      params:
+        BLOB_NAME: rootfs
+        BLOB_GLOB: blob/cflinuxfs3-*.tar.gz
+        RELEASE_NAME: cflinuxfs3
+        ACCESS_KEY_ID: ((cloudfoundry-s3-access-key))
+        SECRET_ACCESS_KEY: ((cloudfoundry-s3-secret-key))
+    - task: create-release-body
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
+      params:
+        STACK: cflinuxfs3
+    - task: create-release-commit
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-commit/task.yml
+    - put: cflinuxfs3-release
+      params:
+        repository: release-artifacts
+    - put: cflinuxfs3-release-github-release
+      params:
+        name: version/number
+        tag: version/number
+        tag_prefix: v
+        commitish: release-commit/sha
+        body: release-body/body
+        globs:
+          - release-artifacts/releases/cflinuxfs3/*.tgz
+    on_failure: #@ failure_alert()

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -1,0 +1,704 @@
+#@ buildpacks = ["binary", "dotnet-core", "go", "java", "nodejs", "php", "python", "ruby", "staticfile"]
+
+#@ def failure_alert():
+put: failure-alert
+params:
+  text: "$BUILD_PIPELINE_NAME $BUILD_JOB_NAME job on Concourse failed! \n Check: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME"
+  channel: "#buildpacks-firehose"
+  username: concourse
+  icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+#@ end
+
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+- name: bosh-deployment
+  type: docker-image
+  source:
+    repository: cloudfoundry/bosh-deployment-resource
+
+resources:
+#@ for buildpack in buildpacks:
+- name: #@ buildpack + "-buildpack-release"
+  type: git
+  source:
+    branch: master
+    uri: #@ "https://github.com/cloudfoundry/{}-buildpack-release.git".format(buildpack)
+#@ end
+
+- name: cf-deployment-concourse-tasks
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+    tag_filter: v8.*
+
+- name: cf-deployment-concourse-tasks-latest
+  type: git
+  source:
+    branch: main
+    uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
+
+- name: cf-acceptance-tests
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
+    branch: develop #! TODO switch to main when https://github.com/cloudfoundry/cf-acceptance-tests/pull/819 is merged and available on main
+
+- name: bbl-state
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/buildpacks-envs
+    branch: master
+    private_key: ((buildpacks-envs-deploy-key.private_key))
+
+- name: bosh-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/bosh-deployment.git
+    branch: master
+
+- name: cf-deployment
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/cf-deployment
+    tag: v21.11.0
+
+- name: buildpacks-ci
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+
+- name: cflinuxfs4
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
+
+- name: cflinuxfs4-github-tags
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
+    tag_filter: "*"
+
+- name: cflinuxfs4-build-trigger
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/cflinuxfs4.git
+    private_key: ((cflinuxfs4-deploy-key.private_key))
+    ignore_paths:
+    - receipt.cflinuxfs4.x86_64
+    - README.md
+    - .gitignore
+
+- name: new-cves
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ new-cve-notifications/ubuntu22.04.yml ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
+
+- name: receipt-diff
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    paths: [ receipt.cflinuxfs4.x86_64 ]
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    tag_filter: "newpackages_cflinuxfs4_*"
+
+- name: public-robots
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+    private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+    branch: main
+
+- name: cflinuxfs4-release
+  type: git
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/cflinuxfs4-release.git
+    private_key: ((cflinuxfs4-release-deploy-key.private_key))
+
+- name: capi-release
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/capi-release
+    branch: main
+
+- name: stack-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/cflinuxfs4-(.*).tar.gz
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: receipt-s3
+  type: s3
+  source:
+    bucket: pivotal-buildpacks
+    regexp: rootfs/receipt.cflinuxfs4.x86_64-(.*)
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: cflinuxfs4-cf-deployment
+  type: bosh-deployment
+  source:
+    deployment: cf
+    skip_check: true
+
+- name: cflinuxfs4-rootfs-smoke-test-deployment
+  type: bosh-deployment
+  source:
+    skip_check: true
+    deployment: rootfs-smoke-test
+
+- name: gcp-stemcell
+  type: bosh-io-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-jammy-go_agent
+
+- name: cflinuxfs4-image
+  type: docker-image
+  source:
+    repository: cloudfoundry/cflinuxfs4
+    username: ((cfbuildpacks-dockerhub-user.username))
+    password: ((cfbuildpacks-dockerhub-user.password))
+    email: cf-buildpacks-eng@pivotal.io
+
+- name: cflinuxfs4-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs4
+    access_token: ((buildpacks-github-token))
+
+- name: cflinuxfs4-release-github-release
+  type: github-release
+  source:
+    drafts: false
+    user: cloudfoundry
+    repository: cflinuxfs4-release
+    access_token: ((buildpacks-github-token))
+
+- name: version
+  type: semver
+  source:
+    bucket: pivotal-buildpacks
+    key: versions/stack-cflinuxfs4
+    access_key_id: ((pivotal-buildpacks-s3-access-key))
+    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: ((concourse-job-failure-notifications-slack-webhook))
+
+jobs:
+- name: build-rootfs
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+    - get: buildpacks-ci
+    - get: new-cves
+      trigger: true
+    - get: rootfs
+      resource: cflinuxfs4
+    - get: cflinuxfs4-build-trigger
+      trigger: true
+    - get: version
+      params: { pre: rc }
+    - get: public-robots
+  - do:
+    - task: make-rootfs
+      file: buildpacks-ci/tasks/make-rootfs/task.yml
+      privileged: true
+      params:
+        STACK: cflinuxfs4
+    - put: stack-s3
+      params:
+        file: rootfs-artifacts/cflinuxfs4-*.tar.gz
+    - put: receipt-s3
+      params:
+        file: receipt-artifacts/receipt.cflinuxfs4.x86_64-*
+    - task: generate-receipt-diff
+      file: buildpacks-ci/tasks/generate-rootfs-receipt-diff/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: public-robots
+      params:
+        repository: public-robots-artifacts
+        rebase: true
+        tag: git-tags/TAG
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
+
+- name: bbl-up
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ build-rootfs ]
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: bbl-config
+      resource: bbl-state
+    - get: bosh-deployment
+    - get: buildpacks-ci
+    - get: receipt-diff
+      trigger: true
+    - get: new-cves
+      passed: [ build-rootfs ]
+    - get: stack-s3
+      passed: [ build-rootfs ]
+    - get: version
+      passed: [ build-rootfs ]
+    - get: receipt-s3
+      passed: [ build-rootfs ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ build-rootfs ]
+  - task: bbl-up
+    file: cf-deployment-concourse-tasks/bbl-up/task.yml
+    params:
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_ZONE: us-east1-c
+      BBL_GCP_REGION: us-east1
+      BBL_IAAS: gcp
+      BBL_LB_CERT: ((cflinuxfs4-lb-cert.certificate))
+      BBL_LB_KEY: ((cflinuxfs4-lb-cert.private_key))
+      LB_DOMAIN: cflinuxfs4.buildpacks-gcp.ci.cf-app.com
+      BBL_ENV_NAME: cflinuxfs4
+      BBL_STATE_DIR: cflinuxfs4
+    input_mapping:
+      ops-files: bosh-deployment
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+  - task: add-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/add-gcp-parent-dns-record/task.yml
+    params:
+      ENV_NAME: cflinuxfs4
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+
+- name: deploy
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - do:
+    - in_parallel:
+      - get: new-cves
+        passed: [ bbl-up ]
+      - get: stack-s3
+        passed: [ bbl-up ]
+      - get: version
+        passed: [ bbl-up ]
+        trigger: true
+      - get: receipt-s3
+        passed: [ bbl-up ]
+      - get: rootfs
+        resource: cflinuxfs4
+        passed: [ bbl-up ]
+      - get: previous-rootfs-release
+        resource: cflinuxfs4-github-tags
+        passed: [ bbl-up ]
+      - get: rootfs-release
+        resource: cflinuxfs4-release
+      - get: buildpacks-ci
+      - get: capi-release
+      - get: bbl-state
+      - get: cf-deployment
+      - get: gcp-stemcell
+      - get: cf-deployment-concourse-tasks
+      - get: bosh-deployment
+#@ for buildpack in buildpacks:
+      - get: #@ buildpack + "-buildpack-release"
+#@ end
+    - in_parallel:
+      - task: create-deployment-source-config
+        file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+        params:
+          ENV_NAME: cflinuxfs4
+      - task: overwrite-rootfs-release
+        file: buildpacks-ci/tasks/overwrite-rootfs-release/task.yml
+        params:
+          STACK: cflinuxfs4
+      - task: create-capi-release-with-rootfs
+        file: buildpacks-ci/tasks/create-capi-release-with-rootfs/task.yml
+        params:
+          STACK: cflinuxfs4
+      - task: use-new-buildpack-bosh-releases
+        file: buildpacks-ci/tasks/use-new-buildpack-bosh-releases/task.yml
+        params:
+          ACCESS_KEY_ID: ((pivotal-offline-buildpacks-s3-access-key))
+          SECRET_ACCESS_KEY: ((pivotal-offline-buildpacks-s3-secret-key))
+    - put: cflinuxfs4-rootfs-smoke-test-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: rootfs-release-artifacts/manifests/manifest.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs4/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+    - task: run-rootfs-smoke-test
+      file: buildpacks-ci/tasks/run-rootfs-smoke-test/task.yml
+      params:
+        ENV_NAME: cflinuxfs4
+    - put: cflinuxfs4-cf-deployment
+      params:
+        source_file: deployment-source-config/source_file.yml
+        manifest: cf-deployment/cf-deployment.yml
+        releases:
+        - rootfs-release-artifacts/dev_releases/cflinuxfs4/*.tgz
+        - capi-release-artifacts/dev_releases/capi/*.tgz
+        - built-buildpacks-artifacts/*.tgz
+        stemcells:
+        - gcp-stemcell/*.tgz
+        ops_files:
+        - cf-deployment/operations/experimental/fast-deploy-with-downtime-and-danger.yml
+        - cf-deployment/operations/use-latest-stemcell.yml
+        - cf-deployment/operations/use-compiled-releases.yml
+        - cf-deployment/operations/experimental/add-cflinuxfs4.yml
+        - cf-deployment/operations/experimental/set-cflinuxfs4-default-stack.yml
+        - buildpacks-opsfile/use-latest-buildpack-releases.yml
+        - rootfs-release-artifacts/use-dev-release-opsfile.yml
+        - capi-release-artifacts/use-dev-release-opsfile.yml
+        vars:
+          system_domain: cflinuxfs4.buildpacks-gcp.ci.cf-app.com
+    on_failure: #@ failure_alert()
+
+- name: cats
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ deploy ]
+    - get: cf-acceptance-tests
+    - get: new-cves
+      passed: [ deploy ]
+    - get: stack-s3
+      passed: [ deploy ]
+    - get: version
+      passed: [ deploy ]
+      trigger: true
+    - get: receipt-s3
+      passed: [ deploy ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ deploy ]
+  - do:
+    - task: get-cf-creds
+      file: buildpacks-ci/tasks/get-cf-creds/task.yml
+      params:
+        ENV_NAME: cflinuxfs4
+    - task: write-cats-config
+      file: buildpacks-ci/tasks/write-cats-config/task.yml
+      params:
+        APPS_DOMAIN: cflinuxfs4.buildpacks-gcp.ci.cf-app.com
+        DIEGO_DOCKER_ON: true
+        STACKS: cflinuxfs4
+    - task: cats
+      attempts: 3
+      file: cf-deployment-concourse-tasks/run-cats/task.yml
+      params:
+        NODES: 12
+        CONFIG_FILE_PATH: integration_config.json
+        SKIP_REGEXP: "Specifying a specific Stack"
+        FLAKE_ATTEMPTS: 3
+    on_failure: #@ failure_alert()
+
+- name: check-for-race-condition
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: version
+      passed: [ cats ]
+      trigger: true
+    - get: latest-version
+      resource: version
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ cats ]
+    - get: new-cves
+      passed: [ cats ]
+    - get: stack-s3
+      passed: [ cats ]
+    - get: receipt-s3
+      passed: [ cats ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ cats ]
+  - task: check-for-rootfs-race-condition
+    file: buildpacks-ci/tasks/check-for-rootfs-race-condition/task.yml
+
+- name: delete-deployment
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [ check-for-race-condition ]
+      trigger: true
+    - get: bbl-state
+    - get: buildpacks-ci
+  - task: create-deployment-source-config
+    file: buildpacks-ci/tasks/create-deployment-source-config/task.yml
+    params:
+      ENV_NAME: cflinuxfs4
+  - put: cflinuxfs4-rootfs-smoke-test-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+  - put: cflinuxfs4-cf-deployment
+    params:
+      source_file: deployment-source-config/source_file.yml
+      delete:
+        enabled: true
+        force: true
+
+- name: bbl-destroy
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: cf-deployment-concourse-tasks
+      resource: cf-deployment-concourse-tasks-latest
+    - get: bbl-state
+    - get: buildpacks-ci
+    - get: version
+      passed: [ delete-deployment ]
+      trigger: true
+  - task: remove-gcp-parent-dns-record
+    file: buildpacks-ci/tasks/remove-gcp-parent-dns-record/task.yml
+    params:
+      GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+      ENV_NAME: cflinuxfs4
+  - task: bbl-destroy
+    file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
+    params:
+      BBL_STATE_DIR: cflinuxfs4
+      BBL_GCP_PROJECT_ID: cf-buildpacks
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
+    ensure:
+      put: bbl-state
+      params:
+        repository: updated-bbl-state
+        rebase: true
+
+- name: release-cflinuxfs4
+  serial: true
+  serial_groups: [ cflinuxfs4 ]
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: new-cves
+      passed: [ check-for-race-condition ]
+    - get: stack-s3
+      passed: [ check-for-race-condition ]
+    - get: receipt-s3
+      passed: [ check-for-race-condition ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ check-for-race-condition ]
+    - get: version
+      trigger: true
+      passed: [ check-for-race-condition ]
+      params: { bump: final }
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ check-for-race-condition ]
+  - do:
+    - task: update-receipt
+      file: buildpacks-ci/tasks/update-rootfs-receipt/task.yml
+      params:
+        STACK: cflinuxfs4
+    - task: update-filename
+      file: buildpacks-ci/tasks/update-rootfs-filename/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: cflinuxfs4
+      params:
+        repository: new-rootfs-commit
+        tag: version/number
+        rebase: true
+    - put: stack-s3
+      params:
+        from: rootfs-archive/cflinuxfs4-(.*).tar.gz
+        to: /rootfs/
+    - put: version
+      params: { file: version/number }
+    on_failure: #@ failure_alert()
+
+- name: reset-minor-version-to-rc
+  serial: true
+  public: true
+  plan:
+  - get: version
+    trigger: true
+    passed: [ release-cflinuxfs4 ]
+    params: { bump: minor, pre: rc }
+  - put: version
+    params: { file: version/number }
+
+- name: upload-to-github
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: previous-rootfs-release
+      resource: cflinuxfs4-github-tags
+      passed: [ release-cflinuxfs4 ]
+    - get: rootfs
+      resource: cflinuxfs4
+      passed: [ release-cflinuxfs4 ]
+    - get: new-cves
+      passed: [ release-cflinuxfs4 ]
+    - get: stack-s3
+      passed: [ release-cflinuxfs4 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs4 ]
+  - do:
+    - task: generate-release-notes
+      file: buildpacks-ci/tasks/generate-rootfs-release-notes/task.yml
+      params:
+        STACK: cflinuxfs4
+    - put: cflinuxfs4-github-release
+      params:
+        name: version/number
+        tag: version/number
+        body: release-body/body
+        globs:
+          - stack-s3/cflinuxfs4-*.tar.gz
+    - put: new-cves
+      params:
+        repository: new-cves-artifacts
+        rebase: true
+    on_failure: #@ failure_alert()
+
+- name: finalize-security-notices
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+      resource: buildpacks-ci
+    - get: version
+      trigger: true
+      passed: [ upload-to-github ]
+  - do:
+    - task: finalize-security-notices
+      file: buildpacks-ci/tasks/finalize-security-notice-stories/task.yml
+      attempts: 20
+      params:
+        TRACKER_PROJECT_ID: 2537714
+        TRACKER_REQUESTER_ID: 1431988
+        TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+        STACK: cflinuxfs4
+
+- name: upload-to-docker
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: stack-s3
+      passed: [ release-cflinuxfs4 ]
+    - get: version
+      trigger: true
+      passed: [ release-cflinuxfs4 ]
+  - do:
+    - task: rename
+      file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
+      params:
+        STACK: cflinuxfs4
+    - in_parallel:
+      - put: cflinuxfs4-image
+        params:
+          skip_download: true
+          import_file: docker-s3/cflinuxfs4.tar.gz
+          tag: version/number
+          tag_as_latest: true
+    on_failure: #@ failure_alert()
+
+- name: create-cflinuxfs4-release
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: buildpacks-ci
+    - get: blob
+      resource: stack-s3
+      passed: [ release-cflinuxfs4 ]
+      trigger: true
+    - get: version
+      passed: [ release-cflinuxfs4 ]
+    - get: release
+      resource: cflinuxfs4-release
+  - do:
+    - task: create-cflinuxfs4-release
+      file: buildpacks-ci/tasks/rootfs/create-release/task.yml
+      params:
+        BLOB_NAME: rootfs
+        BLOB_GLOB: blob/cflinuxfs4-*.tar.gz
+        RELEASE_NAME: cflinuxfs4
+        ACCESS_KEY_ID: ((cloudfoundry-s3-access-key))
+        SECRET_ACCESS_KEY: ((cloudfoundry-s3-secret-key))
+    - task: create-release-body
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
+      params:
+        STACK: cflinuxfs4
+    - task: create-release-commit
+      file: buildpacks-ci/tasks/create-rootfs-bosh-release-commit/task.yml
+    - put: cflinuxfs4-release
+      params:
+        repository: release-artifacts
+    - put: cflinuxfs4-release-github-release
+      params:
+        name: version/number
+        tag: version/number
+        tag_prefix: v
+        commitish: release-commit/sha
+        body: release-body/body
+        globs:
+          - release-artifacts/releases/cflinuxfs4/*.tgz
+    on_failure: #@ failure_alert()

--- a/pipelines/ci-images.yml
+++ b/pipelines/ci-images.yml
@@ -50,6 +50,14 @@ resources:
     username: ((dockerhub-account.username))
     password: ((dockerhub-account.password))
 
+- name: core-deps-ci-image
+  type: docker-image
+  icon: docker
+  source:
+    repository: coredeps/core-deps-ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
+
 - name: minimal-dockerfile
   type: git
   icon: github
@@ -85,6 +93,15 @@ resources:
     branch: master
     paths:
     - dockerfiles/gcloud.Dockerfile
+
+- name: core-deps-ci-dockerfile
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
+    paths:
+    - dockerfiles/core-deps-ci.Dockerfile
 
 jobs:
 - name: build-minimal-image
@@ -163,5 +180,22 @@ jobs:
     params:
       DOCKERFILE: source/dockerfiles/gcloud.Dockerfile
   - put: gcloud-image
+    params:
+      image: image/image.tar
+
+- name: build-core-deps-ci-image
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: core-deps-ci-dockerfile
+      trigger: true
+  - task: build
+    file: ci/tasks/build-image/task.yml
+    privileged: true
+    input_mapping:
+      source: core-deps-ci-dockerfile
+    params:
+      DOCKERFILE: source/dockerfiles/core-deps-ci.Dockerfile
+  - put: core-deps-ci-image
     params:
       image: image/image.tar

--- a/pipelines/notifications.yml
+++ b/pipelines/notifications.yml
@@ -1,0 +1,209 @@
+---
+resource_types:
+  - name: cf-tracker-resource
+    type: docker-image
+    source:
+      repository: cfbuildpacks/cf-tracker-resource
+      tag: latest
+  - name: email-sender
+    type: docker-image
+    source:
+      repository: pcfseceng/email-resource
+  - name: cron
+    type: docker-image
+    source:
+      repository: cfbuildpacks/cron-resource
+
+resources:
+  - name: davos-cve-stories-cflinuxfs3
+    type: cf-tracker-resource
+    source:
+      project_id: 2537714
+      token: ((pivotal-tracker-api-token))
+      labels:
+        - cflinuxfs3
+        - security-notice
+
+  - name: davos-cve-stories-cflinuxfs4
+    type: cf-tracker-resource
+    source:
+      project_id: 2537714
+      token: ((pivotal-tracker-api-token))
+      labels:
+        - cflinuxfs4
+        - security-notice
+
+  - name: first-of-month
+    type: cron
+    check_every: 15m
+    source:
+      expression: 15 0 1 * *
+      location: America/New_York
+
+  - name: last-week-of-month
+    type: cron
+    check_every: 1h
+    source:
+      expression: 0 0 25 * *
+      location: America/New_York
+
+  - name: check-interval
+    type: cron
+    source:
+      expression: "0 * * * *"
+      location: America/New_York
+
+  - name: buildpacks-ci
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/buildpacks-ci
+      branch: master
+
+  - name: new-cves
+    type: git
+    source:
+      uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
+      branch: main
+      paths: [ new-cve-notifications/* ]
+      private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
+
+  - name: cflinuxfs3
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/cflinuxfs3
+
+  - name: cflinuxfs3-release
+    type: github-release
+    source:
+      owner: cloudfoundry
+      repository: cflinuxfs3
+      access_token: ((buildpacks-github-token))
+
+  - name: cflinuxfs4
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/cflinuxfs4
+
+  - name: cflinuxfs4-release
+    type: github-release
+    source:
+      owner: cloudfoundry
+      repository: cflinuxfs4
+      access_token: ((buildpacks-github-token))
+
+jobs:
+  - name: categorize-security-notices-cflinuxfs3
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: davos-cve-stories
+            resource: davos-cve-stories-cflinuxfs3
+            trigger: true
+          - get: buildpacks-ci
+          - get: cflinuxfs3-release
+            params:
+              include_source_tarball: true
+      - in_parallel:
+          - task: categorize-security-notices-cflinuxfs3
+            file: buildpacks-ci/tasks/categorize-security-notices/task.yml
+            params:
+              TRACKER_PROJECT_ID: 2537714
+              TRACKER_PROJECT_REQUESTER: 1431988
+              TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+              STACK: cflinuxfs3
+
+  - name: new-rootfs-cves-cflinuxfs3
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: buildpacks-ci
+          - get: new-cves
+          - get: cflinuxfs3
+          - get: check-interval
+            trigger: true
+      - in_parallel:
+          - do:
+              - task: check-for-new-cflinuxfs3-cves
+                file: buildpacks-ci/tasks/check-for-new-rootfs-cves/task.yml
+                output_mapping:
+                  output-new-cves: output-new-cves-cflinuxfs3
+              - put: new-cves-cflinuxfs3
+                resource: new-cves
+                params:
+                  repository: output-new-cves-cflinuxfs3
+                  rebase: true
+
+  - name: categorize-security-notices-cflinuxfs4
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: davos-cve-stories
+            resource: davos-cve-stories-cflinuxfs4
+            trigger: true
+          - get: buildpacks-ci
+          - get: cflinuxfs4-release
+            params:
+              include_source_tarball: true
+      - in_parallel:
+          - task: categorize-security-notices-cflinuxfs4
+            file: buildpacks-ci/tasks/categorize-security-notices/task.yml
+            params:
+              TRACKER_PROJECT_ID: 2537714
+              TRACKER_PROJECT_REQUESTER: 1431988
+              TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+              STACK: cflinuxfs4
+
+  - name: new-rootfs-cves-cflinuxfs4
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: buildpacks-ci
+          - get: new-cves
+          - get: cflinuxfs4
+          - get: check-interval
+            trigger: true
+      - in_parallel:
+          - do:
+              - task: check-for-new-cflinuxfs4-cves
+                file: buildpacks-ci/tasks/check-for-new-rootfs-cves-cflinuxfs4/task.yml
+                output_mapping:
+                  output-new-cves: output-new-cves-cflinuxfs4
+              - put: new-cves-cflinuxfs4
+                resource: new-cves
+                params:
+                  repository: output-new-cves-cflinuxfs4
+                  rebase: true
+
+  - name: php-module-checker
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: last-week-of-month
+            trigger: true
+          - get: buildpacks-ci
+      - task: check-for-latest-php-module-versions
+        file: buildpacks-ci/tasks/check-for-latest-php-module-versions/task.yml
+        params:
+          TRACKER_PROJECT_ID: 2537714
+          TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+          TRACKER_REQUESTER_ID: 1431988
+
+  - name: bosh-release-reminder
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+          - get: first-of-month
+            trigger: true
+          - get: buildpacks-ci
+      - task: create-reminder-story
+        file: buildpacks-ci/tasks/create-bosh-release-reminder-story/task.yml
+        params:
+          TRACKER_PROJECT_ID: 2537714
+          TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
+          TRACKER_RELEASE_REMINDER_MARKER_STORY: 180346921

--- a/pipelines/recipe-specs/recipe-specs-config.yml
+++ b/pipelines/recipe-specs/recipe-specs-config.yml
@@ -1,0 +1,16 @@
+#@data/values
+---
+integration_spec_names:
+- bundler
+- glide
+- go
+- godep
+- dep
+- httpd
+- hwc
+- jruby
+- nodejs
+- php7_with_oracle
+- ruby
+- url_output
+- yaml_flag

--- a/pipelines/recipe-specs/recipe-specs.yml
+++ b/pipelines/recipe-specs/recipe-specs.yml
@@ -1,0 +1,93 @@
+#@ load("@ytt:data", "data")
+
+resources:
+
+  #!# Git Repos ##
+  - name: binary-builder
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/binary-builder.git
+
+  - name: buildpacks-ci
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/buildpacks-ci
+      branch: master
+
+ #!# Docker Images ##
+  - name: docker-cflinuxfs3-rootfs
+    type: docker-image
+    source:
+      repository: cloudfoundry/cflinuxfs3
+      username: ((cfbuildpacks-dockerhub-user.username))
+      password: ((cfbuildpacks-dockerhub-user.password))
+      email: cf-buildpacks-eng@pivotal.io
+
+groups:
+  - name: binary-builder-specs
+    jobs:
+    - binary-builder-specs
+    - binary-builder-specs-unit
+#@ for spec_name in data.values.integration_spec_names:
+    - #@ "binary-builder-specs-" + spec_name.replace("_", "-")
+#@ end
+jobs:
+  - name: binary-builder-specs
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+        - get: buildpacks-ci
+        - get: binary-builder
+          trigger: true
+          passed:
+#@ for spec_name in data.values.integration_spec_names:
+          - #@ "binary-builder-specs-" + spec_name.replace("_", "-")
+#@ end
+
+  - name: binary-builder-specs-unit
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+        - get: buildpacks-ci
+        - get: docker-cflinuxfs3-rootfs
+          trigger: true
+        - get: binary-builder
+          trigger: true
+      - do:
+        - task: all-expected-integration-specs-will-run
+          file: buildpacks-ci/tasks/check-for-binary-builder-integration-spec-presence/task.yml
+          params:
+            SPEC_NAMES: #@ ",".join(data.values.integration_spec_names)
+        - task: all-unit-tests
+          file: buildpacks-ci/tasks/run-binary-builder-unit-specs/task.yml
+          params:
+            RUBYGEM_MIRROR: https://rubygems.org
+#@ for spec_name in data.values.integration_spec_names:
+  - name: #@ "binary-builder-specs-" + spec_name.replace("_", "-")
+    serial: true
+    public: true
+    plan:
+      - in_parallel:
+        - get: buildpacks-ci
+        - get: docker-cflinuxfs3-rootfs
+          trigger: true
+        - get: binary-builder
+          passed: [ binary-builder-specs-unit ]
+          trigger: true
+      - do:
+        - in_parallel:
+          - task: #@ "integration-" + spec_name.replace("_", "-")
+            file: buildpacks-ci/tasks/run-binary-builder-integration-specs/task.yml
+            params:
+              SPEC_TO_RUN: #@ spec_name
+              RUBYGEM_MIRROR: https://rubygems.org
+              RUN_ORACLE_PHP_TESTS: true
+              AWS_ACCESS_KEY_ID: ((oracle-client-library-s3-download-access-key))
+              AWS_SECRET_ACCESS_KEY: ((oracle-client-library-s3-download-secret-key))
+              AWS_DEFAULT_REGION: us-east-1
+              ORACLE_LIBS_AWS_BUCKET: buildpacks-oracle-client-libs
+              ORACLE_LIBS_FILENAME: oracle_client_libs.tgz
+            attempts: 5
+#@ end

--- a/pipelines/resources.yml
+++ b/pipelines/resources.yml
@@ -1,0 +1,49 @@
+resources:
+- name: depwatcher
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/buildpacks-ci.git
+    private_key: ((buildpacks-ci-deploy-key.private_key))
+    branch: master
+    paths: [ dockerfiles/depwatcher/ ]
+
+- name: create-pull-request-resource
+  type: git
+  source:
+    uri: git@github.com:pivotal/create-pull-request-resource.git
+    private_key: ((create-pull-request-resource-deploy-key.private_key))
+    branch: master
+
+- name: depwatcher-image
+  type: docker-image
+  source:
+    repository: coredeps/depwatcher
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
+
+- name: create-pull-request-resource-image
+  type: docker-image
+  source:
+    repository: coredeps/create-pull-request-resource
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
+
+
+jobs:
+- name: build-and-push-depwatcher
+  plan:
+  - in_parallel:
+    - get: depwatcher
+      trigger: true
+  - put: depwatcher-image
+    params:
+      build: depwatcher/dockerfiles/depwatcher
+
+- name: build-and-push-create-pull-request-resource
+  plan:
+  - in_parallel:
+     - get: create-pull-request-resource
+       trigger: true
+  - put: create-pull-request-resource-image
+    params:
+     build: create-pull-request-resource

--- a/tasks/cf-release/create-buildpack-dev-release/run
+++ b/tasks/cf-release/create-buildpack-dev-release/run
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+get_buildpack_name() {
+  get_buildpack_release_name | sed 's/-offline//'
+}
+
+get_buildpack_release_name() {
+  yj -yj < release/config/final.yml | jq -r .final_name
+}
+
+get_version() {
+  local versions
+  for version_file in buildpack-*/version; do
+    local version
+    version="$(sed 's/[#+].*$//' "${version_file}" | sed 's/Java Buildpack //')"
+    versions+="${version}\n"
+  done
+
+  version="$(echo -e "${versions}" | grep -v '^$' | sort -u)"
+  if [[ "$(echo -e "${version}" | wc -l)" -gt 1 ]]; then
+    >&2 echo -e "versions do not match:\n${version}"
+    exit 1
+  fi
+
+  echo "${version}"
+}
+
+buildpack_blob_is_latest() {
+  local new_version=$1
+
+  local existing_version
+  if [[ "$(bosh blobs --dir release --column=path)" =~ v?([0-9\.]+).zip ]]; then
+    existing_version="${BASH_REMATCH[1]}"
+  else
+    echo "Could not determine version of existing buildpack blob"
+    exit 1
+  fi
+
+  [[ "${existing_version}" == "${new_version}" ]] && return 0 || return 1
+}
+
+remove_old_blobs() {
+  bosh blobs --dir release --json \
+    | jq -r '.Tables[0].Rows[].path' \
+    | grep buildpack \
+    | xargs -I {} bosh remove-blob --dir release {}
+}
+
+add_new_blobs() {
+  local buildpack_name
+  buildpack_name="$(get_buildpack_name)"
+
+  for buildpack_file in buildpack-*/*.zip; do
+    local blob_name
+    blob_name="$(basename "${buildpack_file}" | sed 's/+.*\.zip/.zip/')"
+    bosh add-blob --dir release "${buildpack_file}" "${buildpack_name}/${blob_name}"
+  done
+}
+
+write_private_yml() {
+  cat >release/config/private.yml <<-EOF
+---
+blobstore:
+  options:
+    access_key_id: ${AWS_ACCESS_KEY_ID}
+    secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+EOF
+}
+
+upload_blobs() {
+  bosh upload-blobs --dir release
+}
+
+commit_blobs() {
+  local version=$1
+
+  git -C release add config/blobs.yml
+  git -C release commit -m "Updating blobs for $(get_buildpack_name) at ${version}"
+}
+
+create_release_tarball() {
+  local version=$1
+
+  dev_release_version="${version}-$(date +%s)"
+  release_name="$(get_buildpack_release_name)"
+  tarball_path="$PWD/release-tarball/${release_name}-release-${dev_release_version}.tgz"
+
+  pushd release >/dev/null
+    bosh create-release \
+      --force \
+      --version "${dev_release_version}" \
+      --name "${release_name}" \
+      --tarball "${tarball_path}"
+  popd >/dev/null
+}
+
+main() {
+  local version
+  version="$(get_version)"
+
+  write_private_yml
+
+  if ! buildpack_blob_is_latest "${version}"; then
+    remove_old_blobs
+    add_new_blobs
+    upload_blobs
+    commit_blobs "${version}"
+  fi
+
+  create_release_tarball "${version}"
+}
+
+main "$@"

--- a/tasks/cf-release/create-buildpack-dev-release/task.yml
+++ b/tasks/cf-release/create-buildpack-dev-release/task.yml
@@ -1,0 +1,27 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: coredeps/core-deps-ci
+inputs:
+- name: core-deps-ci
+- name: release
+- name: buildpack-stack0
+  optional: true
+- name: buildpack-stack1
+  optional: true
+- name: buildpack-stack2
+  optional: true
+- name: buildpack-stack3
+  optional: true
+- name: buildpack-stack4
+  optional: true
+outputs:
+- name: release
+- name: release-tarball
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+run:
+  path: core-deps-ci/tasks/cf-release/create-buildpack-dev-release/run

--- a/tasks/cf-release/create-buildpack-release-ops-file/run
+++ b/tasks/cf-release/create-buildpack-release-ops-file/run
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+buildpack_name="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .name)"
+version="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .version)"
+
+cat >>"ops-file/bump-${buildpack_name}.yml" <<-EOF
+- path: /releases/name=${buildpack_name}
+  type: replace
+  value:
+    name: "${buildpack_name}"
+    version: "${version}"
+EOF

--- a/tasks/cf-release/create-buildpack-release-ops-file/task.yml
+++ b/tasks/cf-release/create-buildpack-release-ops-file/task.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: coredeps/core-deps-ci
+inputs:
+- name: core-deps-ci
+- name: buildpack-release-tarball
+outputs:
+- name: ops-file
+run:
+  path: core-deps-ci/tasks/cf-release/create-buildpack-release-ops-file/run

--- a/tasks/cf-release/create-cats-integration-config/run
+++ b/tasks/cf-release/create-cats-integration-config/run
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source cf-deployment-concourse-tasks/shared-functions
+setup_bosh_env_vars
+
+api="$(jq -r .cf.api_url toolsmiths-env/metadata)"
+apps_domain="${api#api.}"
+admin_password="$(get_password_from_credhub cf_admin_password)"
+credhub_secret="$(get_password_from_credhub credhub_admin_client_secret)"
+
+cat >cats-integration-config/integration-config.json <<-EOF
+{
+  "api": "${api}",
+  "apps_domain": "${apps_domain}",
+  "admin_user": "admin",
+  "admin_password": "${admin_password}",
+  "credhub_client": "credhub_admin_client",
+  "credhub_secret": "${credhub_secret}",
+  "credhub_mode" : "assisted",
+  "artifacts_directory": "logs",
+  "skip_ssl_validation": true,
+  "timeout_scale": 2,
+  "default_timeout": 300,
+  "async_service_operation_timeout": 1200,
+  "cf_push_timeout": 600,
+  "broker_start_timeout": 600,
+  "use_http": true,
+  "use_log_cache": false,
+  "include_apps": true,
+  "include_backend_compatibility": true,
+  "include_capi_no_bridge": true,
+  "include_container_networking": true,
+  "include_credhub": true,
+  "include_detect": true,
+  "include_docker": false,
+  "include_internet_dependent": true,
+  "include_internetless": false,
+  "include_isolation_segments": false,
+  "include_private_docker_registry": false,
+  "include_route_services": false,
+  "include_routing": false,
+  "include_routing_isolation_segments": false,
+  "include_security_groups": false,
+  "include_service_discovery": false,
+  "include_service_instance_sharing": false,
+  "include_services": false,
+  "include_ssh": true,
+  "include_sso": true,
+  "include_tasks": true,
+  "include_tcp_routing": true,
+  "include_v3": false,
+  "include_volume_services": false,
+  "include_zipkin": false,
+  "stacks": ["cflinuxfs3"]
+}
+EOF

--- a/tasks/cf-release/create-cats-integration-config/task.yml
+++ b/tasks/cf-release/create-cats-integration-config/task.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/ci
+    tag: latest
+inputs:
+  - name: core-deps-ci
+  - name: cf-deployment-concourse-tasks
+  - name: toolsmiths-env
+outputs:
+  - name: cats-integration-config
+run:
+  path: core-deps-ci/tasks/cf-release/create-cats-integration-config/run

--- a/tasks/cf-release/finalize-buildpack-release/run
+++ b/tasks/cf-release/finalize-buildpack-release/run
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+get_version() {
+  version="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .version | cut -d'-' -f1)"
+  echo "${version}" > version/version
+  echo "${version}"
+}
+
+
+get_name() {
+  tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .name
+}
+
+release_version_exists() {
+  local version=$1
+
+  if [[ -n "$(git -C release tag --list "${version}")" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+write_private_yml() {
+  cat >release/config/private.yml <<-EOF
+---
+blobstore:
+  options:
+    access_key_id: ${AWS_ACCESS_KEY_ID}
+    secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+EOF
+}
+
+
+finalize_release() {
+  local version=$1
+
+  bosh finalize-release --dir release --version "${version}" buildpack-release-tarball/*.tgz
+}
+
+commit_changes() {
+  local name=$1
+  local version=$2
+
+  git -C release add config/blobs.yml
+  git -C release add releases/**/*-"${version}".yml
+  git -C release add releases/**/index.yml
+  git -C release add .final_builds/**/index.yml
+  git -C release add .final_builds/**/**/index.yml
+  git -C release commit -m "Final release for ${name} at ${version}"
+}
+
+create_final_tarball() {
+  local name=$1
+  local version=$2
+
+  bosh cr "release/releases/${name}/${name}-${version}.yml" --dir release --tarball "release-tarball/${name}-${version}.tgz"
+}
+
+main() {
+  local name
+  local version
+  name="$(get_name)"
+  version="$(get_version)"
+  write_private_yml
+
+  if release_version_exists "${version}"; then
+    echo "Version ${version} is already released"
+  else
+    finalize_release "${version}"
+    commit_changes "${name}" "${version}"
+  fi
+
+  create_final_tarball "${name}" "${version}"
+}
+
+main "$@"

--- a/tasks/cf-release/finalize-buildpack-release/task.yml
+++ b/tasks/cf-release/finalize-buildpack-release/task.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: coredeps/core-deps-ci
+inputs:
+- name: core-deps-ci
+- name: release
+- name: buildpack-release-tarball
+outputs:
+- name: release
+- name: release-tarball
+- name: version
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+run:
+  path: core-deps-ci/tasks/cf-release/finalize-buildpack-release/run

--- a/tasks/cf-release/update-buildpack-release-trigger/run
+++ b/tasks/cf-release/update-buildpack-release-trigger/run
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+buildpack_name="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .name)"
+old_version="$(cat "buildpack-release-trigger/${buildpack_name}")"
+new_version="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .version | cut -d'-' -f1)"
+
+if [[ "${old_version}" != "${new_version}" ]]; then
+  echo "Updating trigger to ${new_version}"
+  echo -n "${new_version}" | aws s3 cp - "s3://${BUCKET}/${buildpack_name}"
+else
+  echo "Version ${new_version} is already released"
+fi

--- a/tasks/cf-release/update-buildpack-release-trigger/task.yml
+++ b/tasks/cf-release/update-buildpack-release-trigger/task.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: coredeps/core-deps-ci
+inputs:
+- name: core-deps-ci
+- name: buildpack-release-tarball
+- name: buildpack-release-trigger
+params:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  BUCKET:
+run:
+  path: core-deps-ci/tasks/cf-release/update-buildpack-release-trigger/run

--- a/tasks/cf-release/upload-bosh-release/run
+++ b/tasks/cf-release/upload-bosh-release/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source cf-deployment-concourse-tasks/shared-functions
+setup_bosh_env_vars
+
+bosh -n upload-release release-tarball/*.tgz

--- a/tasks/cf-release/upload-bosh-release/task.yml
+++ b/tasks/cf-release/upload-bosh-release/task.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/ci
+    tag: latest
+inputs:
+- name: core-deps-ci
+- name: cf-deployment-concourse-tasks
+- name: bbl-state
+  optional: true
+- name: toolsmiths-env
+  optional: true
+- name: release-tarball
+run:
+  path: core-deps-ci/tasks/cf-release/upload-bosh-release/run
+
+params:
+  BBL_STATE_DIR: bbl-state

--- a/tasks/cf-release/write-buildpack-release-trigger-file/run
+++ b/tasks/cf-release/write-buildpack-release-trigger-file/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Last released on $(date)" > buildpack-release-trigger-file/file

--- a/tasks/cf-release/write-buildpack-release-trigger-file/task.yml
+++ b/tasks/cf-release/write-buildpack-release-trigger-file/task.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: coredeps/core-deps-ci
+inputs:
+- name: core-deps-ci
+run:
+  path: core-deps-ci/tasks/cf-release/write-buildpack-release-trigger-file/run
+outputs:
+- name: buildpack-release-trigger-file

--- a/tasks/create-bosh-release-reminder-story/run.sh
+++ b/tasks/create-bosh-release-reminder-story/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+content=$(cat << EOF
+{
+  "before_id": $TRACKER_RELEASE_REMINDER_MARKER_STORY,
+  "estimate": 0,
+  "name": "**Release:** Buildpack BOSH Releases",
+  "description": "Publish buildpack BOSH releases for OSS CF and for TAS.\n\nSee [release runbook](https://github.com/pivotal-cf/tanzu-buildpacks/wiki/Releasing-CF-Buildpacks) for details.",
+  "tasks": [
+    { "description": "Publish OSS BOSH releases" },
+    { "description": "Publish offline (TAS) BOSH releases" }
+  ],
+  "labels": ["release", "bosh"]
+}
+EOF
+)
+
+response=$(curl -s \
+    -X POST \
+    -H "X-TrackerToken: $TRACKER_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$content" \
+    "https://www.pivotaltracker.com/services/v5/projects/$TRACKER_PROJECT_ID/stories")
+
+echo "$response"
+
+if [[ "$response" == *'"error":'* ]]; then
+    echo "Error creating story"
+    exit 1
+else
+  echo "Story created successfully"
+fi

--- a/tasks/create-bosh-release-reminder-story/task.yml
+++ b/tasks/create-bosh-release-reminder-story/task.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/ci
+
+inputs:
+  - name: buildpacks-ci
+
+run:
+  path: buildpacks-ci/tasks/create-bosh-release-reminder-story/run.sh
+
+params:
+  TRACKER_API_TOKEN:
+  TRACKER_PROJECT_ID:
+  TRACKER_RELEASE_REMINDER_MARKER_STORY:


### PR DESCRIPTION
This PR migrates the CI from https://github.com/cloudfoundry/core-deps-ci to this repo.

There will likely need to be some work to merge the teams in CI, as running `./bin/update-pipelines` likely won't be sufficient to migrate all the pipelines. However, I think that work is better done as a separate refactor to use `ytt` for all pipelines, rather than trying to merge the teams first.

Once this PR is merged, we can unblock the corresponding PR: https://github.com/cloudfoundry/core-deps-ci/pull/48