### PR TITLE
new dep version lines: tracker story -> github event

### DIFF
--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -108,12 +108,6 @@ end
 def get_git_repo(buildpack)
   bp_uri = "cloudfoundry/#{buildpack}-buildpack"
 end
-
-def read_tracker_story_id(tracker_story_dir)
-  Dir.glob("#{tracker_story_dir}/id").first do |file|
-    return File.read(file).strip
-  end
-end
 %>
 
 resource_types:
@@ -241,12 +235,9 @@ version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version
     - task: create-new-version-line-story
       file: buildpacks-ci/tasks/create-new-version-line-story/create-new-version-line-story.yml
       params:
-        TRACKER_PROJECT_ID: '{{cf-buildpacks-private-tracker-id}}'
-        TRACKER_REQUESTER_ID: '{{cf-buildpacks-requester-id}}'
-        TRACKER_API_TOKEN: {{pivotal-tracker-api-token}}
         BUILDPACKS: <%= dep['buildpacks'].keys.join(' ') %>
         EXISTING_VERSION_LINES: <%= version_lines.join(' ') %>
-        TRACKER_BEFORE_ID: '{{cf-buildpacks-new-version-line-release-marker-story-id}}'
+        GITHUB_TOKEN: ((buildpacks-github-token))
 <% end %>
 
 <% version_lines.each do |line| %>
@@ -292,13 +283,11 @@ version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version
           - name: all-monitored-deps
   <% end %>
   <% if dep_name.downcase == 'node' && line.downcase == 'node-lts' %>
-    - task: create-tracker-story
+    - task: create-new-version-line-story-node
       file: buildpacks-ci/tasks/create-new-version-line-story/create_node_lts.yml
       params:
-        TRACKER_PROJECT_ID: '{{cf-buildpacks-rel-eng-tracker-id}}'
-        TRACKER_REQUESTER_ID: '{{cf-buildpacks-requester-id}}'
-        TRACKER_API_TOKEN: {{pivotal-tracker-api-token}}
         BUILDPACKS: <%= dep['buildpacks'].select{ |_, bp_data| bp_uses_line?(bp_data,line) }.keys.join(' ') %>
+        GITHUB_TOKEN: ((buildpacks-github-token))
   <% else %>
     - task: create-tracker-story
       file: buildpacks-ci/tasks/build-binary-new/create.yml
@@ -433,14 +422,10 @@ version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version
       DEPRECATION_MATCH: <%= line_hash['match'] %>
     output_mapping:
       artifacts: buildpack
-  - task: get-tracker-story-id
-    file: buildpacks-ci/tasks/get-dep-update-tracker-story-id/task.yml
   - put: <%= bp_name %>-pull-request
     params:
       repo_location: buildpack
-      tracker_story_id_location: tracker-story-id
       title: <%= "Updating version for #{dep_name} for #{line_hash['line']} " %>
-      <%# Adding a tracker story id because we have have configured cfgitbot to ignore such PRs %>
       branch_prefix: "pr-by-releng-bot"
       auto_merge: false
       base: develop

--- a/tasks/create-new-version-line-story/create-new-version-line-story.yml
+++ b/tasks/create-new-version-line-story/create-new-version-line-story.yml
@@ -13,11 +13,8 @@ run:
   path: bash
   args:
     - -cl
-    - gem install tracker_api && buildpacks-ci/tasks/create-new-version-line-story/create-new-version-line-story.rb
+    - buildpacks-ci/tasks/create-new-version-line-story/create-new-version-line-story.rb
 params:
-  TRACKER_API_TOKEN:
-  TRACKER_PROJECT_ID:
-  TRACKER_REQUESTER_ID:
   BUILDPACKS:
   EXISTING_VERSION_LINES:
-  TRACKER_BEFORE_ID:
+  GITHUB_TOKEN:

--- a/tasks/create-new-version-line-story/create_node_lts.rb
+++ b/tasks/create-new-version-line-story/create_node_lts.rb
@@ -2,7 +2,7 @@
 require 'fileutils'
 require 'json'
 require 'yaml'
-require 'tracker_api'
+require_relative './dispatch.rb'
 
 BUILDPACKS = ENV['BUILDPACKS']
                  .split(' ')
@@ -16,38 +16,10 @@ data = JSON.parse(open('source/data.json').read)
 name = data.dig('source', 'name')
 version = data.dig('version', 'ref')
 
-tracker_client = TrackerApi::Client.new(token: ENV['TRACKER_API_TOKEN'])
-buildpack_project = tracker_client.project(ENV['TRACKER_PROJECT_ID'])
-
 if File.file?('all-monitored-deps/data.json')
   all_monitored_deps = JSON.parse(open('all-monitored-deps/data.json').read)
   data['packages'] = all_monitored_deps
 end
 
-story_params = {
-    name: "Build and/or Include new Node LTS version: #{name} #{version}",
-    description: "A new LTS version of node has been found. Make sure that the Node Buildpack contains it and that the Ruby and .NET Core Buildpacks are updated by automation\n"+
-    "```\n#{data.to_yaml}\n```\n",
-    estimate: 0,
-    labels: (['deps', name] + BUILDPACKS).uniq,
-    requested_by_id: ENV['TRACKER_REQUESTER_ID'].to_i,
-    owner_ids: [ENV['TRACKER_REQUESTER_ID'].to_i]
-}
-
-story = buildpack_project.create_story(story_params)
-
-puts "Created tracker story #{story.id}"
-
-system('rsync -a builds/ builds-artifacts/')
-raise('Could not copy builds to builds artifacts') unless $?.success?
-Dir.chdir('builds-artifacts') do
-  GitClient.set_global_config('user.email', 'cf-buildpacks-eng@pivotal.io')
-  GitClient.set_global_config('user.name', 'CF Buildpacks Team CI Server')
-
-  version = data.dig('version', 'ref')
-  FileUtils.mkdir_p("binary-builds-new/#{data.dig('source', 'name')}")
-  File.write("binary-builds-new/#{data.dig('source', 'name')}/#{version}.json", {tracker_story_id: story.id}.to_json)
-
-  GitClient.add_file("binary-builds-new/#{data.dig('source', 'name')}/#{version}.json")
-  GitClient.safe_commit("Create Tracker Story #{data.dig('source', 'name')} - #{version}")
-end
+puts "Sending dispatch to create github issue..."
+send_dispatch(name, version, data, ENV['GITHUB_TOKEN'])

--- a/tasks/create-new-version-line-story/create_node_lts.yml
+++ b/tasks/create-new-version-line-story/create_node_lts.yml
@@ -7,7 +7,6 @@ image_resource:
 inputs:
   - name: buildpacks-ci
   - name: source
-  - name: builds
   - name: all-monitored-deps
     optional: true
 outputs:
@@ -16,9 +15,7 @@ run:
   path: bash
   args:
     - -cl
-    - gem install tracker_api && buildpacks-ci/tasks/create-new-version-line-story/create_node_lts.rb
+    - buildpacks-ci/tasks/create-new-version-line-story/create_node_lts.rb
 params:
-  TRACKER_API_TOKEN:
-  TRACKER_PROJECT_ID:
-  TRACKER_REQUESTER_ID:
   BUILDPACKS:
+  GITHUB_TOKEN:

--- a/tasks/create-new-version-line-story/dispatch.rb
+++ b/tasks/create-new-version-line-story/dispatch.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+def send_dispatch(name, version, jsonData, token)
+  jsonStr = JSON.generate(jsonData)
+  uri = URI.parse("https://api.github.com/repos/cloudfoundry/buildpacks-github-config/dispatches")
+  request = Net::HTTP::Post.new(uri)
+  request["Authorization"] = "token #{token}"
+  request.body = "{
+                \"event_type\": \"new-version-line\",
+                \"client_payload\":{
+                  \"Name\": \"#{name}\",
+                  \"Version\": \"#{version}\",
+                  \"DependencyJSON\": #{jsonStr}
+                }
+              }"
+  req_options = {
+    use_ssl: uri.scheme == "https",
+  }
+
+  response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+    http.request(request)
+  end
+  response.value()
+end


### PR DESCRIPTION
When depwatcher detects new version lines, it used to create a story in the tracker project to remind engineers to include it in the dependency-build config. Instead of API call to tracker to create a story, call Github API to send a dispatch of type `new-version-line` to the "cloudfoundry/buildpacks-github-config" repo. This change also requires a dispatch handler at that repo which uses the data to create an issue and add it to the right project. (https://github.com/cloudfoundry/buildpacks-github-config/pull/24)