### PR TITLE
Make mail module available dynamically

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -734,6 +734,8 @@ class DependencyBuild
       '--with-cc-opt=-fPIC -pie',
       '--with-ld-opt=-fPIC -pie -z now',
       '--with-compat',
+      '--with-mail=dynamic',
+      '--with-mail_ssl_module',
       '--with-stream=dynamic',
       '--with-http_sub_module',
     ]
@@ -792,6 +794,8 @@ class DependencyBuild
             '--with-cc-opt=-fPIC -pie',
             '--with-ld-opt=-fPIC -pie -z now',
             '--with-compat',
+            '--with-mail=dynamic',
+            '--with-mail_ssl_module',
             '--with-stream=dynamic',
           )
           Runner.run('make', '-j2')

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -355,6 +355,8 @@ module DependencyBuild
             '--with-cc-opt=-fPIC -pie',
             '--with-ld-opt=-fPIC -pie -z now',
             '--with-compat',
+            '--with-mail=dynamic',
+            '--with-mail_ssl_module',
             '--with-stream=dynamic',
             '--with-http_sub_module',
           ]
@@ -452,6 +454,8 @@ module DependencyBuild
               '--with-cc-opt=-fPIC -pie',
               '--with-ld-opt=-fPIC -pie -z now',
               '--with-compat',
+              '--with-mail=dynamic',
+              '--with-mail_ssl_module',
               '--with-stream=dynamic',
             )
             Runner.run('make', '-j2')


### PR DESCRIPTION
The [NGINX mail module](https://nginx.org/en/docs/mail/ngx_mail_core_module.html) is a core NGINX module, useful for constructing proxies (my use-case). There are built-in configure flags for it; [see docs here.](https://nginx.org/en/docs/configure.html#:~:text=%2D%2Dwith%2Dmail%3Ddynamic,run%20this%20module.) 

This PR builds the module dynamically so it will not change the buildpack's behavior for anyone who doesn't deliberately enable it. Including this module in the available dynamic modules removes the need for people (eg me) to separately maintain builds that are compatible with each new version of nginx supported by the buildpack!