### PR TITLE
keep updating python patches in node BP

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -289,6 +289,11 @@ dependencies:
           - line: 3.11.X
             deprecation_date: 2027-10-24
             link: https://www.python.org/dev/peps/pep-0664/
+      nodejs:
+        lines:
+          - line: 3.10.X
+            deprecation_date: 2026-10-04
+            link: https://www.python.org/dev/peps/pep-0619/
         removal_strategy: remove_all
     versions_to_keep: 1
   r:


### PR DESCRIPTION
I noticed that the python dep in nodejs buildpack never got updated since it was manually added.[1]

We should probably keep up with patches to aviod CVEs in the shipped buildpack

1: https://github.com/cloudfoundry/nodejs-buildpack/blame/v1.8.11/manifest.yml#L120-L135