### PR TITLE
Deprecate Nodejs v14.x (EOL)

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -202,9 +202,6 @@ dependencies:
     buildpacks:
       nodejs:
         lines:
-          - line: 14.X.X
-            deprecation_date: 2023-04-30
-            link: https://github.com/nodejs/Release
           - line: 16.X.X
             deprecation_date: 2023-09-11
             link: https://github.com/nodejs/Release


### PR DESCRIPTION
Part of https://github.com/cloudfoundry/nodejs-buildpack/issues/601.

Ref: Ref: https://nodejs.dev/en/about/releases/