### PR TITLE
Add Nginx latest stable/mainline versions for nginx/static

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -167,9 +167,9 @@ dependencies:
           #! each odd version line (ex. 1.19) is the "mainline"
           #! the even numbered version line that precedes the mainline is the associated stable version line.
           #! See explanation of release cadence: https://www.nginx.com/blog/nginx-1-18-1-19-released/
-          - line: 1.22.X
+          - line: 1.24.X
             link: https://nginx.org/
-          - line: 1.23.X
+          - line: 1.25.X
             link: https://nginx.org/
     versions_to_keep: 2
   openresty:
@@ -186,15 +186,15 @@ dependencies:
           #! nginx deprecation dates are 1 year after the mainline release date
           #! each odd version line (ex. 1.19) is the "mainline"
           #! the even numbered version line that precedes the mainline is the associated stable version line.
-          - line: 1.22.X
+          - line: 1.24.X
             link: https://nginx.org/
-          - line: 1.23.X
+          - line: 1.25.X
             link: https://nginx.org/
       staticfile:
         lines:
-          - line: 1.22.X
+          - line: 1.24.X
             link: https://nginx.org/
-          - line: 1.23.X
+          - line: 1.25.X
             link: https://nginx.org/
     source_type: nginx
     versions_to_keep: 2


### PR DESCRIPTION
Solves https://github.com/cloudfoundry/buildpacks-github-config/issues/28 and https://github.com/cloudfoundry/buildpacks-github-config/issues/29

## Note
Also, the latest stable version (1.24.x) was added to the Buildpacks. We had no track of this update in any issue but checking the Nginx [news page](https://nginx.org/) we can see the 1.24 release on April 11th. 

![Screenshot 2023-05-24 at 4 01 59 PM](https://github.com/cloudfoundry/buildpacks-ci/assets/17348387/e24f6b26-5280-4a49-8a17-d610acc1ee8a)
