### PR TITLE
Fix error in create-node-node-lts-story job

### DIFF
--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -296,11 +296,12 @@ version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version
         TRACKER_REQUESTER_ID: '{{cf-buildpacks-requester-id}}'
         TRACKER_API_TOKEN: {{pivotal-tracker-api-token}}
         BUILDPACKS: <%= dep['buildpacks'].select{ |_, bp_data| bp_uses_line?(bp_data,line) }.keys.join(' ') %>
-  <% end %>
     - put: builds
       params:
         repository: builds-artifacts
         rebase: true
+  <% end %>
+
 
   <% dep['copy-stacks']&.each do |stack| %>
 - name: copy-<%= dep_name.downcase %>-<%= line.downcase %>-<%= stack.downcase %>


### PR DESCRIPTION
# Context

In #278 the changes that were introduced affected the `lts` NodeJS story creation. Now that the `tracker-client` is not used it won't produce output artifacts so the `push` step in [this](https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/create-node-node-lts-story/builds/32) job fails because there is nothing to push.

# Solution

The removal of the `put` step when the story is `node-lts` solves the issue. Changes are already applied and [work successfully.](https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/create-node-node-lts-story/builds/33)