### PR TITLE
minor fix in cf-release pipeline

### DIFF
--- a/bin/update-pipelines-core-deps-team
+++ b/bin/update-pipelines-core-deps-team
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# TODO Temporary script
+# Remove this script when core-deps team pipelines are
+# merged into the main team (Context: github.com/cloudfoundry/buildpacks-ci/pull/271)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && cd .. && pwd)"
+target="buildpacks"
+filter=
+
+login() {
+  fly -t "$target" login -n core-deps -b
+}
+
+check_login_status() {
+  current_team="$(yq e .targets.buildpacks.team ~/.flyrc)"
+  if [[ "${current_team}" != "core-deps" ]]; then
+    login
+  fi
+
+  fly -t "$target" status >/dev/null 2>&1 || login
+}
+
+set_pipelines() {
+  for pipeline_dir in "$REPO_ROOT"/pipelines/*; do
+    pipeline_name="$(basename "${pipeline_dir%.yml}")"
+    if [[ $filter != "" ]] && [[ ! $pipeline_name =~ $filter ]]; then
+      continue
+    fi
+
+    echo "Setting $pipeline_name"
+    pipeline_config="$(ytt -f "$pipeline_dir")"
+    fly -t "$target" set-pipeline -p "$pipeline_name" -c <(echo "$pipeline_config")
+  done
+}
+
+main() {
+  if [ "$#" -eq 1 ]; then
+    filter="$1"
+  fi
+
+  check_login_status
+  set_pipelines
+}
+
+main "$@"

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -20,6 +20,7 @@ resources:
   type: git
   source:
     uri: git@github.com:cloudfoundry/buildpacks-ci.git
+    private_key: ((buildpacks-ci-deploy-key.private_key))
 
 - name: cf-deployment-concourse-tasks
   type: git


### PR DESCRIPTION
- it looks like git ssh resource won't run without a private_key (partially revert #277)
- Since we haven't yet migrated core-deps team pipelines to main team yet (#271), temporarily copy-in update-pipeline script from the old core-deps repo for current daytoday use.