### PR TITLE
depwatcher/miniconda: adapt to new format

### DIFF
--- a/dockerfiles/depwatcher/spec/depwatcher/miniconda_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/miniconda_spec.cr
@@ -7,33 +7,33 @@ Spec2.describe Depwatcher::Miniconda do
   subject { described_class.new.tap { |s| s.client = client } }
   before do
     client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
-    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
-    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
   end
 
   describe "#check" do
-    it "returns real linux releases for miniconda3-py37 sorted" do
-      expect(subject.check("3.7").map(&.ref)).to eq ["4.8.2"]
+    it "returns real linux releases for miniconda3-py39 sorted" do
+      expect(subject.check("3.9").map(&.ref)).to eq ["22.11.1", "23.1.0",
+      "23.3.1", "23.5.0", "23.5.1", "23.5.2"]
     end
     it "returns real linux releases for miniconda3-py38 sorted" do
-      expect(subject.check("3.8").map(&.ref)).to eq ["4.8.2"]
+      expect(subject.check("3.8").map(&.ref)).to eq ["22.11.1", "23.1.0",
+      "23.3.1", "23.5.0", "23.5.1", "23.5.2"]
     end
   end
 
   describe "#in" do
-    it "returns the release version, url, md5 for miniconda37" do
-      obj = subject.in("3.7", "4.8.2")
-      expect(obj.ref).to eq "4.8.2"
-      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh"
-      expect(obj.md5).to eq "87e77f097f6ebb5127c77662dfc3165e"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    it "returns the release version, url, sha256 for miniconda39" do
+      obj = subject.in("3.9", "23.1.0")
+      expect(obj.ref).to eq "23.1.0"
+      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh"
+      expect(obj.sha256).to eq "5dc619babc1d19d6688617966251a38d245cb93d69066ccde9a013e1ebb5bf18"
     end
-    it "returns the release version, url, md5 for miniconda38" do
-      obj = subject.in("3.8", "4.8.2")
-      expect(obj.ref).to eq "4.8.2"
-      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh"
-      expect(obj.md5).to eq "cbda751e713b5a95f187ae70b509403f"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    it "returns the release version, url, sha256 for miniconda38" do
+      obj = subject.in("3.8", "23.1.0")
+      expect(obj.ref).to eq "23.1.0"
+      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh"
+      expect(obj.sha256).to eq "640b7dceee6fad10cb7e7b54667b2945c4d6f57625d062b2b0952b7f3a908ab7"
    end
- end
+  end
 end

--- a/dockerfiles/depwatcher/spec/fixtures/miniconda.html
+++ b/dockerfiles/depwatcher/spec/fixtures/miniconda.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Miniconda installer archive</title>
+  <title>Index of /</title>
   <style type="text/css">
 a, a:active {text-decoration: none; color: blue;}
 a:visited {color: #48468F;}
@@ -17,2794 +17,4816 @@ address {color: #787878; padding-top: 10px;}
   </style>
 </head>
 <body>
-  <h2>Miniconda installer archive</h2>
+  <h2>Index of /</h2>
   <table>
     <tr>
       <th>Filename</th>
       <th>Size</th>
       <th>Last Modified</th>
-      <th>MD5</th>
+      <th>SHA256</th>
     </tr>
     <tr>
-      <td><a href="Miniconda3-latest-Linux-ppc64le.sh">Miniconda3-latest-Linux-ppc64le.sh</a></td>
-      <td class="s">50.1M</td>
-      <td>2020-03-11 10:37:04</td>
-      <td>e50662a93f3f5e56ef2d3fdfaf2f8e91</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-latest-Linux-x86_64.sh">Miniconda3-latest-Linux-x86_64.sh</a></td>
-      <td class="s">81.1M</td>
-      <td>2020-03-11 10:37:27</td>
-      <td>87e77f097f6ebb5127c77662dfc3165e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-latest-MacOSX-x86_64.pkg">Miniconda3-latest-MacOSX-x86_64.pkg</a></td>
-      <td class="s">61.3M</td>
-      <td>2020-03-11 10:39:17</td>
-      <td>43966070a98a8bf590f24d9b44098e11</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-latest-MacOSX-x86_64.sh">Miniconda3-latest-MacOSX-x86_64.sh</a></td>
-      <td class="s">50.3M</td>
-      <td>2020-03-11 10:37:45</td>
-      <td>e0320c20ea13d04407424ecf57b70eaf</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-latest-Windows-x86.exe">Miniconda3-latest-Windows-x86.exe</a></td>
-      <td class="s">52.2M</td>
-      <td>2020-03-11 10:38:51</td>
-      <td>a3c6c76ab13ff195f2ead63fac87e070</td>
+      <td><a href=".winzip/">.winzip/</a></td>
+      <td class="s">- &nbsp;</td>
+      <td>&nbsp;</td>
+      <td>&lt;directory&gt;</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-latest-Windows-x86_64.exe">Miniconda3-latest-Windows-x86_64.exe</a></td>
-      <td class="s">51.6M</td>
-      <td>2020-03-11 10:38:26</td>
-      <td>20d6bd9b3bd62f1fd874315b6b38c159</td>
+      <td class="s">73.2M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>00e8370542836862d4c790aa8966f1d7344a8addd4b766004febcb23f40e2914</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-Linux-ppc64le.sh">Miniconda3-py37_4.8.2-Linux-ppc64le.sh</a></td>
-      <td class="s">50.1M</td>
-      <td>2020-03-11 10:37:04</td>
-      <td>e50662a93f3f5e56ef2d3fdfaf2f8e91</td>
+      <td><a href="Miniconda3-latest-MacOSX-x86_64.sh">Miniconda3-latest-MacOSX-x86_64.sh</a></td>
+      <td class="s">69.6M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>1622e7a0fa60a7d3d892c2d8153b54cd6ffe3e6b979d931320ba56bd52581d4b</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-Linux-x86_64.sh">Miniconda3-py37_4.8.2-Linux-x86_64.sh</a></td>
-      <td class="s">81.1M</td>
-      <td>2020-03-11 10:37:27</td>
-      <td>87e77f097f6ebb5127c77662dfc3165e</td>
+      <td><a href="Miniconda3-latest-MacOSX-x86_64.pkg">Miniconda3-latest-MacOSX-x86_64.pkg</a></td>
+      <td class="s">69.2M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>2236a243b6cbe6f16ec324ecc9e631102494c031d41791b44612bbb6a7a1a6b4</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-MacOSX-x86_64.pkg">Miniconda3-py37_4.8.2-MacOSX-x86_64.pkg</a></td>
-      <td class="s">61.3M</td>
-      <td>2020-03-11 10:39:17</td>
-      <td>43966070a98a8bf590f24d9b44098e11</td>
+      <td><a href="Miniconda3-latest-MacOSX-arm64.sh">Miniconda3-latest-MacOSX-arm64.sh</a></td>
+      <td class="s">68.6M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>c8f436dbde130f171d39dd7b4fca669c223f130ba7789b83959adc1611a35644</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-MacOSX-x86_64.sh">Miniconda3-py37_4.8.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">50.3M</td>
-      <td>2020-03-11 10:37:45</td>
-      <td>e0320c20ea13d04407424ecf57b70eaf</td>
+      <td><a href="Miniconda3-latest-MacOSX-arm64.pkg">Miniconda3-latest-MacOSX-arm64.pkg</a></td>
+      <td class="s">68.1M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>837371f3b6e8ae2b65bdfc8370e6be812b564ff9f40bcd4eb0b22f84bf9b4fe5</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-Windows-x86.exe">Miniconda3-py37_4.8.2-Windows-x86.exe</a></td>
-      <td class="s">52.2M</td>
-      <td>2020-03-11 10:38:51</td>
-      <td>a3c6c76ab13ff195f2ead63fac87e070</td>
+      <td><a href="Miniconda3-latest-Linux-x86_64.sh">Miniconda3-latest-Linux-x86_64.sh</a></td>
+      <td class="s">98.4M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py37_4.8.2-Windows-x86_64.exe">Miniconda3-py37_4.8.2-Windows-x86_64.exe</a></td>
-      <td class="s">51.6M</td>
-      <td>2020-03-11 10:38:26</td>
-      <td>20d6bd9b3bd62f1fd874315b6b38c159</td>
+      <td><a href="Miniconda3-latest-Linux-s390x.sh">Miniconda3-latest-Linux-s390x.sh</a></td>
+      <td class="s">94.5M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>221a4cd7f0a9275c3263efa07fa37385746de884f4306bb5d1fe5733ca770550</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py38_4.8.2-Linux-ppc64le.sh">Miniconda3-py38_4.8.2-Linux-ppc64le.sh</a></td>
-      <td class="s">50.5M</td>
-      <td>2020-03-11 10:39:28</td>
-      <td>8dbe9589f7ba6e17428ac57658802eb2</td>
+      <td><a href="Miniconda3-latest-Linux-ppc64le.sh">Miniconda3-latest-Linux-ppc64le.sh</a></td>
+      <td class="s">77.3M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>92237cb2a443dd15005ec004f2f744b14de02cd5513a00983c2f191eb43d1b29</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py38_4.8.2-Linux-x86_64.sh">Miniconda3-py38_4.8.2-Linux-x86_64.sh</a></td>
-      <td class="s">85.7M</td>
-      <td>2020-03-11 10:39:44</td>
-      <td>cbda751e713b5a95f187ae70b509403f</td>
+      <td><a href="Miniconda3-latest-Linux-aarch64.sh">Miniconda3-latest-Linux-aarch64.sh</a></td>
+      <td class="s">76.4M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>3962738cfac270ae4ff30da0e382aecf6b3305a12064b196457747b157749a7a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-py38_4.8.2-MacOSX-x86_64.pkg">Miniconda3-py38_4.8.2-MacOSX-x86_64.pkg</a></td>
-      <td class="s">62.3M</td>
-      <td>2020-03-11 10:40:18</td>
-      <td>c6f0a7a76bbece0096af55367f926cf7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-py38_4.8.2-MacOSX-x86_64.sh">Miniconda3-py38_4.8.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">51.3M</td>
-      <td>2020-03-11 10:39:58</td>
-      <td>589972cf83097c97e70c41813f2fe3a2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-py38_4.8.2-Windows-x86_64.exe">Miniconda3-py38_4.8.2-Windows-x86_64.exe</a></td>
-      <td class="s">52.7M</td>
-      <td>2020-03-11 10:40:08</td>
-      <td>da6a97905f458b0fd6ddf3224e6aa60c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-Linux-ppc64le.sh">Miniconda2-4.7.12.1-Linux-ppc64le.sh</a></td>
-      <td class="s">50.9M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>f00e3c5881c2629a9b516cc7a62bbc3c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-Linux-x86_64.sh">Miniconda2-4.7.12.1-Linux-x86_64.sh</a></td>
-      <td class="s">46.0M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>23bf3acd6aead6e91fb936fc185b033e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-MacOSX-x86_64.pkg">Miniconda2-4.7.12.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">47.8M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>a95e15427dad995ab0b373ad00ad6b58</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-MacOSX-x86_64.sh">Miniconda2-4.7.12.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">39.4M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>5a10de42eb90c1c21dbda191f1ec19b1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-Windows-x86.exe">Miniconda2-4.7.12.1-Windows-x86.exe</a></td>
-      <td class="s">48.7M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>5558fc87a4bd5a66d5b2969a04010712</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12.1-Windows-x86_64.exe">Miniconda2-4.7.12.1-Windows-x86_64.exe</a></td>
-      <td class="s">50.9M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>42b2cbdb3f066bb30758d3f64a2984b4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-Linux-ppc64le.sh">Miniconda2-latest-Linux-ppc64le.sh</a></td>
-      <td class="s">50.9M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>f00e3c5881c2629a9b516cc7a62bbc3c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-Linux-x86_64.sh">Miniconda2-latest-Linux-x86_64.sh</a></td>
-      <td class="s">46.0M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>23bf3acd6aead6e91fb936fc185b033e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-MacOSX-x86_64.pkg">Miniconda2-latest-MacOSX-x86_64.pkg</a></td>
-      <td class="s">47.8M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>a95e15427dad995ab0b373ad00ad6b58</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-MacOSX-x86_64.sh">Miniconda2-latest-MacOSX-x86_64.sh</a></td>
-      <td class="s">39.4M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>5a10de42eb90c1c21dbda191f1ec19b1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-Windows-x86.exe">Miniconda2-latest-Windows-x86.exe</a></td>
-      <td class="s">48.7M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>5558fc87a4bd5a66d5b2969a04010712</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-Windows-x86_64.exe">Miniconda2-latest-Windows-x86_64.exe</a></td>
-      <td class="s">50.9M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>42b2cbdb3f066bb30758d3f64a2984b4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-Linux-ppc64le.sh">Miniconda3-4.7.12.1-Linux-ppc64le.sh</a></td>
-      <td class="s">78.0M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>9de38932ed6a8865562e6057b578694f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-Linux-x86_64.sh">Miniconda3-4.7.12.1-Linux-x86_64.sh</a></td>
-      <td class="s">68.5M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>81c773ff87af5cfac79ab862942ab6b3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-MacOSX-x86_64.pkg">Miniconda3-4.7.12.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">59.8M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>b0c20eb2839bed5da0fc27fe49417f9a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-MacOSX-x86_64.sh">Miniconda3-4.7.12.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">49.4M</td>
-      <td>2019-10-25 14:32:09</td>
-      <td>621daddf9de519014c6c38e8923583b8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-Windows-x86.exe">Miniconda3-4.7.12.1-Windows-x86.exe</a></td>
-      <td class="s">54.0M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>77d39801e97498ef05231d95ab77dedb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12.1-Windows-x86_64.exe">Miniconda3-4.7.12.1-Windows-x86_64.exe</a></td>
-      <td class="s">51.5M</td>
-      <td>2019-10-25 14:32:08</td>
-      <td>7129ff5a947966c61cf69ec99fdf9c3d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-Linux-ppc64le.sh">Miniconda2-4.7.12-Linux-ppc64le.sh</a></td>
-      <td class="s">49.5M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>59325e5b37e93f39ab4b3987abe1b7dd</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-Linux-x86_64.sh">Miniconda2-4.7.12-Linux-x86_64.sh</a></td>
-      <td class="s">44.8M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>5a218d9dce3a77905d17ae87ac72a1e8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-MacOSX-x86_64.pkg">Miniconda2-4.7.12-MacOSX-x86_64.pkg</a></td>
-      <td class="s">47.8M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>2fa3c0be0885f8214d418c5dc41c1dc0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-MacOSX-x86_64.sh">Miniconda2-4.7.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">38.1M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>2498099a426fcaafd1068fd6d79e3a6d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-Windows-x86.exe">Miniconda2-4.7.12-Windows-x86.exe</a></td>
-      <td class="s">48.0M</td>
-      <td>2019-10-16 14:11:27</td>
-      <td>fff953eef0a5667a6aef16ed93e3460f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.12-Windows-x86_64.exe">Miniconda2-4.7.12-Windows-x86_64.exe</a></td>
-      <td class="s">50.0M</td>
-      <td>2019-10-16 14:11:25</td>
-      <td>5cb7dcc7233c7cddadf8645f2639a23f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-Linux-ppc64le.sh">Miniconda3-4.7.12-Linux-ppc64le.sh</a></td>
-      <td class="s">76.8M</td>
-      <td>2019-10-16 14:11:25</td>
-      <td>bd5c2331edcbe87391465e6acf2d3f10</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-Linux-x86_64.sh">Miniconda3-4.7.12-Linux-x86_64.sh</a></td>
-      <td class="s">67.2M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>0dba759b8ecfc8948f626fa18785e3d8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-MacOSX-x86_64.pkg">Miniconda3-4.7.12-MacOSX-x86_64.pkg</a></td>
-      <td class="s">59.8M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>66fd9a8285a955c6d892ba19be1f244e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-MacOSX-x86_64.sh">Miniconda3-4.7.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">48.2M</td>
-      <td>2019-10-16 14:11:27</td>
-      <td>677f38d5ab7e1ce4fef134068e3bd76a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-Windows-x86.exe">Miniconda3-4.7.12-Windows-x86.exe</a></td>
-      <td class="s">53.2M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>1528d82e68014e5b432ccaa3672db0cd</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.12-Windows-x86_64.exe">Miniconda3-4.7.12-Windows-x86_64.exe</a></td>
-      <td class="s">50.6M</td>
-      <td>2019-10-16 14:11:26</td>
-      <td>ca44ef9a5ac2ff0e088193a02d3ca807</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-Linux-ppc64le.sh">Miniconda2-4.7.10-Linux-ppc64le.sh</a></td>
-      <td class="s">58.9M</td>
-      <td>2019-07-29 09:15:37</td>
-      <td>dee73c820a4e3af712f0b3ff02f57264</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-Linux-x86_64.sh">Miniconda2-4.7.10-Linux-x86_64.sh</a></td>
-      <td class="s">49.7M</td>
-      <td>2019-07-29 09:15:39</td>
-      <td>3bc6ffc6cda8efa467926dfd92a30bca</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-MacOSX-x86_64.pkg">Miniconda2-4.7.10-MacOSX-x86_64.pkg</a></td>
-      <td class="s">56.4M</td>
-      <td>2019-07-29 09:15:39</td>
-      <td>20949521d9a76e37aca22a4052ece94f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-MacOSX-x86_64.sh">Miniconda2-4.7.10-MacOSX-x86_64.sh</a></td>
-      <td class="s">42.3M</td>
-      <td>2019-07-29 09:15:37</td>
-      <td>f540257a4b1df264e6f72c75f75620bb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-Windows-x86.exe">Miniconda2-4.7.10-Windows-x86.exe</a></td>
-      <td class="s">66.3M</td>
-      <td>2019-07-29 09:15:40</td>
-      <td>0be41914501356a9ec81c32b7872a182</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.7.10-Windows-x86_64.exe">Miniconda2-4.7.10-Windows-x86_64.exe</a></td>
-      <td class="s">71.7M</td>
-      <td>2019-07-29 09:15:39</td>
-      <td>b1f7ffe70409b9b68bd4bf550b67b621</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-Linux-ppc64le.sh">Miniconda3-4.7.10-Linux-ppc64le.sh</a></td>
-      <td class="s">82.6M</td>
-      <td>2019-07-29 09:15:39</td>
-      <td>f406a65d6362b33b22520186555c8d88</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-Linux-x86_64.sh">Miniconda3-4.7.10-Linux-x86_64.sh</a></td>
-      <td class="s">71.8M</td>
-      <td>2019-07-29 09:15:37</td>
-      <td>1c945f2b3335c7b2b15130b1b2dc5cf4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-MacOSX-x86_64.pkg">Miniconda3-4.7.10-MacOSX-x86_64.pkg</a></td>
-      <td class="s">68.0M</td>
-      <td>2019-07-29 09:15:38</td>
-      <td>b9974b2ef1b17b8be9b1fd2c619c6702</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-MacOSX-x86_64.sh">Miniconda3-4.7.10-MacOSX-x86_64.sh</a></td>
-      <td class="s">52.0M</td>
-      <td>2019-07-29 09:15:37</td>
-      <td>9cc5819a400a3fd5c7363792483fef1e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-Windows-x86.exe">Miniconda3-4.7.10-Windows-x86.exe</a></td>
-      <td class="s">67.4M</td>
-      <td>2019-07-29 09:15:38</td>
-      <td>d49f184edef5bdcb23afb14155b83cef</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.7.10-Windows-x86_64.exe">Miniconda3-4.7.10-Windows-x86_64.exe</a></td>
-      <td class="s">72.6M</td>
-      <td>2019-07-29 09:15:38</td>
-      <td>71130d69fd521f5f38448fa31e4d98de</td>
-    </tr>
-    <tr>
-      <td><a href="index.json">index.json</a></td>
-      <td class="s">2</td>
-      <td>2019-07-22 15:19:22</td>
-      <td>99914b932bd37a50b983c5e7c90ae93b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-Linux-x86_64.sh">Miniconda2-4.6.14-Linux-x86_64.sh</a></td>
-      <td class="s">43.0M</td>
-      <td>2019-04-19 10:23:43</td>
-      <td>faa7cb0b0c8986ac3cacdbbd00fe4168</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-MacOSX-x86_64.pkg">Miniconda2-4.6.14-MacOSX-x86_64.pkg</a></td>
-      <td class="s">38.0M</td>
-      <td>2019-04-19 10:23:49</td>
-      <td>e815dbeed2b01a9d746a371b360fe59d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-MacOSX-x86_64.sh">Miniconda2-4.6.14-MacOSX-x86_64.sh</a></td>
-      <td class="s">33.0M</td>
-      <td>2019-04-19 10:23:42</td>
-      <td>6665a5911f92dce1cf6d1021249af9db</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-Windows-x86.exe">Miniconda2-4.6.14-Windows-x86.exe</a></td>
-      <td class="s">57.0M</td>
-      <td>2019-04-19 10:23:45</td>
-      <td>a2eeae848b31353804b3d99a8251bca3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-Windows-x86_64.exe">Miniconda2-4.6.14-Windows-x86_64.exe</a></td>
-      <td class="s">61.3M</td>
-      <td>2019-04-19 10:23:44</td>
-      <td>f662cd2b2865d891870c9cf505922124</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-Linux-ppc64le.sh">Miniconda3-4.6.14-Linux-ppc64le.sh</a></td>
-      <td class="s">67.0M</td>
-      <td>2019-04-19 10:23:46</td>
-      <td>6d3bd64dfc436f38755cde1a3ad40799</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-Linux-x86_64.sh">Miniconda3-4.6.14-Linux-x86_64.sh</a></td>
-      <td class="s">67.1M</td>
-      <td>2019-04-19 10:23:47</td>
-      <td>718259965f234088d785cad1fbd7de03</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-MacOSX-x86_64.pkg">Miniconda3-4.6.14-MacOSX-x86_64.pkg</a></td>
-      <td class="s">49.9M</td>
-      <td>2019-04-19 10:23:49</td>
-      <td>f32cb8d30f695d70fa87151b9bc59be8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-MacOSX-x86_64.sh">Miniconda3-4.6.14-MacOSX-x86_64.sh</a></td>
-      <td class="s">44.0M</td>
-      <td>2019-04-19 10:23:42</td>
-      <td>ffa5f0eead5576fb26b7e6902f5eed09</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-Windows-x86.exe">Miniconda3-4.6.14-Windows-x86.exe</a></td>
-      <td class="s">55.0M</td>
-      <td>2019-04-19 10:23:50</td>
-      <td>845599d086810be499145082cc2acd8a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.6.14-Windows-x86_64.exe">Miniconda3-4.6.14-Windows-x86_64.exe</a></td>
-      <td class="s">58.4M</td>
-      <td>2019-04-19 10:23:48</td>
-      <td>bb90bcddd1422c79e182ee7e48abfc3d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.6.14-Linux-ppc64le.sh">Miniconda2-4.6.14-Linux-ppc64le.sh</a></td>
-      <td class="s">42.9M</td>
-      <td>2019-04-17 16:59:37</td>
-      <td>76eeccfcf127bb29ce71a279ebd185a9</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-Linux-ppc64le.sh">Miniconda2-4.5.12-Linux-ppc64le.sh</a></td>
-      <td class="s">42.9M</td>
-      <td>2019-01-02 10:05:16</td>
-      <td>e441328782c71c7ce71cc2a668df0451</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-Linux-x86.sh">Miniconda2-4.5.12-Linux-x86.sh</a></td>
-      <td class="s">39.0M</td>
-      <td>2019-01-02 10:05:16</td>
-      <td>56c90370226fd410c9b0086bd693d9c0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-Linux-x86_64.sh">Miniconda2-4.5.12-Linux-x86_64.sh</a></td>
-      <td class="s">42.8M</td>
-      <td>2019-01-02 10:05:15</td>
-      <td>4be03f925e992a8eda03758b72a77298</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-MacOSX-x86_64.pkg">Miniconda2-4.5.12-MacOSX-x86_64.pkg</a></td>
-      <td class="s">38.4M</td>
-      <td>2019-01-02 10:05:17</td>
-      <td>77ef30eea39537b6f914804207103823</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-MacOSX-x86_64.sh">Miniconda2-4.5.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">33.1M</td>
-      <td>2019-01-02 10:05:14</td>
-      <td>76041da218ab91e2c9538a5dc19cd14e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-Windows-x86.exe">Miniconda2-4.5.12-Windows-x86.exe</a></td>
-      <td class="s">55.0M</td>
-      <td>2019-01-02 10:05:17</td>
-      <td>6c4300ec4aac538c47e82506277c31b8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.12-Windows-x86_64.exe">Miniconda2-4.5.12-Windows-x86_64.exe</a></td>
-      <td class="s">59.2M</td>
-      <td>2019-01-02 10:05:16</td>
-      <td>e7626f133e803ac970fe963507c62dc1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-latest-Linux-x86.sh">Miniconda2-latest-Linux-x86.sh</a></td>
-      <td class="s">39.0M</td>
-      <td>2019-01-02 10:05:16</td>
-      <td>56c90370226fd410c9b0086bd693d9c0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-Linux-x86.sh">Miniconda3-4.5.12-Linux-x86.sh</a></td>
-      <td class="s">62.7M</td>
-      <td>2019-01-02 10:05:14</td>
-      <td>38f586a269ac74f5f10195867c4f96ae</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-Linux-x86_64.sh">Miniconda3-4.5.12-Linux-x86_64.sh</a></td>
-      <td class="s">66.6M</td>
-      <td>2019-01-02 10:05:18</td>
-      <td>866ae9dff53ad0874e1d1a60b1ad1ef8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-MacOSX-x86_64.pkg">Miniconda3-4.5.12-MacOSX-x86_64.pkg</a></td>
-      <td class="s">49.7M</td>
-      <td>2019-01-02 10:05:14</td>
-      <td>06768d099ef6f34120f9249caaa32cb3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-MacOSX-x86_64.sh">Miniconda3-4.5.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">43.3M</td>
-      <td>2019-01-02 10:05:14</td>
-      <td>a583d1e174e1dc960e87fb4b026a9370</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-Windows-x86.exe">Miniconda3-4.5.12-Windows-x86.exe</a></td>
-      <td class="s">52.5M</td>
-      <td>2019-01-02 10:05:14</td>
-      <td>ec5c5c29892ad45bd840f8ccaf2cbc03</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.12-Windows-x86_64.exe">Miniconda3-4.5.12-Windows-x86_64.exe</a></td>
-      <td class="s">56.1M</td>
-      <td>2019-01-02 10:05:15</td>
-      <td>06c4feeabce6a35ef4033f94a3f5a998</td>
+      <td><a href="Miniconda3-latest-Windows-x86.exe">Miniconda3-latest-Windows-x86.exe</a></td>
+      <td class="s">67.8M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-latest-Linux-x86.sh">Miniconda3-latest-Linux-x86.sh</a></td>
       <td class="s">62.7M</td>
       <td>2019-01-02 10:05:14</td>
-      <td>38f586a269ac74f5f10195867c4f96ae</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-Linux-ppc64le.sh">Miniconda2-4.5.11-Linux-ppc64le.sh</a></td>
-      <td class="s">39.7M</td>
-      <td>2018-09-04 11:57:24</td>
-      <td>b85a019f75ff87714eb3254dd1f3390f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-Linux-x86.sh">Miniconda2-4.5.11-Linux-x86.sh</a></td>
-      <td class="s">36.1M</td>
-      <td>2018-09-04 11:57:25</td>
-      <td>187c460ffc6ea5f890b512320b2994c6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-Linux-x86_64.sh">Miniconda2-4.5.11-Linux-x86_64.sh</a></td>
-      <td class="s">39.9M</td>
-      <td>2018-09-04 11:57:25</td>
-      <td>458324438b7b0e5afcc272b63d44195d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-MacOSX-x86_64.pkg">Miniconda2-4.5.11-MacOSX-x86_64.pkg</a></td>
-      <td class="s">35.2M</td>
-      <td>2018-09-04 11:57:25</td>
-      <td>a2c5fe5058f70a02d2646905f16129da</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-MacOSX-x86_64.sh">Miniconda2-4.5.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">30.4M</td>
-      <td>2018-09-04 11:57:25</td>
-      <td>a444da43ad50a83c332ea1fb7a5bb96c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-Windows-x86.exe">Miniconda2-4.5.11-Windows-x86.exe</a></td>
-      <td class="s">50.5M</td>
-      <td>2018-09-04 11:57:26</td>
-      <td>e7629d753c04404e84241f90c3cab57d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.11-Windows-x86_64.exe">Miniconda2-4.5.11-Windows-x86_64.exe</a></td>
-      <td class="s">54.5M</td>
-      <td>2018-09-04 11:57:26</td>
-      <td>d7da3126f26f37205dd8da5ff5732501</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-Linux-ppc64le.sh">Miniconda3-4.5.11-Linux-ppc64le.sh</a></td>
-      <td class="s">60.1M</td>
-      <td>2018-09-04 11:57:26</td>
-      <td>4b1ac3b4b70bfa710c9f1c5c6d3f3166</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-Linux-x86.sh">Miniconda3-4.5.11-Linux-x86.sh</a></td>
-      <td class="s">56.5M</td>
-      <td>2018-09-04 11:57:27</td>
-      <td>d8c3ea1bd25cf02c4ea92df4d31ef652</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-Linux-x86_64.sh">Miniconda3-4.5.11-Linux-x86_64.sh</a></td>
-      <td class="s">59.7M</td>
-      <td>2018-09-04 11:57:26</td>
-      <td>e1045ee415162f944b6aebfe560b8fee</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-MacOSX-x86_64.pkg">Miniconda3-4.5.11-MacOSX-x86_64.pkg</a></td>
-      <td class="s">41.7M</td>
-      <td>2018-09-04 11:57:27</td>
-      <td>e65364fe505abc09283af2819d7bcf8a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-MacOSX-x86_64.sh">Miniconda3-4.5.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">36.3M</td>
-      <td>2018-09-04 11:57:27</td>
-      <td>7f7613bf98023f7d6ffe5df53c3a00a0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-Windows-x86.exe">Miniconda3-4.5.11-Windows-x86.exe</a></td>
-      <td class="s">49.0M</td>
-      <td>2018-09-04 11:57:28</td>
-      <td>be95ddce4bb7aee25dace1f8ab4419fc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.11-Windows-x86_64.exe">Miniconda3-4.5.11-Windows-x86_64.exe</a></td>
-      <td class="s">52.8M</td>
-      <td>2018-09-04 11:57:27</td>
-      <td>b2978141f8d9608ba455c0f03b313c15</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-Linux-ppc64le.sh">Miniconda2-4.5.4-Linux-ppc64le.sh</a></td>
-      <td class="s">36.9M</td>
-      <td>2018-06-06 23:07:18</td>
-      <td>3e26ee6447c8025609ea1e410f768417</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-Linux-x86.sh">Miniconda2-4.5.4-Linux-x86.sh</a></td>
-      <td class="s">35.5M</td>
-      <td>2018-06-06 22:27:33</td>
-      <td>a638ae058a0ce15c5b289d151c488045</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-Linux-x86_64.sh">Miniconda2-4.5.4-Linux-x86_64.sh</a></td>
-      <td class="s">38.1M</td>
-      <td>2018-06-06 22:24:38</td>
-      <td>8a1c02f6941d8778f8afad7328265cf5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-MacOSX-x86_64.pkg">Miniconda2-4.5.4-MacOSX-x86_64.pkg</a></td>
-      <td class="s">34.5M</td>
-      <td>2018-06-06 23:12:27</td>
-      <td>6040ee82686b36f9bffa32d5f2a1341b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-MacOSX-x86_64.sh">Miniconda2-4.5.4-MacOSX-x86_64.sh</a></td>
-      <td class="s">29.8M</td>
-      <td>2018-06-06 23:12:26</td>
-      <td>35f4ca99d33ed56f68745eeaf1449274</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-Windows-x86.exe">Miniconda2-4.5.4-Windows-x86.exe</a></td>
-      <td class="s">51.8M</td>
-      <td>2018-06-07 00:09:59</td>
-      <td>55502ce28ba3a16aa12954522d3624d2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.4-Windows-x86_64.exe">Miniconda2-4.5.4-Windows-x86_64.exe</a></td>
-      <td class="s">55.9M</td>
-      <td>2018-06-06 23:52:04</td>
-      <td>d285b7451deb4a33037033307c153684</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-Linux-ppc64le.sh">Miniconda3-4.5.4-Linux-ppc64le.sh</a></td>
-      <td class="s">54.9M</td>
-      <td>2018-06-06 23:07:24</td>
-      <td>05c1e073f262105179cf57920dfc4d43</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-Linux-x86.sh">Miniconda3-4.5.4-Linux-x86.sh</a></td>
-      <td class="s">53.7M</td>
-      <td>2018-06-06 22:27:35</td>
-      <td>0fcc79d640d82b7d36ea39654a82dd9d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-Linux-x86_64.sh">Miniconda3-4.5.4-Linux-x86_64.sh</a></td>
-      <td class="s">55.8M</td>
-      <td>2018-06-06 22:24:39</td>
-      <td>a946ea1d0c4a642ddf0c3a26a18bb16d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-MacOSX-x86_64.pkg">Miniconda3-4.5.4-MacOSX-x86_64.pkg</a></td>
-      <td class="s">40.2M</td>
-      <td>2018-06-06 23:12:28</td>
-      <td>242882072fda2ada8551239e9041f5e9</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-MacOSX-x86_64.sh">Miniconda3-4.5.4-MacOSX-x86_64.sh</a></td>
-      <td class="s">34.9M</td>
-      <td>2018-06-06 23:12:26</td>
-      <td>164ec263c4070db642ce31bb45d68813</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-Windows-x86.exe">Miniconda3-4.5.4-Windows-x86.exe</a></td>
-      <td class="s">51.1M</td>
-      <td>2018-06-07 00:10:06</td>
-      <td>bc2f687a9e92455a099242929df8471d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.4-Windows-x86_64.exe">Miniconda3-4.5.4-Windows-x86_64.exe</a></td>
-      <td class="s">54.8M</td>
-      <td>2018-06-06 23:52:12</td>
-      <td>1c73051ccd997770288275ee6474b423</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-Linux-ppc64le.sh">Miniconda2-4.5.1-Linux-ppc64le.sh</a></td>
-      <td class="s">36.6M</td>
-      <td>2018-05-02 13:04:48</td>
-      <td>02a0628652df3ab5917568606fecb8c3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-Linux-x86.sh">Miniconda2-4.5.1-Linux-x86.sh</a></td>
-      <td class="s">35.8M</td>
-      <td>2018-05-02 13:05:42</td>
-      <td>9da5b43024d7edba30d0359c547cd2e5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-Linux-x86_64.sh">Miniconda2-4.5.1-Linux-x86_64.sh</a></td>
-      <td class="s">38.4M</td>
-      <td>2018-05-02 13:05:41</td>
-      <td>332aeff0bb6b45bbf7e220dec17ba867</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-MacOSX-x86_64.pkg">Miniconda2-4.5.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">34.8M</td>
-      <td>2018-05-02 13:05:14</td>
-      <td>bc8cbf4bec596f3e4195a8afedd19441</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-MacOSX-x86_64.sh">Miniconda2-4.5.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">30.1M</td>
-      <td>2018-05-02 13:05:14</td>
-      <td>ad96c4012ca4d84d94f94d9c2f90a889</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-Windows-x86.exe">Miniconda2-4.5.1-Windows-x86.exe</a></td>
-      <td class="s">49.3M</td>
-      <td>2018-05-02 13:04:48</td>
-      <td>ba9758900b526890378bbc6a58500f64</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.5.1-Windows-x86_64.exe">Miniconda2-4.5.1-Windows-x86_64.exe</a></td>
-      <td class="s">53.2M</td>
-      <td>2018-05-02 13:05:55</td>
-      <td>f22d019cc10879d4e6701959af617334</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-Linux-ppc64le.sh">Miniconda3-4.5.1-Linux-ppc64le.sh</a></td>
-      <td class="s">54.8M</td>
-      <td>2018-05-02 13:04:48</td>
-      <td>454e3b786937eeaa50fb7bee991ac19e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-Linux-x86.sh">Miniconda3-4.5.1-Linux-x86.sh</a></td>
-      <td class="s">54.1M</td>
-      <td>2018-05-02 13:05:43</td>
-      <td>5d6627bfad03b87f1ad4173ebbeb933d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-Linux-x86_64.sh">Miniconda3-4.5.1-Linux-x86_64.sh</a></td>
-      <td class="s">56.1M</td>
-      <td>2018-05-02 13:05:42</td>
-      <td>0c28787e3126238df24c5d4858bd0744</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-MacOSX-x86_64.pkg">Miniconda3-4.5.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">40.8M</td>
-      <td>2018-05-02 13:05:14</td>
-      <td>f0c3695c040e55a426e4de9d283d4635</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-MacOSX-x86_64.sh">Miniconda3-4.5.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">35.3M</td>
-      <td>2018-05-02 13:05:15</td>
-      <td>ac87d2074bd50103468b8681084236f6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-Windows-x86.exe">Miniconda3-4.5.1-Windows-x86.exe</a></td>
-      <td class="s">48.8M</td>
-      <td>2018-05-02 13:04:49</td>
-      <td>9f2416951b8cae060d5ef5b28879b5ae</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.5.1-Windows-x86_64.exe">Miniconda3-4.5.1-Windows-x86_64.exe</a></td>
-      <td class="s">52.4M</td>
-      <td>2018-05-02 13:05:55</td>
-      <td>64adf151b4a60b503a3b6d7c4ac9eae8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-Linux-ppc64le.sh">Miniconda2-4.4.10-Linux-ppc64le.sh</a></td>
-      <td class="s">36.9M</td>
-      <td>2018-02-20 13:04:23</td>
-      <td>c6bf34cef423be4cda46df61fd09e069</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-Linux-x86.sh">Miniconda2-4.4.10-Linux-x86.sh</a></td>
-      <td class="s">35.0M</td>
-      <td>2018-02-20 13:04:23</td>
-      <td>1e8bf30cb77548f6aae9f4444b826fcb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-Linux-x86_64.sh">Miniconda2-4.4.10-Linux-x86_64.sh</a></td>
-      <td class="s">38.0M</td>
-      <td>2018-02-20 13:04:23</td>
-      <td>dd54b344661560b861f86cc5ccff044b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-MacOSX-x86_64.pkg">Miniconda2-4.4.10-MacOSX-x86_64.pkg</a></td>
-      <td class="s">34.4M</td>
-      <td>2018-02-20 13:04:23</td>
-      <td>83ef0231b385ff9107706ec70a14cae4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-MacOSX-x86_64.sh">Miniconda2-4.4.10-MacOSX-x86_64.sh</a></td>
-      <td class="s">29.7M</td>
-      <td>2018-02-20 13:04:24</td>
-      <td>20e0f8851c93331f763635c89840c39c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-Windows-x86.exe">Miniconda2-4.4.10-Windows-x86.exe</a></td>
-      <td class="s">50.7M</td>
-      <td>2018-02-20 13:04:24</td>
-      <td>e53de27198cd1b3ba7ff82abdc09698b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.4.10-Windows-x86_64.exe">Miniconda2-4.4.10-Windows-x86_64.exe</a></td>
-      <td class="s">54.5M</td>
-      <td>2018-02-20 13:04:24</td>
-      <td>c53b02fc17d88b9b28ad6261dc265778</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-Linux-ppc64le.sh">Miniconda3-4.4.10-Linux-ppc64le.sh</a></td>
-      <td class="s">54.6M</td>
-      <td>2018-02-20 13:04:24</td>
-      <td>57ca0b05eb96868b83aa69e4567b86ae</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-Linux-x86.sh">Miniconda3-4.4.10-Linux-x86.sh</a></td>
-      <td class="s">53.0M</td>
-      <td>2018-02-20 13:04:25</td>
-      <td>e770b4e45ac596c35f6393db988c5c33</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-Linux-x86_64.sh">Miniconda3-4.4.10-Linux-x86_64.sh</a></td>
-      <td class="s">55.6M</td>
-      <td>2018-02-20 13:04:24</td>
-      <td>bec6203dbb2f53011e974e9bf4d46e93</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-MacOSX-x86_64.pkg">Miniconda3-4.4.10-MacOSX-x86_64.pkg</a></td>
-      <td class="s">40.2M</td>
-      <td>2018-02-20 13:04:25</td>
-      <td>9983aa28ea6990642a738318928002f7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-MacOSX-x86_64.sh">Miniconda3-4.4.10-MacOSX-x86_64.sh</a></td>
-      <td class="s">34.9M</td>
-      <td>2018-02-20 13:04:25</td>
-      <td>268ec716435aa19212901510f00815fd</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-Windows-x86.exe">Miniconda3-4.4.10-Windows-x86.exe</a></td>
-      <td class="s">50.4M</td>
-      <td>2018-02-20 13:04:25</td>
-      <td>babd60b85e37830a6dbbfe5c9d74d8dc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.4.10-Windows-x86_64.exe">Miniconda3-4.4.10-Windows-x86_64.exe</a></td>
-      <td class="s">53.8M</td>
-      <td>2018-02-20 13:04:25</td>
-      <td>7842b190762abd73c4e5ca6b643827c8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-Linux-x86.sh">Miniconda2-4.3.31-Linux-x86.sh</a></td>
-      <td class="s">34.5M</td>
-      <td>2017-12-19 07:17:31</td>
-      <td>4067ba22e1d687f92b11531a0b30b17f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-Linux-x86_64.sh">Miniconda2-4.3.31-Linux-x86_64.sh</a></td>
-      <td class="s">37.5M</td>
-      <td>2017-12-19 07:17:31</td>
-      <td>da2dd466d26e33a2b1f72fdb853a8ff0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-MacOSX-x86_64.pkg">Miniconda2-4.3.31-MacOSX-x86_64.pkg</a></td>
-      <td class="s">33.8M</td>
-      <td>2017-12-19 07:17:31</td>
-      <td>4685b84526352f0fa5e6f9588f026ed6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-MacOSX-x86_64.sh">Miniconda2-4.3.31-MacOSX-x86_64.sh</a></td>
-      <td class="s">29.2M</td>
-      <td>2017-12-19 07:17:31</td>
-      <td>2c499488605bafd9e13a430f299f1489</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-Windows-x86.exe">Miniconda2-4.3.31-Windows-x86.exe</a></td>
-      <td class="s">52.4M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>e8d9e30422ddb6be78f10d704df664c8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.31-Windows-x86_64.exe">Miniconda2-4.3.31-Windows-x86_64.exe</a></td>
-      <td class="s">56.0M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>cc2345257028da275b75bd2581abe6b1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-Linux-x86.sh">Miniconda3-4.3.31-Linux-x86.sh</a></td>
-      <td class="s">52.5M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>df2f9770d83df8269f3f43f1e60285e6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-Linux-x86_64.sh">Miniconda3-4.3.31-Linux-x86_64.sh</a></td>
-      <td class="s">55.0M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>7fe70b214bee1143e3e3f0467b71453c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-MacOSX-x86_64.pkg">Miniconda3-4.3.31-MacOSX-x86_64.pkg</a></td>
-      <td class="s">39.6M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>d30e50b10b4a69e63e3ed5797d947b3e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-MacOSX-x86_64.sh">Miniconda3-4.3.31-MacOSX-x86_64.sh</a></td>
-      <td class="s">34.3M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>03c2dedc466886459e968157c63197f3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-Windows-x86.exe">Miniconda3-4.3.31-Windows-x86.exe</a></td>
-      <td class="s">51.9M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>78c30daaf66bd9eeae8ec3d03fd88508</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.31-Windows-x86_64.exe">Miniconda3-4.3.31-Windows-x86_64.exe</a></td>
-      <td class="s">55.8M</td>
-      <td>2017-12-19 07:17:32</td>
-      <td>93137a6f253664d239883b366c26fe71</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30.2-Windows-x86.exe">Miniconda2-4.3.30.2-Windows-x86.exe</a></td>
-      <td class="s">52.1M</td>
-      <td>2017-11-20 19:13:50</td>
-      <td>1cc210b37301eca5c040063b518bd618</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30.2-Windows-x86_64.exe">Miniconda2-4.3.30.2-Windows-x86_64.exe</a></td>
-      <td class="s">55.7M</td>
-      <td>2017-11-20 19:13:15</td>
-      <td>162de58ae465ecdb0f98a0e5a402f23c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30.2-Windows-x86.exe">Miniconda3-4.3.30.2-Windows-x86.exe</a></td>
-      <td class="s">51.5M</td>
-      <td>2017-11-20 19:13:57</td>
-      <td>75173293abe3714cb47b5d28490e1a0e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30.2-Windows-x86_64.exe">Miniconda3-4.3.30.2-Windows-x86_64.exe</a></td>
-      <td class="s">55.5M</td>
-      <td>2017-11-20 19:13:22</td>
-      <td>0cf836e1869e6abb033e69f915eb7dd6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30.1-MacOSX-x86_64.pkg">Miniconda2-4.3.30.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">31.4M</td>
-      <td>2017-10-26 12:42:51</td>
-      <td>182b443aef9d8e755f947ed14fe3be6b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30.1-MacOSX-x86_64.sh">Miniconda2-4.3.30.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">26.9M</td>
-      <td>2017-10-26 12:42:50</td>
-      <td>726cb6ba61196b5014918d836dd7a67a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30.1-MacOSX-x86_64.pkg">Miniconda3-4.3.30.1-MacOSX-x86_64.pkg</a></td>
-      <td class="s">36.7M</td>
-      <td>2017-10-26 12:42:51</td>
-      <td>197447a2d33d594b5c1ba28b5f2292d5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30.1-MacOSX-x86_64.sh">Miniconda3-4.3.30.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">31.6M</td>
-      <td>2017-10-26 12:42:50</td>
-      <td>edd8037f8271314fdca00011987ce537</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-Linux-x86.sh">Miniconda2-4.3.30-Linux-x86.sh</a></td>
-      <td class="s">31.4M</td>
-      <td>2017-10-19 17:59:06</td>
-      <td>a8088c56572ae7f3ce51b16ce84317d9</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-Linux-x86_64.sh">Miniconda2-4.3.30-Linux-x86_64.sh</a></td>
-      <td class="s">34.5M</td>
-      <td>2017-10-19 17:52:40</td>
-      <td>bd1655b4b313f7b2a1f2e15b7b925d03</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-MacOSX-x86_64.pkg">Miniconda2-4.3.30-MacOSX-x86_64.pkg</a></td>
-      <td class="s">31.3M</td>
-      <td>2017-10-19 17:47:35</td>
-      <td>4d05c89e6ee8bce6693a26512a297d63</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-MacOSX-x86_64.sh">Miniconda2-4.3.30-MacOSX-x86_64.sh</a></td>
-      <td class="s">26.9M</td>
-      <td>2017-10-19 17:47:34</td>
-      <td>a2028825bbbb40f390ccb8ddc83e00bb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-Windows-x86.exe">Miniconda2-4.3.30-Windows-x86.exe</a></td>
-      <td class="s">48.9M</td>
-      <td>2017-10-19 19:20:41</td>
-      <td>0d5a1a901586e5abed55a4c4d5bc31f4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.30-Windows-x86_64.exe">Miniconda2-4.3.30-Windows-x86_64.exe</a></td>
-      <td class="s">52.6M</td>
-      <td>2017-10-19 19:21:10</td>
-      <td>99a95087308c7cd8e5133db9bf11167a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-Linux-x86.sh">Miniconda3-4.3.30-Linux-x86.sh</a></td>
-      <td class="s">49.2M</td>
-      <td>2017-10-19 17:59:07</td>
-      <td>c9518b83488c85d44505a44c03a0ea1e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-Linux-x86_64.sh">Miniconda3-4.3.30-Linux-x86_64.sh</a></td>
-      <td class="s">51.7M</td>
-      <td>2017-10-19 17:52:40</td>
-      <td>0b80a152332a4ce5250f3c09589c7a81</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-MacOSX-x86_64.pkg">Miniconda3-4.3.30-MacOSX-x86_64.pkg</a></td>
-      <td class="s">36.7M</td>
-      <td>2017-10-19 17:47:34</td>
-      <td>0bc420982e088bbd8cff5d1e56ee7ef7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-MacOSX-x86_64.sh">Miniconda3-4.3.30-MacOSX-x86_64.sh</a></td>
-      <td class="s">31.5M</td>
-      <td>2017-10-19 17:47:34</td>
-      <td>49c6a540347426ab522600a93b73e39e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-Windows-x86.exe">Miniconda3-4.3.30-Windows-x86.exe</a></td>
-      <td class="s">45.8M</td>
-      <td>2017-10-19 19:20:46</td>
-      <td>a3c414a0aa5d6915d24f1e315cf3f717</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.30-Windows-x86_64.exe">Miniconda3-4.3.30-Windows-x86_64.exe</a></td>
-      <td class="s">52.1M</td>
-      <td>2017-10-19 19:21:17</td>
-      <td>790a7a99a4f38ec221c9747c4ee3bbfc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27.1-Linux-x86_64.sh">Miniconda2-4.3.27.1-Linux-x86_64.sh</a></td>
-      <td class="s">34.4M</td>
-      <td>2017-10-02 08:52:08</td>
-      <td>7efba9cbe774169e36695564f197becb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27.1-Linux-x86_64.sh">Miniconda3-4.3.27.1-Linux-x86_64.sh</a></td>
-      <td class="s">51.6M</td>
-      <td>2017-10-02 08:52:08</td>
-      <td>63049c871c7d426f4bc5f3dc4feb78cc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27.1-Linux-x86.sh">Miniconda2-4.3.27.1-Linux-x86.sh</a></td>
-      <td class="s">31.4M</td>
-      <td>2017-10-01 04:00:02</td>
-      <td>e3911e1fb544a04e048ce139dcbb7bd4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27.1-Linux-x86.sh">Miniconda3-4.3.27.1-Linux-x86.sh</a></td>
-      <td class="s">49.2M</td>
-      <td>2017-10-01 04:00:02</td>
-      <td>66d4005d4a401b7dc4c0f829acb6d41d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-Linux-ppc64le.sh">Miniconda2-4.3.27-Linux-ppc64le.sh</a></td>
-      <td class="s">28.2M</td>
-      <td>2017-09-27 12:00:12</td>
-      <td>fe3a081f2bbc7e5e2e0031d9396bbd81</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-Linux-ppc64le.sh">Miniconda3-4.3.27-Linux-ppc64le.sh</a></td>
-      <td class="s">34.4M</td>
-      <td>2017-09-27 12:00:12</td>
-      <td>c51bc5fb00da12b487959b5adf0133ab</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-Linux-x86.sh">Miniconda2-4.3.27-Linux-x86.sh</a></td>
-      <td class="s">30.9M</td>
-      <td>2017-09-26 16:26:31</td>
-      <td>91da4526e830813261f0b3adebabde02</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-Linux-x86_64.sh">Miniconda2-4.3.27-Linux-x86_64.sh</a></td>
-      <td class="s">33.8M</td>
-      <td>2017-09-26 16:26:31</td>
-      <td>907cd0f8386a4e25f302a88ec1a61d44</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-MacOSX-x86_64.pkg">Miniconda2-4.3.27-MacOSX-x86_64.pkg</a></td>
-      <td class="s">31.2M</td>
-      <td>2017-09-26 16:26:31</td>
-      <td>6c7ba3d8d9a7dcdfdd6c6838df387d88</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-MacOSX-x86_64.sh">Miniconda2-4.3.27-MacOSX-x86_64.sh</a></td>
-      <td class="s">26.8M</td>
-      <td>2017-09-26 16:26:31</td>
-      <td>1fde29bfd20b056d3476ccf589d76196</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-Windows-x86.exe">Miniconda2-4.3.27-Windows-x86.exe</a></td>
-      <td class="s">48.6M</td>
-      <td>2017-09-26 16:55:24</td>
-      <td>355a27de5b00b866aea47ff5cf0eae38</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.27-Windows-x86_64.exe">Miniconda2-4.3.27-Windows-x86_64.exe</a></td>
-      <td class="s">52.1M</td>
-      <td>2017-09-26 16:55:26</td>
-      <td>51428e8e9da2340c54b6b823a72a5711</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-Linux-x86.sh">Miniconda3-4.3.27-Linux-x86.sh</a></td>
-      <td class="s">48.7M</td>
-      <td>2017-09-26 16:26:32</td>
-      <td>88d98a51f1029deda52539d14e216cbb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-Linux-x86_64.sh">Miniconda3-4.3.27-Linux-x86_64.sh</a></td>
-      <td class="s">51.0M</td>
-      <td>2017-09-26 16:26:32</td>
-      <td>f0f385b9abce0d47ee09c05480feb6cf</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-MacOSX-x86_64.pkg">Miniconda3-4.3.27-MacOSX-x86_64.pkg</a></td>
-      <td class="s">36.5M</td>
-      <td>2017-09-26 16:26:32</td>
-      <td>bb3b2363320517928f8709499b4ea062</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-MacOSX-x86_64.sh">Miniconda3-4.3.27-MacOSX-x86_64.sh</a></td>
-      <td class="s">31.5M</td>
-      <td>2017-09-26 16:26:32</td>
-      <td>634903a8a1e32a95aa0cd31a68d46995</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-Windows-x86.exe">Miniconda3-4.3.27-Windows-x86.exe</a></td>
-      <td class="s">45.5M</td>
-      <td>2017-09-26 16:55:34</td>
-      <td>ea9f8d873425fd1e8703649174db20d4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.27-Windows-x86_64.exe">Miniconda3-4.3.27-Windows-x86_64.exe</a></td>
-      <td class="s">49.1M</td>
-      <td>2017-09-26 16:55:40</td>
-      <td>a02c3272a1a9ab461043966285d76777</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.21-Linux-x86.sh">Miniconda2-4.3.21-Linux-x86.sh</a></td>
-      <td class="s">23.5M</td>
-      <td>2017-06-02 11:13:37</td>
-      <td>669ae8b9f2d5b92177906910c0df171e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.21-Linux-x86_64.sh">Miniconda2-4.3.21-Linux-x86_64.sh</a></td>
-      <td class="s">27.8M</td>
-      <td>2017-06-02 11:12:06</td>
-      <td>7097150146dd3b83c805223663ebffcc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.21-MacOSX-x86_64.sh">Miniconda2-4.3.21-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.4M</td>
-      <td>2017-06-02 11:15:20</td>
-      <td>3f7860462b4e9cd42d17132300c270cc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.21-Windows-x86.exe">Miniconda2-4.3.21-Windows-x86.exe</a></td>
-      <td class="s">47.7M</td>
-      <td>2017-06-02 11:24:42</td>
-      <td>49e26b862472a2e05d6b5954abcdb5c4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.21-Windows-x86_64.exe">Miniconda2-4.3.21-Windows-x86_64.exe</a></td>
-      <td class="s">51.4M</td>
-      <td>2017-06-02 11:24:51</td>
-      <td>9c98e98931b952848c7372a63e04cdc7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.21-Linux-x86.sh">Miniconda3-4.3.21-Linux-x86.sh</a></td>
-      <td class="s">28.9M</td>
-      <td>2017-06-02 11:13:39</td>
-      <td>657df0098d79b0aa547b401c31ee4e67</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.21-Linux-x86_64.sh">Miniconda3-4.3.21-Linux-x86_64.sh</a></td>
-      <td class="s">33.4M</td>
-      <td>2017-06-02 11:12:07</td>
-      <td>c1c15d3baba15bf50293ae963abef853</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.21-MacOSX-x86_64.sh">Miniconda3-4.3.21-MacOSX-x86_64.sh</a></td>
-      <td class="s">24.3M</td>
-      <td>2017-06-02 11:15:22</td>
-      <td>cf092c4fb158ecf28c88c388ca565d95</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.21-Windows-x86.exe">Miniconda3-4.3.21-Windows-x86.exe</a></td>
-      <td class="s">53.9M</td>
-      <td>2017-06-02 11:25:00</td>
-      <td>4960b46179b69d2051c86eeeaafcfede</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.21-Windows-x86_64.exe">Miniconda3-4.3.21-Windows-x86_64.exe</a></td>
-      <td class="s">57.8M</td>
-      <td>2017-06-02 11:25:10</td>
-      <td>29000c7082bad516c5c5b92c180b6793</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-Linux-x86.sh">Miniconda2-4.3.14-Linux-x86.sh</a></td>
-      <td class="s">23.3M</td>
-      <td>2017-05-12 14:11:33</td>
-      <td>f5f96d8b57cb6d7c0d092e75c704799c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-Linux-x86_64.sh">Miniconda2-4.3.14-Linux-x86_64.sh</a></td>
-      <td class="s">27.5M</td>
-      <td>2017-05-12 14:11:24</td>
-      <td>8cb075cf5462480980ef2373ad9fad38</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-MacOSX-x86_64.sh">Miniconda2-4.3.14-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.1M</td>
-      <td>2017-05-12 14:11:45</td>
-      <td>263a4b0c65bae7cd4f70ebfd8192da82</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-Windows-x86.exe">Miniconda2-4.3.14-Windows-x86.exe</a></td>
-      <td class="s">47.5M</td>
-      <td>2017-05-12 14:17:47</td>
-      <td>deebac24faf3e8ac00f5356958e2a9e3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-Windows-x86_64.exe">Miniconda2-4.3.14-Windows-x86_64.exe</a></td>
-      <td class="s">51.2M</td>
-      <td>2017-05-12 14:17:54</td>
-      <td>878ca3c0fde4de0863791a4b48ca685e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-Linux-x86.sh">Miniconda3-4.3.14-Linux-x86.sh</a></td>
-      <td class="s">28.6M</td>
-      <td>2017-05-12 14:11:36</td>
-      <td>7b9b7571a9208cfacb94ed70cad581b8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-Linux-x86_64.sh">Miniconda3-4.3.14-Linux-x86_64.sh</a></td>
-      <td class="s">33.1M</td>
-      <td>2017-05-12 14:11:25</td>
-      <td>fc6fc37479e3e3fcf3f9ba52cae98991</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-MacOSX-x86_64.sh">Miniconda3-4.3.14-MacOSX-x86_64.sh</a></td>
-      <td class="s">24.0M</td>
-      <td>2017-05-12 14:11:46</td>
-      <td>e46f4555439134cd41ccb914ba283958</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-Windows-x86.exe">Miniconda3-4.3.14-Windows-x86.exe</a></td>
-      <td class="s">53.8M</td>
-      <td>2017-05-12 14:18:16</td>
-      <td>87f0432802473f304d86373652d00147</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-Windows-x86_64.exe">Miniconda3-4.3.14-Windows-x86_64.exe</a></td>
-      <td class="s">57.8M</td>
-      <td>2017-05-12 14:18:25</td>
-      <td>b6d686ee2279eb115c8df2038ebdc411</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.14-Linux-ppc64le.sh">Miniconda2-4.3.14-Linux-ppc64le.sh</a></td>
-      <td class="s">27.2M</td>
-      <td>2017-03-17 15:39:53</td>
-      <td>a69a128439e8135b3388541c344a957e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.14-Linux-ppc64le.sh">Miniconda3-4.3.14-Linux-ppc64le.sh</a></td>
-      <td class="s">33.2M</td>
-      <td>2017-03-17 15:39:57</td>
-      <td>d468a5ec166c9c1179e0574dccae6de0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.11-Linux-x86.sh">Miniconda2-4.3.11-Linux-x86.sh</a></td>
-      <td class="s">23.2M</td>
-      <td>2017-02-14 11:18:56</td>
-      <td>09e9780288d29e46f3dd7eaa7ce280bc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.11-Linux-x86_64.sh">Miniconda2-4.3.11-Linux-x86_64.sh</a></td>
-      <td class="s">27.5M</td>
-      <td>2017-02-14 11:18:44</td>
-      <td>d573980fe3b5cdf80485add2466463f5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.11-MacOSX-x86_64.sh">Miniconda2-4.3.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.1M</td>
-      <td>2017-02-14 11:20:38</td>
-      <td>d2edb7d4f3f55c35b9a25fd2d0ef6856</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.11-Windows-x86.exe">Miniconda2-4.3.11-Windows-x86.exe</a></td>
-      <td class="s">47.5M</td>
-      <td>2017-02-14 11:23:45</td>
-      <td>1563b7371c50189b9c1eaf2573a03c3f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.3.11-Windows-x86_64.exe">Miniconda2-4.3.11-Windows-x86_64.exe</a></td>
-      <td class="s">51.2M</td>
-      <td>2017-02-14 11:23:52</td>
-      <td>3560e23fbf249864f25c53080fb1b805</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.11-Linux-x86.sh">Miniconda3-4.3.11-Linux-x86.sh</a></td>
-      <td class="s">28.5M</td>
-      <td>2017-02-14 11:18:58</td>
-      <td>5407097ca83126bd50645cac3b8c1081</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.11-Linux-x86_64.sh">Miniconda3-4.3.11-Linux-x86_64.sh</a></td>
-      <td class="s">33.1M</td>
-      <td>2017-02-14 11:18:45</td>
-      <td>1924c8d9ec0abf09005aa03425e9ab1a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.11-MacOSX-x86_64.sh">Miniconda3-4.3.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">24.0M</td>
-      <td>2017-02-14 11:20:38</td>
-      <td>2155351c97b5da8ef081b81cc37f2eb3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.11-Windows-x86.exe">Miniconda3-4.3.11-Windows-x86.exe</a></td>
-      <td class="s">53.8M</td>
-      <td>2017-02-14 11:23:59</td>
-      <td>ee20822f44d8c2b43f267a2587aa0e95</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.3.11-Windows-x86_64.exe">Miniconda3-4.3.11-Windows-x86_64.exe</a></td>
-      <td class="s">57.8M</td>
-      <td>2017-02-14 11:24:07</td>
-      <td>c20199f69c243b1c2a2010b1fc036e3f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.15-MacOSX-x86_64.sh">Miniconda2-4.2.15-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.4M</td>
-      <td>2017-01-12 13:27:24</td>
-      <td>bceff466f5088562f639333ad42225b8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-Linux-ppc64le.sh">Miniconda2-4.2.12-Linux-ppc64le.sh</a></td>
-      <td class="s">25.5M</td>
-      <td>2016-11-04 15:02:58</td>
-      <td>28c5f9bba391cc8a79cdce0dce36710f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-Linux-ppc64le.sh">Miniconda3-4.2.12-Linux-ppc64le.sh</a></td>
-      <td class="s">31.1M</td>
-      <td>2016-11-04 15:03:09</td>
-      <td>8a1b764a59c407f1a5cc3dc352add814</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-Linux-x86.sh">Miniconda2-4.2.12-Linux-x86.sh</a></td>
-      <td class="s">22.5M</td>
-      <td>2016-11-03 14:04:57</td>
-      <td>c6d585324fa359c929b87bb1189839e5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-Linux-x86_64.sh">Miniconda2-4.2.12-Linux-x86_64.sh</a></td>
-      <td class="s">26.5M</td>
-      <td>2016-11-03 14:04:46</td>
-      <td>c8b836baaa4ff89192947e4b1a70b07e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-MacOSX-x86_64.sh">Miniconda2-4.2.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">20.5M</td>
-      <td>2016-11-03 14:05:03</td>
-      <td>ff3d7b69e32e1e4246176fb90f8480c8</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-Windows-x86.exe">Miniconda2-4.2.12-Windows-x86.exe</a></td>
-      <td class="s">42.3M</td>
-      <td>2016-11-03 14:05:50</td>
-      <td>f554e2300cc357f26526aba9a7adc913</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.12-Windows-x86_64.exe">Miniconda2-4.2.12-Windows-x86_64.exe</a></td>
-      <td class="s">45.2M</td>
-      <td>2016-11-03 14:05:56</td>
-      <td>f78d2e149d017c3ccc691fb0586d57e4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-Linux-x86.sh">Miniconda3-4.2.12-Linux-x86.sh</a></td>
-      <td class="s">27.7M</td>
-      <td>2016-11-03 14:04:59</td>
-      <td>7101feeb22588b77bcf31aba7cf4c07a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-Linux-x86_64.sh">Miniconda3-4.2.12-Linux-x86_64.sh</a></td>
-      <td class="s">32.3M</td>
-      <td>2016-11-03 14:04:49</td>
-      <td>d0c7c71cc5659e54ab51f2005a8d96f3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-MacOSX-x86_64.sh">Miniconda3-4.2.12-MacOSX-x86_64.sh</a></td>
-      <td class="s">23.8M</td>
-      <td>2016-11-03 14:05:03</td>
-      <td>73463d2644d5e428419b7c1d304e89fa</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-Windows-x86.exe">Miniconda3-4.2.12-Windows-x86.exe</a></td>
-      <td class="s">46.3M</td>
-      <td>2016-11-03 14:06:03</td>
-      <td>fd513c721e1cde9bd0fb2d15f38d3df1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.12-Windows-x86_64.exe">Miniconda3-4.2.12-Windows-x86_64.exe</a></td>
-      <td class="s">48.7M</td>
-      <td>2016-11-03 14:06:09</td>
-      <td>109a83d180afad7f43ed7b9a875a838b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.11-Windows-x86.exe">Miniconda2-4.2.11-Windows-x86.exe</a></td>
-      <td class="s">42.3M</td>
-      <td>2016-10-25 19:11:06</td>
-      <td>444e82748243c63e50210fd9eaf3e438</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.11-Windows-x86_64.exe">Miniconda2-4.2.11-Windows-x86_64.exe</a></td>
-      <td class="s">45.2M</td>
-      <td>2016-10-25 19:11:13</td>
-      <td>b6884d67c65f6bdd7cb22659a6bb2c61</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.11-Windows-x86.exe">Miniconda3-4.2.11-Windows-x86.exe</a></td>
-      <td class="s">46.3M</td>
-      <td>2016-10-25 19:11:19</td>
-      <td>8cfa793a80e87091e2369065435a7105</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.11-Windows-x86_64.exe">Miniconda3-4.2.11-Windows-x86_64.exe</a></td>
-      <td class="s">48.7M</td>
-      <td>2016-10-25 19:11:26</td>
-      <td>9382b4f0a574ace5b98d59ab68048165</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.11-Linux-x86.sh">Miniconda2-4.2.11-Linux-x86.sh</a></td>
-      <td class="s">22.4M</td>
-      <td>2016-10-24 12:54:49</td>
-      <td>08de540a577b81da6fe63d51152980d0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.11-Linux-x86_64.sh">Miniconda2-4.2.11-Linux-x86_64.sh</a></td>
-      <td class="s">26.5M</td>
-      <td>2016-10-24 12:54:38</td>
-      <td>db7c873b9dbdc147633e78b6eead738d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.2.11-MacOSX-x86_64.sh">Miniconda2-4.2.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">20.5M</td>
-      <td>2016-10-24 12:55:07</td>
-      <td>a43fc02ef5a7dcb33eb66b0c588bae7b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.11-Linux-x86.sh">Miniconda3-4.2.11-Linux-x86.sh</a></td>
-      <td class="s">27.7M</td>
-      <td>2016-10-24 12:54:50</td>
-      <td>8a57e8c02076c956ae02deae1639034b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.11-Linux-x86_64.sh">Miniconda3-4.2.11-Linux-x86_64.sh</a></td>
-      <td class="s">32.3M</td>
-      <td>2016-10-24 12:54:38</td>
-      <td>67f4d801aafece787a922a1385b1f538</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.2.11-MacOSX-x86_64.sh">Miniconda3-4.2.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">23.8M</td>
-      <td>2016-10-24 12:55:07</td>
-      <td>457af04074aca78e0582f272a6a72fe6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.1.11-Linux-x86.sh">Miniconda2-4.1.11-Linux-x86.sh</a></td>
-      <td class="s">22.4M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>0efa64640ce5c39daa894b6708da9d76</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.1.11-Linux-x86_64.sh">Miniconda2-4.1.11-Linux-x86_64.sh</a></td>
-      <td class="s">26.5M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>b2af3b9ff39c4a4a812f50cecbafcda6</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.1.11-MacOSX-x86_64.sh">Miniconda2-4.1.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">20.3M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>f38a602a07a2064a2eb61ac9d2fbe1fc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.1.11-Windows-x86.exe">Miniconda2-4.1.11-Windows-x86.exe</a></td>
-      <td class="s">29.3M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>26770b97198152c248ec99e9e718d162</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.1.11-Windows-x86_64.exe">Miniconda2-4.1.11-Windows-x86_64.exe</a></td>
-      <td class="s">30.4M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>3a6e6b224720e4489b1b8482f605cb0d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.1.11-Linux-x86.sh">Miniconda3-4.1.11-Linux-x86.sh</a></td>
-      <td class="s">27.8M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>313d4ae1f51129890694714d3b77eb29</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.1.11-Linux-x86_64.sh">Miniconda3-4.1.11-Linux-x86_64.sh</a></td>
-      <td class="s">32.4M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>874dbb0d3c7ec665adf7231bbb575ab2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.1.11-MacOSX-x86_64.sh">Miniconda3-4.1.11-MacOSX-x86_64.sh</a></td>
-      <td class="s">23.7M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>870d6f99eda1263c6e857d637e861d20</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.1.11-Windows-x86.exe">Miniconda3-4.1.11-Windows-x86.exe</a></td>
-      <td class="s">36.8M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>1f5cbd6562f71a5fc7bf9192a51b46b7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.1.11-Windows-x86_64.exe">Miniconda3-4.1.11-Windows-x86_64.exe</a></td>
-      <td class="s">38.4M</td>
-      <td>2016-07-28 21:33:00</td>
-      <td>6c434573474edfc72b1408762b50dde3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.0.5-Linux-x86.sh">Miniconda2-4.0.5-Linux-x86.sh</a></td>
-      <td class="s">24.7M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>cabfeaf9bb82cb5faaa1337ad21ca7bb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.0.5-Linux-x86_64.sh">Miniconda2-4.0.5-Linux-x86_64.sh</a></td>
-      <td class="s">25.9M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>42dac45eee5e58f05f37399adda45e85</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.0.5-MacOSX-x86_64.sh">Miniconda2-4.0.5-MacOSX-x86_64.sh</a></td>
-      <td class="s">20.3M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>26aae03b073d0e8c0977c38bc997179f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.0.5-Windows-x86.exe">Miniconda2-4.0.5-Windows-x86.exe</a></td>
-      <td class="s">29.0M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>c35402d272be8d410f4e8fd62905325f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-4.0.5-Windows-x86_64.exe">Miniconda2-4.0.5-Windows-x86_64.exe</a></td>
-      <td class="s">30.0M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>6b848b2f138376fedca564edefb21096</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.0.5-Linux-x86.sh">Miniconda3-4.0.5-Linux-x86.sh</a></td>
-      <td class="s">30.0M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>1c515df0f6312c8b3eccb2c1bf94ba14</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.0.5-Linux-x86_64.sh">Miniconda3-4.0.5-Linux-x86_64.sh</a></td>
-      <td class="s">31.4M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>b1b15a3436bb7de1da3ccc6e08c7a5df</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.0.5-MacOSX-x86_64.sh">Miniconda3-4.0.5-MacOSX-x86_64.sh</a></td>
-      <td class="s">23.4M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>a728df10c7362d574573fd4bc5b7e597</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.0.5-Windows-x86.exe">Miniconda3-4.0.5-Windows-x86.exe</a></td>
-      <td class="s">36.0M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>03c6989a577a4979582082fe80a01b3c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-4.0.5-Windows-x86_64.exe">Miniconda3-4.0.5-Windows-x86_64.exe</a></td>
-      <td class="s">39.0M</td>
-      <td>2016-03-29 19:32:26</td>
-      <td>333506276458488ec8d1d928e3fa9ac4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.19.0-Linux-x86.sh">Miniconda2-3.19.0-Linux-x86.sh</a></td>
-      <td class="s">23.0M</td>
-      <td>2015-12-17 14:18:08</td>
-      <td>f8b32eb2e948d87ab6aedab27d28bf13</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.19.0-Linux-x86_64.sh">Miniconda2-3.19.0-Linux-x86_64.sh</a></td>
-      <td class="s">24.2M</td>
-      <td>2015-12-17 14:16:41</td>
-      <td>628f158791daf7d634fb6894045a6be1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.19.0-MacOSX-x86_64.sh">Miniconda2-3.19.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">19.6M</td>
-      <td>2015-12-17 14:18:55</td>
-      <td>90010a967a609f4a2575aa7a9f6885fd</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.19.0-Windows-x86.exe">Miniconda2-3.19.0-Windows-x86.exe</a></td>
-      <td class="s">23.2M</td>
-      <td>2015-12-17 14:20:16</td>
-      <td>1822fb7fe67c11c1ca5df36d085d7038</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.19.0-Windows-x86_64.exe">Miniconda2-3.19.0-Windows-x86_64.exe</a></td>
-      <td class="s">24.3M</td>
-      <td>2015-12-17 14:20:20</td>
-      <td>ae8df5c3b2e3d455906efb310ddbe270</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.19.0-Linux-x86.sh">Miniconda3-3.19.0-Linux-x86.sh</a></td>
-      <td class="s">28.3M</td>
-      <td>2015-12-17 14:18:09</td>
-      <td>391bfdd892c2b8594b0d79bcfd2763c5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.19.0-Linux-x86_64.sh">Miniconda3-3.19.0-Linux-x86_64.sh</a></td>
-      <td class="s">29.6M</td>
-      <td>2015-12-17 14:16:41</td>
-      <td>b834b525d3f42add8f2af0153d13f498</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.19.0-MacOSX-x86_64.sh">Miniconda3-3.19.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">22.6M</td>
-      <td>2015-12-17 14:18:55</td>
-      <td>cc3d03d0042d41749915f995ebad80f3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.19.0-Windows-x86.exe">Miniconda3-3.19.0-Windows-x86.exe</a></td>
-      <td class="s">32.4M</td>
-      <td>2015-12-17 14:20:24</td>
-      <td>2983f3ed6a2e1507df47091d3498f2dd</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.19.0-Windows-x86_64.exe">Miniconda3-3.19.0-Windows-x86_64.exe</a></td>
-      <td class="s">34.6M</td>
-      <td>2015-12-17 14:20:29</td>
-      <td>aa2d1ed86600375a4d81681e0f4c4f18</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.8-MacOSX-x86_64.sh">Miniconda2-3.18.8-MacOSX-x86_64.sh</a></td>
-      <td class="s">19.5M</td>
-      <td>2015-12-10 14:19:16</td>
-      <td>e031716dd35ca4496bfc20e9da95a134</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.9-Linux-x86.sh">Miniconda2-3.18.9-Linux-x86.sh</a></td>
-      <td class="s">22.9M</td>
-      <td>2015-12-10 14:18:47</td>
-      <td>a7fb06aba7ac971a9a16234ee35fb6f7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.9-Linux-x86_64.sh">Miniconda2-3.18.9-Linux-x86_64.sh</a></td>
-      <td class="s">24.2M</td>
-      <td>2015-12-10 14:18:08</td>
-      <td>1a8c9fb2913c35df6bd9c304e210f776</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.9-Windows-x86.exe">Miniconda2-3.18.9-Windows-x86.exe</a></td>
-      <td class="s">23.1M</td>
-      <td>2015-12-10 14:22:24</td>
-      <td>bd12e86449c7301dcf19d3fef362074f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.9-Windows-x86_64.exe">Miniconda2-3.18.9-Windows-x86_64.exe</a></td>
-      <td class="s">24.2M</td>
-      <td>2015-12-10 14:22:27</td>
-      <td>ff13eda546543a83ee9a9736711f3b63</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.8-MacOSX-x86_64.sh">Miniconda3-3.18.8-MacOSX-x86_64.sh</a></td>
-      <td class="s">22.5M</td>
-      <td>2015-12-10 14:19:16</td>
-      <td>116b64c0b15f12185e326bfada14bbcc</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.9-Linux-x86.sh">Miniconda3-3.18.9-Linux-x86.sh</a></td>
-      <td class="s">28.2M</td>
-      <td>2015-12-10 14:18:49</td>
-      <td>791be261a7aaf727f865e5ba8dec4caa</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.9-Linux-x86_64.sh">Miniconda3-3.18.9-Linux-x86_64.sh</a></td>
-      <td class="s">29.6M</td>
-      <td>2015-12-10 14:18:09</td>
-      <td>ece4fc1375fe62639f0f625feae3e273</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.9-Windows-x86.exe">Miniconda3-3.18.9-Windows-x86.exe</a></td>
-      <td class="s">32.0M</td>
-      <td>2015-12-10 14:22:32</td>
-      <td>009c18dc5d4163a72671c517d4f80010</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.9-Windows-x86_64.exe">Miniconda3-3.18.9-Windows-x86_64.exe</a></td>
-      <td class="s">34.5M</td>
-      <td>2015-12-10 14:22:37</td>
-      <td>d173a03970b17a80fcb2522663522ff2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.3-Linux-x86.sh">Miniconda2-3.18.3-Linux-x86.sh</a></td>
-      <td class="s">21.2M</td>
-      <td>2015-11-03 11:29:32</td>
-      <td>1039549a2ac9a1b23ca8ef935cc54637</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.3-Linux-x86_64.sh">Miniconda2-3.18.3-Linux-x86_64.sh</a></td>
-      <td class="s">22.4M</td>
-      <td>2015-11-03 11:28:58</td>
-      <td>3f1d3e33dd154aacd7367931d595a74c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.3-MacOSX-x86_64.sh">Miniconda2-3.18.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">17.7M</td>
-      <td>2015-11-03 11:30:20</td>
-      <td>0cb3ee5cd648ed8a3c49327b389ce390</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.3-Windows-x86.exe">Miniconda2-3.18.3-Windows-x86.exe</a></td>
-      <td class="s">20.4M</td>
-      <td>2015-11-03 13:24:36</td>
-      <td>77e599048e9ed6f94c2aae1b9557250c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda2-3.18.3-Windows-x86_64.exe">Miniconda2-3.18.3-Windows-x86_64.exe</a></td>
-      <td class="s">21.7M</td>
-      <td>2015-11-03 13:24:44</td>
-      <td>78accfad67613b62ea8d6eb06c1559a7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.3-Linux-x86.sh">Miniconda3-3.18.3-Linux-x86.sh</a></td>
-      <td class="s">26.4M</td>
-      <td>2015-11-03 11:29:34</td>
-      <td>d4035def84ded2e48b84aeda7777748f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.3-Linux-x86_64.sh">Miniconda3-3.18.3-Linux-x86_64.sh</a></td>
-      <td class="s">27.7M</td>
-      <td>2015-11-03 11:28:58</td>
-      <td>245a839794fe2c3e7a35691ae1d3033f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.3-MacOSX-x86_64.sh">Miniconda3-3.18.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">20.7M</td>
-      <td>2015-11-03 11:30:21</td>
-      <td>ef4a179959f2fe3d2637fe1ac6276b75</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.3-Windows-x86.exe">Miniconda3-3.18.3-Windows-x86.exe</a></td>
-      <td class="s">29.4M</td>
-      <td>2015-11-03 13:24:55</td>
-      <td>42ae3f5404c69003d7bb053b9bd38acb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.18.3-Windows-x86_64.exe">Miniconda3-3.18.3-Windows-x86_64.exe</a></td>
-      <td class="s">40.4M</td>
-      <td>2015-11-03 13:25:08</td>
-      <td>8a0a2bd4261e8e4523630f309b262eb7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Linux-armv7l.sh">Miniconda-3.16.0-Linux-armv7l.sh</a></td>
-      <td class="s">19.8M</td>
-      <td>2015-08-24 11:01:14</td>
-      <td>4fb49180624952721628029097dcf1da</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Linux-ppc64le.sh">Miniconda-3.16.0-Linux-ppc64le.sh</a></td>
-      <td class="s">23.0M</td>
-      <td>2015-08-24 12:20:06</td>
-      <td>cf25b6712ea332775ccb7eef848448bb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Linux-x86.sh">Miniconda-3.16.0-Linux-x86.sh</a></td>
-      <td class="s">22.3M</td>
-      <td>2015-08-24 13:35:28</td>
-      <td>5fc7e6f393433e4655625a31e0903e7f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Linux-x86_64.sh">Miniconda-3.16.0-Linux-x86_64.sh</a></td>
-      <td class="s">23.0M</td>
-      <td>2015-08-24 13:34:47</td>
-      <td>87620e37caf523325ae67889656bc987</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-MacOSX-x86.sh">Miniconda-3.16.0-MacOSX-x86.sh</a></td>
-      <td class="s">18.3M</td>
-      <td>2015-08-24 13:34:39</td>
-      <td>414b2d1b3ba52b0132c7d319e78c4515</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-MacOSX-x86_64.sh">Miniconda-3.16.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">18.4M</td>
-      <td>2015-08-24 13:36:10</td>
-      <td>fb0fb83b20c21b45583ac35803566bce</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Windows-x86.exe">Miniconda-3.16.0-Windows-x86.exe</a></td>
-      <td class="s">31.7M</td>
-      <td>2015-08-24 13:37:57</td>
-      <td>e3833e7e94aa202b59cbb89b52d6fe56</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.16.0-Windows-x86_64.exe">Miniconda-3.16.0-Windows-x86_64.exe</a></td>
-      <td class="s">34.8M</td>
-      <td>2015-08-24 13:38:02</td>
-      <td>280def6845c260a06ec81fc6d6592011</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-latest-Linux-armv7l.sh">Miniconda-latest-Linux-armv7l.sh</a></td>
-      <td class="s">19.8M</td>
-      <td>2015-08-24 12:34:00</td>
-      <td>4fb49180624952721628029097dcf1da</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Linux-armv7l.sh">Miniconda3-3.16.0-Linux-armv7l.sh</a></td>
-      <td class="s">29.9M</td>
-      <td>2015-08-24 11:01:17</td>
-      <td>a01cbe45755d576c2bb9833859cf9fd7</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Linux-ppc64le.sh">Miniconda3-3.16.0-Linux-ppc64le.sh</a></td>
-      <td class="s">33.6M</td>
-      <td>2015-08-24 12:42:21</td>
-      <td>ac3296bcb3bfd5165043222c90d88382</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Linux-x86.sh">Miniconda3-3.16.0-Linux-x86.sh</a></td>
-      <td class="s">32.3M</td>
-      <td>2015-08-24 13:35:30</td>
-      <td>a945d816d422c35b8eed3da925f1b7bb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Linux-x86_64.sh">Miniconda3-3.16.0-Linux-x86_64.sh</a></td>
-      <td class="s">33.3M</td>
-      <td>2015-08-24 13:34:48</td>
-      <td>aed879451a589e4675dd55fc1e682e68</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-MacOSX-x86.sh">Miniconda3-3.16.0-MacOSX-x86.sh</a></td>
-      <td class="s">26.0M</td>
-      <td>2015-08-24 13:34:40</td>
-      <td>5c4d7cf61676fa8487fc0057a26eb061</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-MacOSX-x86_64.sh">Miniconda3-3.16.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">26.3M</td>
-      <td>2015-08-24 13:36:11</td>
-      <td>9f0f3167f413ddfae3dc36ebbbc8faf3</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Windows-x86.exe">Miniconda3-3.16.0-Windows-x86.exe</a></td>
-      <td class="s">38.5M</td>
-      <td>2015-08-24 13:38:07</td>
-      <td>5426c9046aea54e72d7f05f961249aaa</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.16.0-Windows-x86_64.exe">Miniconda3-3.16.0-Windows-x86_64.exe</a></td>
-      <td class="s">41.2M</td>
-      <td>2015-08-24 13:38:13</td>
-      <td>4ae8fd63e4d9923fc45338c133a25b36</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-latest-Linux-armv7l.sh">Miniconda3-latest-Linux-armv7l.sh</a></td>
-      <td class="s">29.9M</td>
-      <td>2015-08-24 12:34:00</td>
-      <td>a01cbe45755d576c2bb9833859cf9fd7</td>
+      <td>f387eded3fa4ddc3104b7775e62d59065b30205c2758a8b86b4c27144adafcc4</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-latest-MacOSX-x86.sh">Miniconda3-latest-MacOSX-x86.sh</a></td>
       <td class="s">26.0M</td>
       <td>2015-08-24 12:34:00</td>
-      <td>5c4d7cf61676fa8487fc0057a26eb061</td>
+      <td>fbf458b76ecc7d76367933d86e215920f2e1d144c689630324a0360d9c017949</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.10.1-Linux-x86.sh">Miniconda-3.10.1-Linux-x86.sh</a></td>
-      <td class="s">21.9M</td>
-      <td>2015-04-15 16:54:01</td>
-      <td>9747ab2491a5bc6d39107e7efdf8ebdc</td>
+      <td><a href="Miniconda3-latest-Linux-armv7l.sh">Miniconda3-latest-Linux-armv7l.sh</a></td>
+      <td class="s">29.9M</td>
+      <td>2015-08-24 12:34:00</td>
+      <td>21797d303260e1f0fb89f1157b4ff1b6b58865e8b710aecdddacd8c2658ded2f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.10.1-Linux-x86_64.sh">Miniconda-3.10.1-Linux-x86_64.sh</a></td>
-      <td class="s">22.7M</td>
-      <td>2015-04-15 16:51:55</td>
-      <td>8eedd8fc03262c9529b47e6d6cdbd5d4</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-Windows-x86_64.exe">Miniconda3-py39_23.5.2-0-Windows-x86_64.exe</a></td>
+      <td class="s">70.0M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>f5738ced68d9ed82996575202dea9375c51fa6419a8e0f3456398c6557a87dc2</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.10.1-MacOSX-x86_64.sh">Miniconda-3.10.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">17.9M</td>
-      <td>2015-04-15 16:55:49</td>
-      <td>ff60dd39365cfce496a0c309c3d31e53</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-MacOSX-x86_64.sh">Miniconda3-py39_23.5.2-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.0M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>dcbbdf92dc2954c79002b64ed53d3451e191dbdde0b30c67334f41dc6ca46ac1</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.10.1-Windows-x86.exe">Miniconda-3.10.1-Windows-x86.exe</a></td>
-      <td class="s">31.0M</td>
-      <td>2015-04-15 16:59:47</td>
-      <td>1d43bd55aaf9817bddcf54a8d6f5bdf5</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-MacOSX-x86_64.pkg">Miniconda3-py39_23.5.2-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>dd4068750b09409436f5e4829007b06e1726c34acf1aff7248a73b2562b6599f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.10.1-Windows-x86_64.exe">Miniconda-3.10.1-Windows-x86_64.exe</a></td>
-      <td class="s">33.7M</td>
-      <td>2015-04-15 17:01:10</td>
-      <td>c4a9c373c110343681aab0b43efebf22</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-MacOSX-arm64.sh">Miniconda3-py39_23.5.2-0-MacOSX-arm64.sh</a></td>
+      <td class="s">64.1M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>1b10164086354b39a46ff928eef5797ff57e0fa9706ccaf7d4e621b416541479</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.10.1-Linux-x86.sh">Miniconda3-3.10.1-Linux-x86.sh</a></td>
-      <td class="s">32.0M</td>
-      <td>2015-04-15 16:54:05</td>
-      <td>15f8114e8dd763094b4f2882f7fe726b</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-MacOSX-arm64.pkg">Miniconda3-py39_23.5.2-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.7M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>c8fa540f615cf164f5a1200313be78654aaf074ca184bf22c4423e90802edd37</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.10.1-Linux-x86_64.sh">Miniconda3-3.10.1-Linux-x86_64.sh</a></td>
-      <td class="s">32.9M</td>
-      <td>2015-04-15 16:51:59</td>
-      <td>e5b3f92a7724db6f29f322f2ac4b9c3c</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-Linux-x86_64.sh">Miniconda3-py39_23.5.2-0-Linux-x86_64.sh</a></td>
+      <td class="s">89.1M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>9829d95f639bd0053b2ed06d1204e60644617bf37dd5cc57523732e0e8d64516</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.10.1-MacOSX-x86_64.sh">Miniconda3-3.10.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.9M</td>
-      <td>2015-04-15 16:55:50</td>
-      <td>33e8722ec3134d483420c8311b782fe6</td>
+      <td><a href="Miniconda3-py39_23.5.2-0-Linux-s390x.sh">Miniconda3-py39_23.5.2-0-Linux-s390x.sh</a></td>
+      <td class="s">85.5M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>40ece8784a9e7dd521ab354ffc816bb466842ae3eee681a93647945c5070c9b4</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.10.1-Windows-x86.exe">Miniconda3-3.10.1-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-py39_23.5.2-0-Linux-ppc64le.sh">Miniconda3-py39_23.5.2-0-Linux-ppc64le.sh</a></td>
+      <td class="s">84.5M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>dc5aee01ee36a154b8070e6948b9a43773b6942476a144bc89e6135ac5beac58</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.2-0-Linux-aarch64.sh">Miniconda3-py39_23.5.2-0-Linux-aarch64.sh</a></td>
+      <td class="s">83.9M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>ecc06a39bdf786ebb8325a2754690a808f873154719c97d10087ef0883b69e84</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-Windows-x86_64.exe">Miniconda3-py38_23.5.2-0-Windows-x86_64.exe</a></td>
+      <td class="s">71.0M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>585befbcd3a3b532d34bba8ab63818d6bc7cfde975b5d6a7fc49483b6a84f371</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-MacOSX-x86_64.sh">Miniconda3-py38_23.5.2-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">66.5M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>6dc8bfb3b382c31be1755545ae6afc5fbdf8a67726ffdb8a05b917204bd08779</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-MacOSX-x86_64.pkg">Miniconda3-py38_23.5.2-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">66.2M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>ad702119896d6dbf25c945174b9999f5bff562e214654310d7f281aa18140349</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-MacOSX-arm64.sh">Miniconda3-py38_23.5.2-0-MacOSX-arm64.sh</a></td>
+      <td class="s">65.7M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>782bd1a401b20b41227a086adae98e270bbc942c3b7621788fb5574a9583142e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-MacOSX-arm64.pkg">Miniconda3-py38_23.5.2-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">65.3M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>dd3eeb5b09f45aa5a1a4f921581582450f4c05ae35f7dd9f837a24f61f9442f5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-Linux-x86_64.sh">Miniconda3-py38_23.5.2-0-Linux-x86_64.sh</a></td>
+      <td class="s">89.3M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>e2a4438671e0e42c5bba14cb51de6ce9763938184d6ca2967340bbe972bbe7e6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-Linux-s390x.sh">Miniconda3-py38_23.5.2-0-Linux-s390x.sh</a></td>
+      <td class="s">85.8M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>b840fd5a8474a3e6831cd50a64eadf73239c6ad7deeebf2c3d3fe366220b2722</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-Linux-ppc64le.sh">Miniconda3-py38_23.5.2-0-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>6fc3bf00d4fe0c724fab884d93b981acbc22bb8fc41c144df6d2fc080ff80e25</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.2-0-Linux-aarch64.sh">Miniconda3-py38_23.5.2-0-Linux-aarch64.sh</a></td>
+      <td class="s">72.7M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>cd39b811ac9a2f9094c4dfff9ec0f7ec811d6ad7ede5ab3f1a31d330ab3a2c55</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-Windows-x86_64.exe">Miniconda3-py311_23.5.2-0-Windows-x86_64.exe</a></td>
+      <td class="s">73.2M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>00e8370542836862d4c790aa8966f1d7344a8addd4b766004febcb23f40e2914</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-MacOSX-x86_64.sh">Miniconda3-py311_23.5.2-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">69.6M</td>
+      <td>2023-07-13 13:55:52</td>
+      <td>1622e7a0fa60a7d3d892c2d8153b54cd6ffe3e6b979d931320ba56bd52581d4b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-MacOSX-x86_64.pkg">Miniconda3-py311_23.5.2-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">69.2M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>2236a243b6cbe6f16ec324ecc9e631102494c031d41791b44612bbb6a7a1a6b4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-MacOSX-arm64.sh">Miniconda3-py311_23.5.2-0-MacOSX-arm64.sh</a></td>
+      <td class="s">68.6M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>c8f436dbde130f171d39dd7b4fca669c223f130ba7789b83959adc1611a35644</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-MacOSX-arm64.pkg">Miniconda3-py311_23.5.2-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">68.1M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>837371f3b6e8ae2b65bdfc8370e6be812b564ff9f40bcd4eb0b22f84bf9b4fe5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-Linux-x86_64.sh">Miniconda3-py311_23.5.2-0-Linux-x86_64.sh</a></td>
+      <td class="s">98.4M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-Linux-s390x.sh">Miniconda3-py311_23.5.2-0-Linux-s390x.sh</a></td>
+      <td class="s">94.5M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>221a4cd7f0a9275c3263efa07fa37385746de884f4306bb5d1fe5733ca770550</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-Linux-ppc64le.sh">Miniconda3-py311_23.5.2-0-Linux-ppc64le.sh</a></td>
+      <td class="s">77.3M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>92237cb2a443dd15005ec004f2f744b14de02cd5513a00983c2f191eb43d1b29</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.2-0-Linux-aarch64.sh">Miniconda3-py311_23.5.2-0-Linux-aarch64.sh</a></td>
+      <td class="s">76.4M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>3962738cfac270ae4ff30da0e382aecf6b3305a12064b196457747b157749a7a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-Windows-x86_64.exe">Miniconda3-py310_23.5.2-0-Windows-x86_64.exe</a></td>
+      <td class="s">69.5M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>e15638645b34921098a3f760fd8af07e53a427f59b99a0f049420a7751cbbc05</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-MacOSX-x86_64.sh">Miniconda3-py310_23.5.2-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.6M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>13c57188a4bcb7462a7580c9ddf8ff2d301e353c835d33042a51a231667cf25d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-MacOSX-x86_64.pkg">Miniconda3-py310_23.5.2-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">65.2M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>7654b911e5649b051d9695e015bc2f24309fbade5d6298ba4c2f2d2118bd524a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-MacOSX-arm64.sh">Miniconda3-py310_23.5.2-0-MacOSX-arm64.sh</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>71b7ca2ae4068504f9c6dab30fd6e83694086241156af1e319d598befe0f3a26</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-MacOSX-arm64.pkg">Miniconda3-py310_23.5.2-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">64.2M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>57674d7cd22529e8425c76507ebbc4ebb6eb4c2fa36b9563439ceb88b5401765</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-Linux-x86_64.sh">Miniconda3-py310_23.5.2-0-Linux-x86_64.sh</a></td>
+      <td class="s">91.4M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>ea5e6e8a3d5a0247b9df85382d27220fac8e59b5778fd313c5913879cd9baafc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-Linux-s390x.sh">Miniconda3-py310_23.5.2-0-Linux-s390x.sh</a></td>
+      <td class="s">88.0M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>7a65b8593db0ec4b561b9968daca7c7c4f5f95cb21fe717ba895fded924bc056</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-Linux-ppc64le.sh">Miniconda3-py310_23.5.2-0-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>3a76e4e400271d1589770dac8f696b03d1faf45fee57da38e8c399b6cb0daadb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.2-0-Linux-aarch64.sh">Miniconda3-py310_23.5.2-0-Linux-aarch64.sh</a></td>
+      <td class="s">72.9M</td>
+      <td>2023-07-13 13:55:51</td>
+      <td>24f7fe91032538cf2d9748facabae346e45e46ca21bb5f2d5875b7865dca6fa4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-Linux-ppc64le.sh">Miniconda3-py311_23.5.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">77.4M</td>
+      <td>2023-07-12 21:10:15</td>
+      <td>63d6756dd9956e3ff581381fd319088fe23af53df8ccad8c6f029c89f5a1e534</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-Linux-s390x.sh">Miniconda3-py311_23.5.1-0-Linux-s390x.sh</a></td>
+      <td class="s">94.5M</td>
+      <td>2023-07-12 21:10:12</td>
+      <td>4472acdf8bab722a6dc4ef0b59636feac12b3520ef3d88c1bebd11106b596a96</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-Linux-aarch64.sh">Miniconda3-py311_23.5.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">76.4M</td>
+      <td>2023-07-12 21:10:09</td>
+      <td>a7a68db6676075aa20991d3fac6d7cfdb2bb3c815c0c17ea26fac96241486c6b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-Linux-x86_64.sh">Miniconda3-py311_23.5.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">98.4M</td>
+      <td>2023-07-12 21:10:06</td>
+      <td>333779c9cae3fe14735949a8dcb9657b9e55ada69e9c60f191c5d582b2deac20</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-Windows-x86_64.exe">Miniconda3-py311_23.5.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">73.2M</td>
+      <td>2023-07-12 21:10:00</td>
+      <td>0e1b4b02e8c814cfa2b522a377902233a393582c301fd24e6b45434be515e271</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-MacOSX-x86_64.sh">Miniconda3-py311_23.5.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">69.6M</td>
+      <td>2023-07-12 21:09:53</td>
+      <td>834a194e6d790eade3db98a78ec3f2857df13bb8b6661a26a34e67462561015b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-MacOSX-x86_64.pkg">Miniconda3-py311_23.5.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">69.2M</td>
+      <td>2023-07-12 21:09:53</td>
+      <td>28246305e5ce559c9dbd8e052aee1b86cc25eee2db291d8a487dbd4ef485d1bd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-MacOSX-arm64.sh">Miniconda3-py311_23.5.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">68.6M</td>
+      <td>2023-07-12 21:09:44</td>
+      <td>52b3a134a73d48204e7517fb5b4378bece65a048e9a32c9276eb3fd51989b976</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.1-0-MacOSX-arm64.pkg">Miniconda3-py311_23.5.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">68.1M</td>
+      <td>2023-07-12 21:09:44</td>
+      <td>701027d1dce28c5b04272eb67e5040afa87ec5d97f195c1346838d225f17e7e0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-Windows-x86_64.exe">Miniconda3-py39_23.5.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">70.1M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>be50a503cb7d33e4d68a249f1e805ea457980f32ff2cfd71679ddd04740cfeac</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-MacOSX-x86_64.sh">Miniconda3-py39_23.5.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.0M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>056b43eb844aac487e5f6e0f748c528a34cd3d38c8409f239a75bf89ffede3b9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-MacOSX-x86_64.pkg">Miniconda3-py39_23.5.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>65bbae95687472d2dbfc8be2b2b6c99e5fa6a9c83c2dfd3bf4f28c979df41a4d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-MacOSX-arm64.sh">Miniconda3-py39_23.5.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">64.1M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>63aaa53c1f6139d667f8e308a2849632efeb575e6223d075ab8a8c15850478d6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-MacOSX-arm64.pkg">Miniconda3-py39_23.5.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.7M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>60cf1239502a63b9bcfda64a5ab64fd07558c7db52762d9ac55a1f5f97fed328</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-Linux-x86_64.sh">Miniconda3-py39_23.5.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">89.1M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>960b7aa0294d6d828739ad5542fe1d8b81bb602be401ad00febdf9d29bf37514</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-Linux-s390x.sh">Miniconda3-py39_23.5.1-0-Linux-s390x.sh</a></td>
+      <td class="s">85.5M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>b3ea1e4ce80901b70b49d14bc4a008d910410ddd58dead9c4c220834f5aa46c2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-Linux-ppc64le.sh">Miniconda3-py39_23.5.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">84.5M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>a981947722decf258e4a21f06ab5ddd545c709ba959957121a3e3b89b3dd860a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.1-0-Linux-aarch64.sh">Miniconda3-py39_23.5.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">83.9M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>ac438ca1a76d78622cc7768d94988e5673983f60f0302941ce05ea4e11e1376e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-Windows-x86_64.exe">Miniconda3-py38_23.5.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">71.0M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>679e951a61d903c24c715d4662c204871d05997f3fe1fc1c32b94de86e8df313</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-MacOSX-x86_64.sh">Miniconda3-py38_23.5.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">66.5M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>ed617d73092e9f0b696f2b55e68126d751040ef6700c2ea38bc913bf18fd8956</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-MacOSX-x86_64.pkg">Miniconda3-py38_23.5.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">66.2M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>12e8cb360ebdc5798334a156a677cb2f2791f20516a778be3ad2f06cd8d7787a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-MacOSX-arm64.sh">Miniconda3-py38_23.5.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">65.7M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>044bc2a3eab865448924bf2aeab069a7a61a174b132c58f6e9a88cf14c5b647c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-MacOSX-arm64.pkg">Miniconda3-py38_23.5.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">65.3M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>db0f714abd5a6cd20047f0091d84191ff49f498bdccf25b812abbee38b02ad92</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-Linux-x86_64.sh">Miniconda3-py38_23.5.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">89.3M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>05c1284d67d35abcc3a9b814cd124ec351020b9172962bcc166bf2f2ac22ea5e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-Linux-s390x.sh">Miniconda3-py38_23.5.1-0-Linux-s390x.sh</a></td>
+      <td class="s">85.8M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>1c7c2188cad19a1a00bf8a5895af8bd67a06f983ea02d34ad3cdb40cb6a86224</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-Linux-ppc64le.sh">Miniconda3-py38_23.5.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>1c141b28ffe6dee40fc04c0d175da22270b86c63ec67e71798cd15183d10bcf2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.1-0-Linux-aarch64.sh">Miniconda3-py38_23.5.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">72.7M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>dcf57b73c3db9b4ce5ab1407f0573c83241b5041f2c6fd590959a091ca518b4c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-Windows-x86_64.exe">Miniconda3-py310_23.5.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">69.5M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>c9945c5530c2632fc4af6ce03bc355d2ce52fd05c30d720dea5cb2cac52d8d50</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-MacOSX-x86_64.sh">Miniconda3-py310_23.5.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.6M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>4e5315e39ce5be6d64fb0bf0a62aa6e8d09224542fa5b9a4d695c599bd6f66b0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-MacOSX-x86_64.pkg">Miniconda3-py310_23.5.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">65.3M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>1d5c372f5f8071f3dc73d9512e174fa662002f0cd10161acf18f10ce3f52bf3f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-MacOSX-arm64.sh">Miniconda3-py310_23.5.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>dde48d596695115a05218d694b20212d900a66c005a1926a9018a756b1188f1f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-MacOSX-arm64.pkg">Miniconda3-py310_23.5.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">64.2M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>240e86f18669a23ddaa85fbe822394bbeed0069e78cae9c118b53cc7f5370af0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-Linux-x86_64.sh">Miniconda3-py310_23.5.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">91.4M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>9f4cd0a9f7289a1e03b79fe6d06bab0769c46c33a774ea8a94dc3c1883344d85</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-Linux-s390x.sh">Miniconda3-py310_23.5.1-0-Linux-s390x.sh</a></td>
+      <td class="s">88.0M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>63962e4c21e13b680f62d8c7cf11fb1a4a2192188d0d7c0a0994099470b65567</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-Linux-ppc64le.sh">Miniconda3-py310_23.5.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>920a8d8f9a6aa6bc1cd2ddf56cb0af779b3c70eb82d61fb05397814adfc0837f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.1-0-Linux-aarch64.sh">Miniconda3-py310_23.5.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">72.9M</td>
+      <td>2023-07-12 21:09:21</td>
+      <td>d6a99c45326f8e849b18964090f0f5ac56bc4f173a6b18a4a5057bc09bd128f3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-uninstaller-patch-win-64-2023.07-0.exe">Miniconda3-uninstaller-patch-win-64-2023.07-0.exe</a></td>
+      <td class="s">707K</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>38a6f11e8f8ebcdbaadd713bb3f3c4ded87c854dc6e2bb8d60df1e2fc2d9f1b5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-Windows-x86_64.exe">Miniconda3-py39_23.5.0-3-Windows-x86_64.exe</a></td>
+      <td class="s">70.0M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>0b457f3279409325eb95939a69a2cbd81d3cfb8d5df672b85315c14eb0ee9544</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-MacOSX-x86_64.sh">Miniconda3-py39_23.5.0-3-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.0M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>86ae780b5c5a32c45bc0f2e146941afea6dd1ca48e8d5e1bf99a83df255a0a78</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-MacOSX-x86_64.pkg">Miniconda3-py39_23.5.0-3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>3a75740b5798e48f22538c7cff4b3d9d9549df4eda5e7a6ced5ebc3eab10f297</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-MacOSX-arm64.sh">Miniconda3-py39_23.5.0-3-MacOSX-arm64.sh</a></td>
+      <td class="s">64.1M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>d006d99f86850510f9aed1a81e16a4213a4829e7ea6913f0c42054b4b0ac05a7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-MacOSX-arm64.pkg">Miniconda3-py39_23.5.0-3-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.7M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>7669a7826ac1195483ca2abd51b7f749620db3aff2f3851670441fc56652a35b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-Linux-x86_64.sh">Miniconda3-py39_23.5.0-3-Linux-x86_64.sh</a></td>
+      <td class="s">89.1M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>b7fc320922235ccbaacba7b5a61e34671e75f3a2c7110c63db0c6a9f98ecf8a8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-Linux-s390x.sh">Miniconda3-py39_23.5.0-3-Linux-s390x.sh</a></td>
+      <td class="s">85.5M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>7ef72ef1411b028788c81308238b604cba46315cb42e70a2d65511c05440ebca</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-Linux-ppc64le.sh">Miniconda3-py39_23.5.0-3-Linux-ppc64le.sh</a></td>
+      <td class="s">84.5M</td>
+      <td>2023-07-11 15:07:06</td>
+      <td>4bbda8ba3b8d1d26f04a469bbe29b3ef626a8b10b823f64314719e132f7c3696</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.5.0-3-Linux-aarch64.sh">Miniconda3-py39_23.5.0-3-Linux-aarch64.sh</a></td>
+      <td class="s">83.9M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>f77868e96eee904cd137ebe463439258d76281830bb9e2bd330d23aea1ddd31a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-Windows-x86_64.exe">Miniconda3-py38_23.5.0-3-Windows-x86_64.exe</a></td>
+      <td class="s">71.0M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>a643675ca68f7c0577864e20f73615a52aeb9c07663576411a86964326fe4288</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-MacOSX-x86_64.sh">Miniconda3-py38_23.5.0-3-MacOSX-x86_64.sh</a></td>
+      <td class="s">66.5M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>54ead65ad1ff77d9cba2512a8765d64e6b7d8ae154e2fc1a6fcb01395b9a8cf3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-MacOSX-x86_64.pkg">Miniconda3-py38_23.5.0-3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">66.2M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>1f53b13e8224b40ad9292c4884c3052359b1826a90b49f4e4724affa10d31bb6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-MacOSX-arm64.sh">Miniconda3-py38_23.5.0-3-MacOSX-arm64.sh</a></td>
+      <td class="s">65.7M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>5daf6837136d08a17f039b29993f67207ba90dcc90abe94c6d5a8925f6888076</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-MacOSX-arm64.pkg">Miniconda3-py38_23.5.0-3-MacOSX-arm64.pkg</a></td>
+      <td class="s">65.3M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>789317cc46f3d1766fe44b701c435f5505318c60eb18d607401b30a9cd7bcc3c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-Linux-x86_64.sh">Miniconda3-py38_23.5.0-3-Linux-x86_64.sh</a></td>
+      <td class="s">89.3M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>f833ae8ad96db31d4f2a09d12f1b188721c769d60d813d7e6341c19e77bc791f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-Linux-s390x.sh">Miniconda3-py38_23.5.0-3-Linux-s390x.sh</a></td>
+      <td class="s">85.8M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>e0271bc3af023053258cfe01059d53769bbd32dc5542b5c96280d29dcd8568f6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-Linux-ppc64le.sh">Miniconda3-py38_23.5.0-3-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>5bef0b71b9c9c6a27e534894e913e47e545793a549a8815bb4a66a8c9d793d45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.5.0-3-Linux-aarch64.sh">Miniconda3-py38_23.5.0-3-Linux-aarch64.sh</a></td>
+      <td class="s">72.7M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>853e1c3c24f1c4cc2a1c57b05059740127724a2b346f887e3f0bb92a6cd05fe1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-Windows-x86_64.exe">Miniconda3-py311_23.5.0-3-Windows-x86_64.exe</a></td>
+      <td class="s">73.2M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>51a50e2997bc4ec9361733f90cb1ed343910fbc73e8a2b01b86e514921f1c026</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-MacOSX-x86_64.sh">Miniconda3-py311_23.5.0-3-MacOSX-x86_64.sh</a></td>
+      <td class="s">69.6M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>2503d9e852fcaf85adca825bde84bdc297b118fd2c14316e4f27a93a190a7bdd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-MacOSX-x86_64.pkg">Miniconda3-py311_23.5.0-3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">69.2M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>2f9a3ccb69c146a748c1270a625a481f73c49d714a35c5ea84399e32892af830</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-MacOSX-arm64.sh">Miniconda3-py311_23.5.0-3-MacOSX-arm64.sh</a></td>
+      <td class="s">68.6M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>c4ce7311d2d1c729bf8d98e6d5aa2581ce0b08a1480985e63efaf8529b2fc6ca</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-MacOSX-arm64.pkg">Miniconda3-py311_23.5.0-3-MacOSX-arm64.pkg</a></td>
+      <td class="s">68.2M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>b0eba1878ce8d4f0c36bead75e849a5f513055756d794344ff6b371e47b66cbe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-Linux-x86_64.sh">Miniconda3-py311_23.5.0-3-Linux-x86_64.sh</a></td>
+      <td class="s">98.4M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>61a5c087893f6210176045931b89ee6e8760c17abd9c862b2cab4c1b7d00f7c8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-Linux-s390x.sh">Miniconda3-py311_23.5.0-3-Linux-s390x.sh</a></td>
+      <td class="s">94.5M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>42e7cc490fc81d9b1dc56cf8bd951e084e804824d60aca3a4b15d35c57ad373e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-Linux-ppc64le.sh">Miniconda3-py311_23.5.0-3-Linux-ppc64le.sh</a></td>
+      <td class="s">77.4M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>c1ab8b5d629f66a1609e456a0d6a83a2896af6dc0b2b702025cb19456030eacd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py311_23.5.0-3-Linux-aarch64.sh">Miniconda3-py311_23.5.0-3-Linux-aarch64.sh</a></td>
+      <td class="s">76.4M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>6e3e60e7093194b3435fde19efc54d0dd78be393bf5b7487cc28cd1039ebed4d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-Windows-x86_64.exe">Miniconda3-py310_23.5.0-3-Windows-x86_64.exe</a></td>
+      <td class="s">69.5M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>cb4e61bc59068a5e3732a2a58b0414c970848d3499c64c725ccd7d0000964335</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-MacOSX-x86_64.sh">Miniconda3-py310_23.5.0-3-MacOSX-x86_64.sh</a></td>
+      <td class="s">65.6M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>03a98ff5d1c813d7bf969203fe404d7a6f149b335c2077703656807721603495</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-MacOSX-x86_64.pkg">Miniconda3-py310_23.5.0-3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">65.3M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>4cbc8d3bec69286364c4fe5b02e88b8059de4ffbb4707f1e589c5deef1a210ff</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-MacOSX-arm64.sh">Miniconda3-py310_23.5.0-3-MacOSX-arm64.sh</a></td>
+      <td class="s">64.6M</td>
+      <td>2023-07-11 15:07:05</td>
+      <td>ff2121c0a8245bbe63ff70cdb76b492c831889225f9c5277e096f08fd03e7f17</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-MacOSX-arm64.pkg">Miniconda3-py310_23.5.0-3-MacOSX-arm64.pkg</a></td>
+      <td class="s">64.2M</td>
+      <td>2023-07-11 15:07:04</td>
+      <td>a6dbd3472410e6afa8b56bf80f2083d2d8ac0922c0d9c07b818c9a131662bb59</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-Linux-x86_64.sh">Miniconda3-py310_23.5.0-3-Linux-x86_64.sh</a></td>
+      <td class="s">91.4M</td>
+      <td>2023-07-11 15:07:04</td>
+      <td>738890e7a6f0719a942c632a0aab1df7a5a592c5667d0495d1f0495990a709ba</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-Linux-s390x.sh">Miniconda3-py310_23.5.0-3-Linux-s390x.sh</a></td>
+      <td class="s">88.0M</td>
+      <td>2023-07-11 15:07:04</td>
+      <td>5701eba074e3c2894949370ab456df48361a2efaad9b11209dbf8258ddf1e331</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-Linux-ppc64le.sh">Miniconda3-py310_23.5.0-3-Linux-ppc64le.sh</a></td>
+      <td class="s">74.1M</td>
+      <td>2023-07-11 15:07:04</td>
+      <td>5ed0af4645f49c4412e33a3f94396bcb3eb25f4a3ccb0bfe5bc23ef06bad6f3f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.5.0-3-Linux-aarch64.sh">Miniconda3-py310_23.5.0-3-Linux-aarch64.sh</a></td>
+      <td class="s">72.9M</td>
+      <td>2023-07-11 15:07:04</td>
+      <td>a632110a9ebddd8528b26241663ee9368d218e36b40e570072774897762f1de8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-Windows-x86_64.exe">Miniconda3-py39_23.3.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">53.7M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>155958e7922d8b7aa6cb3115aeb66d2efcdae1237a6f1c11e23ca75ea96d291a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-MacOSX-x86_64.sh">Miniconda3-py39_23.3.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.4M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>54d739715feb0cd5c127865215cc9f50697709d71e9ee7da430576c5a1c8010d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-MacOSX-x86_64.pkg">Miniconda3-py39_23.3.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">44.1M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>6960a11f74a0717adaacdc979d1817f5d0e3612d2ef7a409d547fbeac6d58ed7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh">Miniconda3-py39_23.3.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">43.0M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>c74474bab188b8b3dcaf0f0ca52f5e0743591dbe171766016023d052acf96502</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-MacOSX-arm64.pkg">Miniconda3-py39_23.3.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.7M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>9bc8a8fde9d01e26ee37a6611a92a66d36db66ff82e76bd4f18cb28cfbad7a1f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-Linux-x86_64.sh">Miniconda3-py39_23.3.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">67.3M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>1564571a6a06a9999a75a6c65d63cb82911fc647e96ba5b729f904bf00c177d3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-Linux-s390x.sh">Miniconda3-py39_23.3.1-0-Linux-s390x.sh</a></td>
+      <td class="s">63.3M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>d0b658566edd239dd50fc28ab1d3a57b8b0da707481b3b18c27d11273c4fdb5a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-Linux-ppc64le.sh">Miniconda3-py39_23.3.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">61.2M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>d2bcef86812863adaf11fcda6df829aa508760cbde4a19174cf0fec03e8498f5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.3.1-0-Linux-aarch64.sh">Miniconda3-py39_23.3.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">61.0M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>e93ccab720b57f821e0d758f54e9aee9bd2f0ea931ebb26b78d866704437a296</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-Windows-x86_64.exe">Miniconda3-py38_23.3.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">53.1M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>f567b46b2312af5e60ec8f45daf9be626295b7716651e6e7434c447feea9123a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-MacOSX-x86_64.sh">Miniconda3-py38_23.3.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.2M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>eb7b2d285f6d3b7c9cde9576c8c647e70b65361426b0e0e069b4ab23ccbb79e2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-MacOSX-x86_64.pkg">Miniconda3-py38_23.3.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">43.9M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>23d6fa672be46632abd0bbed1f12ce9542a6cb4a38922dab503d9a6096d186d3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-MacOSX-arm64.sh">Miniconda3-py38_23.3.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">42.9M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>e0151c68f6a11a38b29c2f4a775bf6a22187fa2c8ca0f31930d69f2f013c0810</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-MacOSX-arm64.pkg">Miniconda3-py38_23.3.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.6M</td>
+      <td>2023-04-24 09:16:50</td>
+      <td>6714fdefd12e1a65c7fd344f3829a4b054ae42d3d1368b07ceeab9dcc41ad48b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-Linux-x86_64.sh">Miniconda3-py38_23.3.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">65.8M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>d1f3a4388c1a6fd065e32870f67abc39eb38f4edd36c4947ec7411e32311bd59</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-Linux-s390x.sh">Miniconda3-py38_23.3.1-0-Linux-s390x.sh</a></td>
+      <td class="s">62.0M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>e4d83bb9f0900c9128504f7e3c4d3b9e5eaf3b87c4bb5190a3086947e92bd3fa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-Linux-ppc64le.sh">Miniconda3-py38_23.3.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">49.3M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>8aa819800ba3ec88ad8518a9e4fc71ada8087547300fc53527c4ecc8072a4d50</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.3.1-0-Linux-aarch64.sh">Miniconda3-py38_23.3.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">48.8M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>ad491ebad6efec7470fe2139c8b407a895cb2c828b3233b97da6e4f22cae0cde</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-Windows-x86_64.exe">Miniconda3-py310_23.3.1-0-Windows-x86_64.exe</a></td>
+      <td class="s">53.9M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>307194e1f12bbeb52b083634e89cc67db4f7980bd542254b43d3309eaf7cb358</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-MacOSX-x86_64.sh">Miniconda3-py310_23.3.1-0-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.1M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>5abc78b664b7da9d14ade330534cc98283bb838c6b10ad9cfd8b9cc4153f8104</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-MacOSX-x86_64.pkg">Miniconda3-py310_23.3.1-0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">43.8M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>cca31a0f1e5394f2b739726dc22551c2a19afdf689c13a25668887ba706cba58</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-MacOSX-arm64.sh">Miniconda3-py310_23.3.1-0-MacOSX-arm64.sh</a></td>
+      <td class="s">42.6M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>9d1d12573339c49050b0d5a840af0ff6c32d33c3de1b3db478c01878eb003d64</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-MacOSX-arm64.pkg">Miniconda3-py310_23.3.1-0-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.3M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>6997472c5ff90a772eb77e6397f4e3e227736c83a7f7b839da33d6cc7facb75d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-Linux-x86_64.sh">Miniconda3-py310_23.3.1-0-Linux-x86_64.sh</a></td>
+      <td class="s">69.7M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>aef279d6baea7f67940f16aad17ebe5f6aac97487c7c03466ff01f4819e5a651</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-Linux-s390x.sh">Miniconda3-py310_23.3.1-0-Linux-s390x.sh</a></td>
+      <td class="s">66.0M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>ed4f51afc967e921ff5721151f567a4c43c4288ac93ec2393c6238b8c4891de8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-Linux-ppc64le.sh">Miniconda3-py310_23.3.1-0-Linux-ppc64le.sh</a></td>
+      <td class="s">50.8M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>b3de538cd542bc4f5a2f2d2a79386288d6e04f0e1459755f3cefe64763e51d16</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.3.1-0-Linux-aarch64.sh">Miniconda3-py310_23.3.1-0-Linux-aarch64.sh</a></td>
+      <td class="s">50.3M</td>
+      <td>2023-04-24 09:16:49</td>
+      <td>6950c7b1f4f65ce9b87ee1a2d684837771ae7b2e6044e0da9e915d1dee6c924c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-Windows-x86_64.exe">Miniconda3-py39_23.1.0-1-Windows-x86_64.exe</a></td>
+      <td class="s">52.9M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>a2e7ec485e5412673fad31e6a5a79f9de73792e7c966764f92eabf25ec37557f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-MacOSX-x86_64.sh">Miniconda3-py39_23.1.0-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">43.3M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>d78eaac94f85bacbc704f629bdfbc2cd42a72dc3a4fd383a3bfc80997495320e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-MacOSX-x86_64.pkg">Miniconda3-py39_23.1.0-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">43.1M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>878c7939731a712ba3dccfccf8df3c0ac8e5a7d7486b43bfc9e422907ecf8ca5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-MacOSX-arm64.sh">Miniconda3-py39_23.1.0-1-MacOSX-arm64.sh</a></td>
+      <td class="s">43.0M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>a7133a703e41ea0b1738196fb03f72b22250327adea94521c9dd6100c304dc63</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-MacOSX-arm64.pkg">Miniconda3-py39_23.1.0-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.7M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>b09fa8474db00127701a670886e8608da6e00c4be97d93f5dd57bbd497cdb92a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-Linux-x86_64.sh">Miniconda3-py39_23.1.0-1-Linux-x86_64.sh</a></td>
+      <td class="s">66.7M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>5dc619babc1d19d6688617966251a38d245cb93d69066ccde9a013e1ebb5bf18</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-Linux-s390x.sh">Miniconda3-py39_23.1.0-1-Linux-s390x.sh</a></td>
+      <td class="s">62.8M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>5159322f15d9e2b22b3cf90fe88b336d84f62189178c872a9288a339d86f5d20</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-Linux-ppc64le.sh">Miniconda3-py39_23.1.0-1-Linux-ppc64le.sh</a></td>
+      <td class="s">60.6M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>cf5d7cad2b0eb260903b3661ee3fa822eecb25cf3c9b14bc9de10d72963d3d5a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_23.1.0-1-Linux-aarch64.sh">Miniconda3-py39_23.1.0-1-Linux-aarch64.sh</a></td>
+      <td class="s">60.5M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>5e67416a574c49e19dc21d5b9ed586400863a685bc4e34b4d933ea8c7c1ed2da</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-Windows-x86_64.exe">Miniconda3-py38_23.1.0-1-Windows-x86_64.exe</a></td>
+      <td class="s">52.4M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>4178df2a15284fd07b10c5fad592e5c15e6be5bfc37ee90d8e02bbde7792f6f9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-MacOSX-x86_64.sh">Miniconda3-py38_23.1.0-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">43.3M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>5d789cda38b23245ffed6b88c60b7479d984bbf20e3b70d66cd150f04a9c25c5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-MacOSX-x86_64.pkg">Miniconda3-py38_23.1.0-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">43.1M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>beed5074ac12b9ef2820f03a3a0efe910cdd545af8fe0aad1d9c190173150f88</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-MacOSX-arm64.sh">Miniconda3-py38_23.1.0-1-MacOSX-arm64.sh</a></td>
+      <td class="s">42.9M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>8dfab7797151a31b16c174da9a5bc09529d5859f21e77f0655ea9b18209cc926</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-MacOSX-arm64.pkg">Miniconda3-py38_23.1.0-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.6M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>975d6daa8afd01459b99b924703494a23519ed113bac5ba7f7db355904f37b22</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-Linux-x86_64.sh">Miniconda3-py38_23.1.0-1-Linux-x86_64.sh</a></td>
+      <td class="s">65.4M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>640b7dceee6fad10cb7e7b54667b2945c4d6f57625d062b2b0952b7f3a908ab7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-Linux-s390x.sh">Miniconda3-py38_23.1.0-1-Linux-s390x.sh</a></td>
+      <td class="s">61.5M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>3d1e06eddaef0976530c54ed7dda80df62705c16513634e58f7d1c4567227b9e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-Linux-ppc64le.sh">Miniconda3-py38_23.1.0-1-Linux-ppc64le.sh</a></td>
+      <td class="s">48.5M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>d89faee2d839c7e8a2c96f3ca60295c08e837c2f134f6bb9e9e21b707babedc2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_23.1.0-1-Linux-aarch64.sh">Miniconda3-py38_23.1.0-1-Linux-aarch64.sh</a></td>
+      <td class="s">48.2M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>10ea91cc579a64a3a88727119ac3f55839562f55118458b82824b544bc74f90d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-Windows-x86_64.exe">Miniconda3-py37_23.1.0-1-Windows-x86_64.exe</a></td>
+      <td class="s">50.6M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>2319e6ab37215daf08f47b0da35a53f6a648121029113ae2ba53917d777b84bd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-MacOSX-x86_64.sh">Miniconda3-py37_23.1.0-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">53.3M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>bdfb2f01c0a3917bf258daffc65b69bfe07e29753be624aaf9cbda5ba02f43f4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-MacOSX-x86_64.pkg">Miniconda3-py37_23.1.0-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">53.0M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>0384041d2ccf777d88ec7ce9326ee15140becbd5faa0fb2cd1269d1e4cc8fc6f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-Linux-x86_64.sh">Miniconda3-py37_23.1.0-1-Linux-x86_64.sh</a></td>
+      <td class="s">86.5M</td>
+      <td>2023-02-07 21:27:23</td>
+      <td>fc96109ea96493e31f70abbc5cae58e80634480c0686ab46924549ac41176812</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-Linux-s390x.sh">Miniconda3-py37_23.1.0-1-Linux-s390x.sh</a></td>
+      <td class="s">82.8M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>72a8fa9aca5abaf99771110746b1345a33d390c9b29a7b4daffe6a2ff00f2366</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-Linux-ppc64le.sh">Miniconda3-py37_23.1.0-1-Linux-ppc64le.sh</a></td>
+      <td class="s">81.2M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>d2de534bfa46aa34ef0b115a309de7e8a681683af65faf86bcee6a00460f07be</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_23.1.0-1-Linux-aarch64.sh">Miniconda3-py37_23.1.0-1-Linux-aarch64.sh</a></td>
+      <td class="s">80.7M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>31c1d635fae931b7c0687018cc87e918e8098ed5dd5e76a658e10c57e00ef864</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-Windows-x86_64.exe">Miniconda3-py310_23.1.0-1-Windows-x86_64.exe</a></td>
+      <td class="s">53.2M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>d4517212c8ac44fd8b5ccc2d4d9f38c2dd924c77a81c2be92c3a72e70dd3e907</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-MacOSX-x86_64.sh">Miniconda3-py310_23.1.0-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">43.0M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>bfb81814e16eb450b1dbde7b4ecb9ebc5186834cb4ede5926c699762ca69953b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-MacOSX-x86_64.pkg">Miniconda3-py310_23.1.0-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">42.8M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>bcc0067864011a93083ff2d6fe7b29e877c1477f24ee9d34b54d0165f8b32f11</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-MacOSX-arm64.sh">Miniconda3-py310_23.1.0-1-MacOSX-arm64.sh</a></td>
+      <td class="s">41.7M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>cc5bcf95d5db0f7f454b2d800d52da8b70563f8454d529e7ac2da9725650eb27</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-MacOSX-arm64.pkg">Miniconda3-py310_23.1.0-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">41.4M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>09d893e44400f61d36daeaa9befff8219a7e0127358d904a4368b2f0ae738df0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-Linux-x86_64.sh">Miniconda3-py310_23.1.0-1-Linux-x86_64.sh</a></td>
+      <td class="s">71.0M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>32d73e1bc33fda089d7cd9ef4c1be542616bd8e437d1f77afeeaf7afdb019787</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-Linux-s390x.sh">Miniconda3-py310_23.1.0-1-Linux-s390x.sh</a></td>
+      <td class="s">67.6M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>0d00a9d34c5fd17d116bf4e7c893b7441a67c7a25416ede90289d87216104a97</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-Linux-ppc64le.sh">Miniconda3-py310_23.1.0-1-Linux-ppc64le.sh</a></td>
+      <td class="s">52.4M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>9ca8077a0af8845fc574a120ef8d68690d7a9862d354a2a4468de5d2196f406c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_23.1.0-1-Linux-aarch64.sh">Miniconda3-py310_23.1.0-1-Linux-aarch64.sh</a></td>
+      <td class="s">51.6M</td>
+      <td>2023-02-07 21:27:22</td>
+      <td>80d6c306b015e1e3b01ea59dc66c676a81fa30279bc2da1f180a7ef7b2191d6e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-Windows-x86_64.exe">Miniconda3-py39_22.11.1-1-Windows-x86_64.exe</a></td>
+      <td class="s">53.0M</td>
+      <td>2022-12-22 16:35:33</td>
+      <td>4b92942fbd70e84a221306a801b3e4c06dd46e894f949a3eb19b4b150ec19171</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-MacOSX-x86_64.sh">Miniconda3-py39_22.11.1-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.7M</td>
+      <td>2022-12-22 16:35:27</td>
+      <td>9a537f3a1b472098754c59a30b94822f1e9458405af831172aaa8f8124e9df88</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-MacOSX-x86_64.pkg">Miniconda3-py39_22.11.1-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">44.5M</td>
+      <td>2022-12-22 16:35:22</td>
+      <td>c3169286b271e0621d00d821f76dd7bd2563c32389896566dee115e53f6002c1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-MacOSX-arm64.sh">Miniconda3-py39_22.11.1-1-MacOSX-arm64.sh</a></td>
+      <td class="s">43.6M</td>
+      <td>2022-12-22 16:35:17</td>
+      <td>eca5e241faea19d4b352aba819f99f42e2336fdbeecb04f5bc89c9ca786ea798</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-MacOSX-arm64.pkg">Miniconda3-py39_22.11.1-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">43.3M</td>
+      <td>2022-12-22 16:35:13</td>
+      <td>4b5cd684601e638da6987b465b95b0ebbde4dcfcac840fe58095eb3940f4a62c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-Linux-x86_64.sh">Miniconda3-py39_22.11.1-1-Linux-x86_64.sh</a></td>
+      <td class="s">66.7M</td>
+      <td>2022-12-22 16:35:08</td>
+      <td>e685005710679914a909bfb9c52183b3ccc56ad7bb84acc861d596fcbe5d28bb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-Linux-s390x.sh">Miniconda3-py39_22.11.1-1-Linux-s390x.sh</a></td>
+      <td class="s">58.8M</td>
+      <td>2022-12-22 16:35:01</td>
+      <td>ed6176aa6b52e22d939ea5c0c38f9f3cf52d2519a5d0dcb414936287893a31f9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-Linux-ppc64le.sh">Miniconda3-py39_22.11.1-1-Linux-ppc64le.sh</a></td>
+      <td class="s">60.4M</td>
+      <td>2022-12-22 16:34:54</td>
+      <td>16cc2d74644cf838d2761723c01172e0b704674317630480902ef429af29bd0b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_22.11.1-1-Linux-aarch64.sh">Miniconda3-py39_22.11.1-1-Linux-aarch64.sh</a></td>
+      <td class="s">60.3M</td>
+      <td>2022-12-22 16:34:47</td>
+      <td>031b6c52060bb75e930846c0a66baa91db8196f0d97fd32f3822c54db6b7c76a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-Windows-x86_64.exe">Miniconda3-py38_22.11.1-1-Windows-x86_64.exe</a></td>
+      <td class="s">52.5M</td>
+      <td>2022-12-22 16:34:41</td>
+      <td>9f6ce5307db5da4e391ced4a6a73159234c3fc64ab4c1d6621dd0b64b0c24b5f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-MacOSX-x86_64.sh">Miniconda3-py38_22.11.1-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.6M</td>
+      <td>2022-12-22 16:34:35</td>
+      <td>6c4cea3c355326f503d15ae97e5126437529a595499e3ce304cd0f247e935da8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-MacOSX-x86_64.pkg">Miniconda3-py38_22.11.1-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">44.4M</td>
+      <td>2022-12-22 16:34:30</td>
+      <td>62e30204221f9e65e89b3644a60d289c6582eed097f83d5dcd9752bafd743491</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-MacOSX-arm64.sh">Miniconda3-py38_22.11.1-1-MacOSX-arm64.sh</a></td>
+      <td class="s">43.2M</td>
+      <td>2022-12-22 16:34:26</td>
+      <td>bf75dbf193db6895c62b2bb963cab2534a8bbdf0ac956f270da8d7a19f4d1b54</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-MacOSX-arm64.pkg">Miniconda3-py38_22.11.1-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">42.9M</td>
+      <td>2022-12-22 16:34:21</td>
+      <td>34ea0d81e51df29a47625f4900f95390bfb079f063e02ddf1ae57a2133fcef56</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-Linux-x86_64.sh">Miniconda3-py38_22.11.1-1-Linux-x86_64.sh</a></td>
+      <td class="s">61.6M</td>
+      <td>2022-12-22 16:34:17</td>
+      <td>473e5ecc8e078e9ef89355fbca21f8eefa5f9081544befca99867c7beac3150d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-Linux-s390x.sh">Miniconda3-py38_22.11.1-1-Linux-s390x.sh</a></td>
+      <td class="s">57.9M</td>
+      <td>2022-12-22 16:34:10</td>
+      <td>5bdc6ead307c098b32ba8473b7cbbe87eb80f8eca9adba03f47848bcb34a9b38</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-Linux-ppc64le.sh">Miniconda3-py38_22.11.1-1-Linux-ppc64le.sh</a></td>
+      <td class="s">48.5M</td>
+      <td>2022-12-22 16:34:02</td>
+      <td>59fd0901f9fa1ba6b07e734adff4d6c5215e9d7f13ad37f0044af22e9b72194a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_22.11.1-1-Linux-aarch64.sh">Miniconda3-py38_22.11.1-1-Linux-aarch64.sh</a></td>
+      <td class="s">48.1M</td>
+      <td>2022-12-22 16:33:57</td>
+      <td>ff65684bce7a7ad7abb698ff649195816ee0f47a4f17cb9632a44abf69357ea5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-Windows-x86_64.exe">Miniconda3-py37_22.11.1-1-Windows-x86_64.exe</a></td>
+      <td class="s">50.7M</td>
+      <td>2022-12-22 16:33:52</td>
+      <td>4d48f78d7edbf4db0660f3b3e28b6fa17fa469cdc98c76b94e08662b92a308bd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-MacOSX-x86_64.sh">Miniconda3-py37_22.11.1-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">54.8M</td>
+      <td>2022-12-22 16:33:46</td>
+      <td>e51d459aae45bb6b86c2716738b778b788785e6e1ea4b2ed244a0fdd754feb19</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-MacOSX-x86_64.pkg">Miniconda3-py37_22.11.1-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">54.5M</td>
+      <td>2022-12-22 16:33:39</td>
+      <td>b694a332b5ae4e3096c9471969cf00188257364a4bfe59d7f312b19af66bcd48</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-Linux-x86_64.sh">Miniconda3-py37_22.11.1-1-Linux-x86_64.sh</a></td>
+      <td class="s">82.3M</td>
+      <td>2022-12-22 16:33:34</td>
+      <td>22b14d52265b4e609c6ce78e2f2884b277d976b83b5f9c8a83423e3eba2ccfbe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-Linux-s390x.sh">Miniconda3-py37_22.11.1-1-Linux-s390x.sh</a></td>
+      <td class="s">78.7M</td>
+      <td>2022-12-22 16:33:26</td>
+      <td>3c71628865164c3f8b461f8e4b2a353ff1367eed61c83b9c3e14fc201608b1a7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-Linux-ppc64le.sh">Miniconda3-py37_22.11.1-1-Linux-ppc64le.sh</a></td>
+      <td class="s">81.1M</td>
+      <td>2022-12-22 16:33:18</td>
+      <td>dda16ae14992697e3c90b56fe9de819f5f3b1dcb3ac7a31d24ab5736ccd5f129</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_22.11.1-1-Linux-aarch64.sh">Miniconda3-py37_22.11.1-1-Linux-aarch64.sh</a></td>
+      <td class="s">80.5M</td>
+      <td>2022-12-22 16:33:10</td>
+      <td>ebba2f7e33ce5594c50e6422477106e6bb327310838fbac3db89d2eaebcde943</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-Windows-x86_64.exe">Miniconda3-py310_22.11.1-1-Windows-x86_64.exe</a></td>
+      <td class="s">52.9M</td>
+      <td>2022-12-22 16:33:02</td>
+      <td>2e3086630fa3fae7636432a954be530c88d0705fce497120d56e0f5d865b0d51</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-MacOSX-x86_64.sh">Miniconda3-py310_22.11.1-1-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.4M</td>
+      <td>2022-12-22 16:32:56</td>
+      <td>7406579393427eaf9bc0e094dcd3c66d1e1b93ee9db4e7686d0a72ea5d7c0ce5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-MacOSX-x86_64.pkg">Miniconda3-py310_22.11.1-1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">44.2M</td>
+      <td>2022-12-22 16:32:51</td>
+      <td>9195ffba1a6984c81c69649ce976a38455ace5b474c24a4363e5ca65fc72e832</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-MacOSX-arm64.sh">Miniconda3-py310_22.11.1-1-MacOSX-arm64.sh</a></td>
+      <td class="s">43.3M</td>
+      <td>2022-12-22 16:32:45</td>
+      <td>22eec9b7d3add25ac3f9b60621d8f3d8df3e63d4aa0ae5eb846b558d7ba68333</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-MacOSX-arm64.pkg">Miniconda3-py310_22.11.1-1-MacOSX-arm64.pkg</a></td>
+      <td class="s">43.0M</td>
+      <td>2022-12-22 16:32:40</td>
+      <td>fbb33c5770b10a0d5a0deef746e7499bfaf8ff840d0d517175036dd8449357f6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-Linux-x86_64.sh">Miniconda3-py310_22.11.1-1-Linux-x86_64.sh</a></td>
+      <td class="s">69.0M</td>
+      <td>2022-12-22 16:32:36</td>
+      <td>00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-Linux-s390x.sh">Miniconda3-py310_22.11.1-1-Linux-s390x.sh</a></td>
+      <td class="s">61.2M</td>
+      <td>2022-12-22 16:32:28</td>
+      <td>a150511e7fd19d07b770f278fb5dd2df4bc24a8f55f06d6274774f209a36c766</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-Linux-ppc64le.sh">Miniconda3-py310_22.11.1-1-Linux-ppc64le.sh</a></td>
+      <td class="s">50.0M</td>
+      <td>2022-12-22 16:32:20</td>
+      <td>4c86c3383bb27b44f7059336c3a46c34922df42824577b93eadecefbf7423836</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py310_22.11.1-1-Linux-aarch64.sh">Miniconda3-py310_22.11.1-1-Linux-aarch64.sh</a></td>
+      <td class="s">49.6M</td>
+      <td>2022-12-22 16:32:14</td>
+      <td>48a96df9ff56f7421b6dd7f9f71d548023847ba918c3826059918c08326c2017</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-MacOSX-arm64.sh">Miniconda3-py39_4.12.0-MacOSX-arm64.sh</a></td>
+      <td class="s">52.2M</td>
+      <td>2022-06-01 14:45:20</td>
+      <td>4bd112168cc33f8a4a60d3ef7e72b52a85972d588cd065be803eb21d73b625ef</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-MacOSX-arm64.pkg">Miniconda3-py39_4.12.0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.5M</td>
+      <td>2022-06-01 14:45:20</td>
+      <td>0cb5165ca751e827d91a4ae6823bfda24d22c398a0b3b01213e57377a2c54226</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-MacOSX-arm64.sh">Miniconda3-py38_4.12.0-MacOSX-arm64.sh</a></td>
+      <td class="s">52.5M</td>
+      <td>2022-06-01 14:45:20</td>
+      <td>13b992328ef088a49a685ae84461f132f8719bf0cabc43792fc9009b0421f611</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-MacOSX-arm64.pkg">Miniconda3-py38_4.12.0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.8M</td>
+      <td>2022-06-01 14:45:20</td>
+      <td>e92fd40710f7123d9e1b2d44f71e7b2101e3397049b87807ccf612c964beef35</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-MacOSX-x86_64.sh">Miniconda3-py38_4.12.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">56.4M</td>
+      <td>2022-05-16 14:57:26</td>
+      <td>f930f5b1c85e509ebbf9f28e13c697a082581f21472dc5360c41905d10802c7b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-MacOSX-x86_64.pkg">Miniconda3-py38_4.12.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">63.1M</td>
+      <td>2022-05-16 14:57:26</td>
+      <td>62eda1322b971d43409e5dde8dc0fd7bfe799d18a49fb2d8d6ad1f6833448f5c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Linux-x86_64.sh">Miniconda3-py38_4.12.0-Linux-x86_64.sh</a></td>
+      <td class="s">72.6M</td>
+      <td>2022-05-16 14:57:26</td>
+      <td>3190da6626f86eee8abf1b2fd7a5af492994eb2667357ee4243975cdbb175d7a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Linux-s390x.sh">Miniconda3-py38_4.12.0-Linux-s390x.sh</a></td>
+      <td class="s">68.7M</td>
+      <td>2022-05-16 14:57:26</td>
+      <td>3125961430c77eae81556fa59fe25dca9e5808f76c05f87092d6f2d57f85e933</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Linux-aarch64.sh">Miniconda3-py37_4.12.0-Linux-aarch64.sh</a></td>
+      <td class="s">101.7M</td>
+      <td>2022-05-16 14:57:26</td>
+      <td>47affd9577889f80197aadbdf1198b04a41528421aaf0ec1f28b04a50b9f3ab8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Windows-x86_64.exe">Miniconda3-py39_4.12.0-Windows-x86_64.exe</a></td>
+      <td class="s">71.2M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>1acbc2e8277ddd54a5f724896c7edee112d068529588d944702966c867e7e9cc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Windows-x86.exe">Miniconda3-py39_4.12.0-Windows-x86.exe</a></td>
+      <td class="s">67.8M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>4fb64e6c9c28b88beab16994bfba4829110ea3145baa60bda5344174ab65d462</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-MacOSX-x86_64.sh">Miniconda3-py39_4.12.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">56.0M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>007bae6f18dc7b6f2ca6209b5a0c9bd2f283154152f82becf787aac709a51633</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Linux-x86_64.sh">Miniconda3-py39_4.12.0-Linux-x86_64.sh</a></td>
+      <td class="s">73.1M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>78f39f9bae971ec1ae7969f0516017f2413f17796670f7040725dd83fcff5689</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Linux-s390x.sh">Miniconda3-py39_4.12.0-Linux-s390x.sh</a></td>
+      <td class="s">69.2M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>ff6fdad3068ab5b15939c6f422ac329fa005d56ee0876c985e22e622d930e424</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Linux-aarch64.sh">Miniconda3-py39_4.12.0-Linux-aarch64.sh</a></td>
+      <td class="s">75.3M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>5f4f865812101fdc747cea5b820806f678bb50fe0a61f19dc8aa369c52c4e513</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Windows-x86_64.exe">Miniconda3-py38_4.12.0-Windows-x86_64.exe</a></td>
+      <td class="s">70.6M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>94f24e52e316fa935ccf94b0c504ceca8e6abc6190c68378e18550c95bb7cee1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Linux-ppc64le.sh">Miniconda3-py38_4.12.0-Linux-ppc64le.sh</a></td>
+      <td class="s">65.9M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>4be4086710845d10a8911856e9aea706c1464051a24c19aabf7f6e1a1aedf454</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Windows-x86.exe">Miniconda3-py37_4.12.0-Windows-x86.exe</a></td>
+      <td class="s">65.5M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>a6af674b984a333b53aaf99043f6af4f50b0bb2ab78e0b732aa60c47bbfb0704</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-MacOSX-x86_64.pkg">Miniconda3-py37_4.12.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">72.7M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>9278875a235ef625d581c63b46129b27373c3cf5516d36250a1a3640978280cd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Linux-x86_64.sh">Miniconda3-py37_4.12.0-Linux-x86_64.sh</a></td>
+      <td class="s">100.1M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>4dc4214839c60b2f5eb3efbdee1ef5d9b45e74f2c09fcae6c8934a13f36ffc3e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Linux-ppc64le.sh">Miniconda3-py37_4.12.0-Linux-ppc64le.sh</a></td>
+      <td class="s">101.4M</td>
+      <td>2022-05-16 14:57:25</td>
+      <td>c99b66a726a5116f7c825f9535de45fcac9e4e8ae825428abfb190f7748a5fd0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-MacOSX-x86_64.pkg">Miniconda3-py39_4.12.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">62.7M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>cb56184637711685b08f6eba9532cef6985ed7007b38e789613d5dd3f94ccc6b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.12.0-Linux-ppc64le.sh">Miniconda3-py39_4.12.0-Linux-ppc64le.sh</a></td>
+      <td class="s">74.3M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>1fe3305d0ccc9e55b336b051ae12d82f33af408af4b560625674fa7ad915102b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Windows-x86.exe">Miniconda3-py38_4.12.0-Windows-x86.exe</a></td>
+      <td class="s">66.8M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>60cc5874b3cce9d80a38fb2b28df96d880e8e95d1b5848b15c20f1181e2807db</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.12.0-Linux-aarch64.sh">Miniconda3-py38_4.12.0-Linux-aarch64.sh</a></td>
+      <td class="s">64.4M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>0c20f121dc4c8010032d64f8e9b27d79e52d28355eb8d7972eafc90652387777</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Windows-x86_64.exe">Miniconda3-py37_4.12.0-Windows-x86_64.exe</a></td>
+      <td class="s">69.0M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>b221ccdb2bbc5a8209a292f858ae05fd87f882f79be75b37d26faa881523c057</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-MacOSX-x86_64.sh">Miniconda3-py37_4.12.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">66.0M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>323179e4873e291f07db041f3d968da2ffc102dcf709915b48a253914d981868</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.12.0-Linux-s390x.sh">Miniconda3-py37_4.12.0-Linux-s390x.sh</a></td>
+      <td class="s">95.9M</td>
+      <td>2022-05-16 14:57:24</td>
+      <td>8401eb61094297cc53709fec4654695d59652b3adde241963d3d993a6d760ed5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-MacOSX-arm64.sh">Miniconda3-py39_4.11.0-MacOSX-arm64.sh</a></td>
+      <td class="s">55.2M</td>
+      <td>2022-04-20 12:34:16</td>
+      <td>7d3d6e695e62651a2473425b84762b1c1b819a97a2c4419b2b60ae94cab8381b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-MacOSX-arm64.pkg">Miniconda3-py39_4.11.0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.2M</td>
+      <td>2022-04-20 12:34:16</td>
+      <td>66e5eab94e950ed3afbdf6ee2b0b44e9bf1efdc894d1fd5b8294a4cdade9f118</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-MacOSX-arm64.sh">Miniconda3-py38_4.11.0-MacOSX-arm64.sh</a></td>
+      <td class="s">55.6M</td>
+      <td>2022-04-20 12:34:16</td>
+      <td>21faf85f8e4278e528025f1f15e3dff1503693953814c64754a7f93df680be5c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-MacOSX-arm64.pkg">Miniconda3-py38_4.11.0-MacOSX-arm64.pkg</a></td>
+      <td class="s">63.5M</td>
+      <td>2022-04-20 12:34:16</td>
+      <td>724f94292293c3cbfa7c8c97a8ce40e18023f34e0eccb093d6d90113e331c8ad</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Linux-s390x.sh">Miniconda3-py39_4.11.0-Linux-s390x.sh</a></td>
+      <td class="s">68.2M</td>
+      <td>2022-04-20 12:34:08</td>
+      <td>e5e5e89cdcef9332fe632cd25d318cf71f681eef029a24495c713b18e66a8018</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Linux-s390x.sh">Miniconda3-py38_4.11.0-Linux-s390x.sh</a></td>
+      <td class="s">67.8M</td>
+      <td>2022-04-20 12:34:08</td>
+      <td>f70343824949d45e19d96664cd6fa9893583ea61cce0eb3adf5606f4d453bd18</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Linux-s390x.sh">Miniconda3-py37_4.11.0-Linux-s390x.sh</a></td>
+      <td class="s">95.2M</td>
+      <td>2022-04-20 12:34:08</td>
+      <td>b05a2be21e83cedc1350d5895ed8639f21f6a7fc7d36b3cb4f18e1df3f49b03e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Windows-x86_64.exe">Miniconda3-py39_4.11.0-Windows-x86_64.exe</a></td>
+      <td class="s">70.4M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>6013152b169c2c2d4bcd75bb03a1b8bf208b8545d69116a59351af695d9a0081</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-MacOSX-x86_64.sh">Miniconda3-py39_4.11.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">55.2M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>7717253055e7c09339cd3d0815a0b1986b9138dcfcb8ec33b9733df32dd40eaa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Linux-x86_64.sh">Miniconda3-py39_4.11.0-Linux-x86_64.sh</a></td>
+      <td class="s">72.2M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Linux-aarch64.sh">Miniconda3-py39_4.11.0-Linux-aarch64.sh</a></td>
+      <td class="s">74.4M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Linux-x86_64.sh">Miniconda3-py38_4.11.0-Linux-x86_64.sh</a></td>
+      <td class="s">71.7M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>4bb91089ecc5cc2538dece680bfe2e8192de1901e5e420f63d4e78eb26b0ac1a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Linux-ppc64le.sh">Miniconda3-py38_4.11.0-Linux-ppc64le.sh</a></td>
+      <td class="s">65.2M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>2f606bd65ffe76a7866bc445d96105d0a15b7447e59e4317d2e017f7786272d0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Linux-aarch64.sh">Miniconda3-py38_4.11.0-Linux-aarch64.sh</a></td>
+      <td class="s">63.6M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>607549f9f9c5c703be850fa3025e845656d275d8226b679faf3b1c1813c692ce</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-MacOSX-x86_64.sh">Miniconda3-py37_4.11.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">63.5M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>c3a863eb85ad7035e5578684509b0b8387e8eb93c022495ab987baac3df6ef41</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Linux-x86_64.sh">Miniconda3-py37_4.11.0-Linux-x86_64.sh</a></td>
+      <td class="s">98.9M</td>
+      <td>2022-02-15 12:57:08</td>
+      <td>745c99af2cb0d0e0f43c7ed1a3417ff4d5118eafb501518120ea30361f1bb8f6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Windows-x86.exe">Miniconda3-py39_4.11.0-Windows-x86.exe</a></td>
+      <td class="s">66.5M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>12a3a7e8aab7a974705ea4ee5bfc44f7c733241dd1b022f8012cbd42309b8472</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-MacOSX-x86_64.pkg">Miniconda3-py39_4.11.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">61.9M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>d3e63d7e8aa3ffb7b095e0b984db47309bb1cb1ec2138f5e6a96a34173671451</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.11.0-Linux-ppc64le.sh">Miniconda3-py39_4.11.0-Linux-ppc64le.sh</a></td>
+      <td class="s">73.5M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Windows-x86_64.exe">Miniconda3-py38_4.11.0-Windows-x86_64.exe</a></td>
+      <td class="s">69.8M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>29d8d1720034df262b079514e5f200140f7303b37bfe90ae8a2b40b8f294d2d8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-Windows-x86.exe">Miniconda3-py38_4.11.0-Windows-x86.exe</a></td>
+      <td class="s">65.6M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>df115c77915519a9a4de9c04ca26f81703be6ac0344762023557fc7659659ac0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-MacOSX-x86_64.sh">Miniconda3-py38_4.11.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">55.7M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>e13a4590879638197b0c506768438406b07de614911610e314f8c78133915b1c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.11.0-MacOSX-x86_64.pkg">Miniconda3-py38_4.11.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">62.4M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>3ca9720a2b47fbbff529057fd4ec8781a23cb825eec289b487dfa040b7ae8e25</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Windows-x86_64.exe">Miniconda3-py37_4.11.0-Windows-x86_64.exe</a></td>
+      <td class="s">68.1M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>0b4890b2b1782c91ae2de2f77a2f6c5cecb9b54729565771f5301c1fc60fa024</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Windows-x86.exe">Miniconda3-py37_4.11.0-Windows-x86.exe</a></td>
+      <td class="s">64.2M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>64a18114bc66aaa73f431ef8ca1edc7b16ad5564a16e18f13e1a69272d85ca5d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-MacOSX-x86_64.pkg">Miniconda3-py37_4.11.0-MacOSX-x86_64.pkg</a></td>
+      <td class="s">70.2M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>e28d2edb8d79b884f9f35479d35635b2d3d415f3af634b39043aff4ed14a0458</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Linux-ppc64le.sh">Miniconda3-py37_4.11.0-Linux-ppc64le.sh</a></td>
+      <td class="s">101.0M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>041ba0d993398200b3e7f88aee862a23a7cb4ca8ddafbc9d74f8aabb0a5747db</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.11.0-Linux-aarch64.sh">Miniconda3-py37_4.11.0-Linux-aarch64.sh</a></td>
+      <td class="s">100.9M</td>
+      <td>2022-02-15 12:57:07</td>
+      <td>736bd228d336f4b2d16cdc94f2e08a5c80c18dc42b0edfc59fe3f66ffb93a87d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.1-MacOSX-arm64.sh">Miniconda3-py38_4.10.1-MacOSX-arm64.sh</a></td>
+      <td class="s">44.9M</td>
+      <td>2021-11-08 08:57:47</td>
+      <td>4ce4047065f32e991edddbb63b3c7108e7f4534cfc1efafc332454a414deab58</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Windows-x86_64.exe">Miniconda3-py39_4.10.3-Windows-x86_64.exe</a></td>
+      <td class="s">58.1M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>b33797064593ab2229a0135dc69001bea05cb56a20c2f243b1231213642e260a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Windows-x86.exe">Miniconda3-py39_4.10.3-Windows-x86.exe</a></td>
+      <td class="s">55.3M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>24f438e57ff2ef1ce1e93050d4e9d13f5050955f759f448d84a4018d3cd12d6b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-MacOSX-x86_64.sh">Miniconda3-py39_4.10.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">42.3M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>786de9721f43e2c7d2803144c635f5f6e4823483536dc141ccd82dbb927cd508</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-MacOSX-x86_64.pkg">Miniconda3-py39_4.10.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">49.9M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>8fa371ae97218c3c005cd5f04b1f40156d1506a9bd1d5c078f89d563fd416816</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Linux-x86_64.sh">Miniconda3-py39_4.10.3-Linux-x86_64.sh</a></td>
+      <td class="s">63.6M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Linux-s390x.sh">Miniconda3-py39_4.10.3-Linux-s390x.sh</a></td>
+      <td class="s">57.1M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>1faed9abecf4a4ddd4e0d8891fc2cdaa3394c51e877af14ad6b9d4aadb4e90d8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Linux-aarch64.sh">Miniconda3-py39_4.10.3-Linux-aarch64.sh</a></td>
+      <td class="s">62.6M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>4879820a10718743f945d88ef142c3a4b30dfc8e448d1ca08e019586374b773f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Windows-x86_64.exe">Miniconda3-py38_4.10.3-Windows-x86_64.exe</a></td>
+      <td class="s">57.3M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>8940cdd621557bc55743d6bb4518c6d343a4587127e76de808fb07e51df03fea</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Windows-x86.exe">Miniconda3-py38_4.10.3-Windows-x86.exe</a></td>
+      <td class="s">54.5M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>f81c165384c18d1986e2ba2f86cef384bc62266c46b34cd3d274e751ff5d91ed</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-MacOSX-x86_64.sh">Miniconda3-py38_4.10.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">53.3M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>93e514e01142866629175f5a9e2e1d0bac8bc705f61d1ed1da3c010b7225683a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-MacOSX-x86_64.pkg">Miniconda3-py38_4.10.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">60.8M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>faab44cd21b4b09f5c032aa49a8a23d3c53ef629dc9322411348ce413e41df35</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Linux-x86_64.sh">Miniconda3-py38_4.10.3-Linux-x86_64.sh</a></td>
+      <td class="s">98.8M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>935d72deb16e42739d69644977290395561b7a6db059b316958d97939e9bdf3d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Linux-s390x.sh">Miniconda3-py38_4.10.3-Linux-s390x.sh</a></td>
+      <td class="s">89.0M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>55f514110a50e98549a68912cbb03e43a36193940a1889e1c8beb30009b4da19</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Linux-ppc64le.sh">Miniconda3-py38_4.10.3-Linux-ppc64le.sh</a></td>
+      <td class="s">93.3M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>c1ac79540cb77b2e0ca5b9f78b3bc367567d810118500a167dea4a0bcab5d063</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.3-Linux-aarch64.sh">Miniconda3-py38_4.10.3-Linux-aarch64.sh</a></td>
+      <td class="s">94.8M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>19584b4fb5c0656e0cf9de72aaa0b0a7991fbd6f1254d12e2119048c9a47e5cc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Windows-x86_64.exe">Miniconda3-py37_4.10.3-Windows-x86_64.exe</a></td>
+      <td class="s">55.8M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>9c031506bfcb0428a0ac46c9152f9bdd48d5bdaa83046691bf8e0a4480663c05</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Windows-x86.exe">Miniconda3-py37_4.10.3-Windows-x86.exe</a></td>
+      <td class="s">52.9M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>a1bb8338be12ee09dbd4cab9dcc2fbdc99f65d99281dd2c07d24ad0f23dd1f7c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-MacOSX-x86_64.sh">Miniconda3-py37_4.10.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">50.6M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>ca7492d456c319d15682b2d3845112a631365f293d38d1f62872c33a2e57e430</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Linux-x86_64.sh">Miniconda3-py37_4.10.3-Linux-x86_64.sh</a></td>
+      <td class="s">84.9M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Linux-s390x.sh">Miniconda3-py37_4.10.3-Linux-s390x.sh</a></td>
+      <td class="s">84.1M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>7ab9f813dd84cb0951a2d755cd84708263ce4e03c656e65e2fa79ed0f024f0f7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Linux-ppc64le.sh">Miniconda3-py37_4.10.3-Linux-ppc64le.sh</a></td>
+      <td class="s">88.1M</td>
+      <td>2021-07-21 11:05:08</td>
+      <td>e4f8b4a5eb8da1badf0b0c91fd7ee25e39120d4d77443e7a1ef3661fd439a997</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.3-Linux-ppc64le.sh">Miniconda3-py39_4.10.3-Linux-ppc64le.sh</a></td>
+      <td class="s">60.6M</td>
+      <td>2021-07-21 11:05:07</td>
+      <td>fa92ee4773611f58ed9333f977d32bbb64769292f605d518732183be1f3321fa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-MacOSX-x86_64.pkg">Miniconda3-py37_4.10.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">58.1M</td>
+      <td>2021-07-21 11:05:07</td>
+      <td>c3710f25748884741ef8d97777ebb3541c992d51130298830b5b9ad449dbbf1e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.3-Linux-aarch64.sh">Miniconda3-py37_4.10.3-Linux-aarch64.sh</a></td>
+      <td class="s">89.2M</td>
+      <td>2021-07-21 11:05:07</td>
+      <td>65f400a906e3132ddbba35a38d619478be77d32210a2acab05133d92ba08f111</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.1-Linux-s390x.sh">Miniconda3-py39_4.10.1-Linux-s390x.sh</a></td>
+      <td class="s">57.1M</td>
+      <td>2021-06-01 18:38:17</td>
+      <td>afa5c587d2e9754a426da34ca032b41bee8fc5419881cc257ef7ee2e6e951c46</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.1-Linux-s390x.sh">Miniconda3-py38_4.10.1-Linux-s390x.sh</a></td>
+      <td class="s">89.0M</td>
+      <td>2021-06-01 18:38:14</td>
+      <td>ebdff38ca1f8a6e994f78ab6108de09bb722633500980ab79c59ba9312443de5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.1-Linux-s390x.sh">Miniconda3-py37_4.10.1-Linux-s390x.sh</a></td>
+      <td class="s">84.1M</td>
+      <td>2021-06-01 18:38:01</td>
+      <td>71957e590f6616096ef69c345f895603682305962d03889293ea937c3c56db94</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.10.1-Linux-aarch64.sh">Miniconda3-py39_4.10.1-Linux-aarch64.sh</a></td>
+      <td class="s">69.8M</td>
+      <td>2021-06-01 18:33:49</td>
+      <td>737687139c3e2aa43875b67f7d6915e412ac179f2e33e14f00e8b4e1f3d31dd7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.10.1-Linux-aarch64.sh">Miniconda3-py38_4.10.1-Linux-aarch64.sh</a></td>
+      <td class="s">111.1M</td>
+      <td>2021-06-01 18:33:45</td>
+      <td>656998faeac584eac33abe90cbe3c7d0565a49031a4f5049d9e5311bb7b616fe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.10.1-Linux-aarch64.sh">Miniconda3-py37_4.10.1-Linux-aarch64.sh</a></td>
+      <td class="s">104.5M</td>
+      <td>2021-06-01 18:33:41</td>
+      <td>33d00488e14e8659a13bc21e78179dd996cbc7502f4c53c2f4037549c1da91d9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Linux-s390x.sh">Miniconda3-py39_4.9.2-Linux-s390x.sh</a></td>
+      <td class="s">67.0M</td>
+      <td>2021-05-14 10:11:19</td>
+      <td>3bb14774e8dc1a4a0bfa60de3e7b7b16d2551c3d2075437a29fb1c65355732d6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Linux-s390x.sh">Miniconda3-py38_4.9.2-Linux-s390x.sh</a></td>
+      <td class="s">102.5M</td>
+      <td>2021-05-14 10:11:19</td>
+      <td>4e6ace66b732170689fd2a7d86559f674f2de0a0a0fbaefd86ef597d52b89d16</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Linux-s390x.sh">Miniconda3-py37_4.9.2-Linux-s390x.sh</a></td>
+      <td class="s">97.4M</td>
+      <td>2021-05-14 10:11:19</td>
+      <td>a5d767c39016b635da50d88ca141e6c2fa554311c9a2af896644fcbe81f7ce82</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Linux-aarch64.sh">Miniconda3-py39_4.9.2-Linux-aarch64.sh</a></td>
+      <td class="s">76.2M</td>
+      <td>2021-03-16 18:15:18</td>
+      <td>45c5246f3e60dfce4d5ab0cd00c5d01cf39c8e59cefa1f053397f37fb13f4410</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Linux-aarch64.sh">Miniconda3-py38_4.9.2-Linux-aarch64.sh</a></td>
+      <td class="s">111.8M</td>
+      <td>2021-03-16 18:15:18</td>
+      <td>b6fbba97d7cef35ebee8739536752cd8b8b414f88e237146b11ebf081c44618f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Linux-aarch64.sh">Miniconda3-py37_4.9.2-Linux-aarch64.sh</a></td>
+      <td class="s">105.3M</td>
+      <td>2021-03-16 18:15:18</td>
+      <td>ccbac800a2d897218dde1df3711d26299a083ca0beb118edf62cf8f3d9516da8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Windows-x86_64.exe">Miniconda3-py39_4.9.2-Windows-x86_64.exe</a></td>
+      <td class="s">57.7M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>c3a43d6bc4c4fa92454dbfa636ccb859a045d875df602b31ae71b9e0c3fec2b8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Windows-x86.exe">Miniconda3-py39_4.9.2-Windows-x86.exe</a></td>
+      <td class="s">54.9M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>5045fb9dc4405dbba21054262b7d104ba61a8739c1a56038ccb0258f233ad646</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-MacOSX-x86_64.sh">Miniconda3-py39_4.9.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">42.2M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>b3bf77cbb81ee235ec6858146a2a84d20f8ecdeb614678030c39baacb5acbed1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-MacOSX-x86_64.pkg">Miniconda3-py39_4.9.2-MacOSX-x86_64.pkg</a></td>
+      <td class="s">49.7M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>298ff80803817921a98e21d81d60f93b44afce67aec8ae492d289b13741bcffe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Linux-x86_64.sh">Miniconda3-py39_4.9.2-Linux-x86_64.sh</a></td>
+      <td class="s">58.6M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>536817d1b14cb1ada88900f5be51ce0a5e042bae178b5550e62f61e223deae7c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py39_4.9.2-Linux-ppc64le.sh">Miniconda3-py39_4.9.2-Linux-ppc64le.sh</a></td>
+      <td class="s">60.3M</td>
+      <td>2020-12-21 11:02:47</td>
+      <td>64616e57a8d86dbd5bbd14c1e5c60e2dc83c33e9b11a2815a1811394484534ab</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-MacOSX-x86_64.sh">Miniconda3-py38_4.9.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">54.5M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>a9ea0afba55b5d872e01323d495b649eac8ff4ce2ea098fb4c357b6139fe6478</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-MacOSX-x86_64.pkg">Miniconda3-py38_4.9.2-MacOSX-x86_64.pkg</a></td>
+      <td class="s">62.0M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>b06f3bf3cffa9b53695c9c3b8da05bf583bc7047d45b0d74492f154d85e317fa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Linux-x86_64.sh">Miniconda3-py38_4.9.2-Linux-x86_64.sh</a></td>
+      <td class="s">89.9M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>1314b90489f154602fd794accfc90446111514a5a72fe1f71ab83e07de9504a7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Linux-ppc64le.sh">Miniconda3-py38_4.9.2-Linux-ppc64le.sh</a></td>
+      <td class="s">91.9M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>2b111dab4b72a34c969188aa7a91eca927a034b14a87f725fa8d295955364e71</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-MacOSX-x86_64.sh">Miniconda3-py37_4.9.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">53.4M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>93fff5577b548fb4a57cb7ea64975bd395f5224a6f90093e3798a352b09a46e7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-MacOSX-x86_64.pkg">Miniconda3-py37_4.9.2-MacOSX-x86_64.pkg</a></td>
+      <td class="s">60.9M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>ee46e102cd348dfcfd9705a1510ff29437114066b070865818628d9a8ea194bb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Linux-x86_64.sh">Miniconda3-py37_4.9.2-Linux-x86_64.sh</a></td>
+      <td class="s">85.9M</td>
+      <td>2020-11-23 13:06:13</td>
+      <td>79510c6e7bd9e012856e25dcb21b3e093aa4ac8113d9aa7e82a86987eabe1c31</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Windows-x86_64.exe">Miniconda3-py38_4.9.2-Windows-x86_64.exe</a></td>
+      <td class="s">57.0M</td>
+      <td>2020-11-23 13:06:12</td>
+      <td>4fa22bba0497babb5b6608cb8843545372a99f5331c8120099ae1d803f627c61</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.9.2-Windows-x86.exe">Miniconda3-py38_4.9.2-Windows-x86.exe</a></td>
+      <td class="s">54.2M</td>
+      <td>2020-11-23 13:06:12</td>
+      <td>9c2ef76bae97246c85c206733ca30fd1feb8a4b3f90a2a511fea681ce7ebc661</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Windows-x86_64.exe">Miniconda3-py37_4.9.2-Windows-x86_64.exe</a></td>
+      <td class="s">55.8M</td>
+      <td>2020-11-23 13:06:12</td>
+      <td>a31f6ce341a790aae3c509e6eb158e4b4efeece07a44988d21d54b07d9830af0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Windows-x86.exe">Miniconda3-py37_4.9.2-Windows-x86.exe</a></td>
+      <td class="s">52.9M</td>
+      <td>2020-11-23 13:06:12</td>
+      <td>e2ccf83165f4b040b12fe302f6d853b91b741761fa6b1c3c1607b4a7afe1ff9b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.9.2-Linux-ppc64le.sh">Miniconda3-py37_4.9.2-Linux-ppc64le.sh</a></td>
+      <td class="s">88.1M</td>
+      <td>2020-11-23 13:06:12</td>
+      <td>eadf91afde193e6bee34a6272b418e5021e82e4002fb0717752b0bc669f54937</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-MacOSX-x86_64.sh">Miniconda2-py27_4.8.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">40.3M</td>
+      <td>2020-06-16 14:57:58</td>
+      <td>0e2961e20a2239c140766456388beba6630f0c869020d2bd1870c3d040980b45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-MacOSX-x86_64.sh">Miniconda2-latest-MacOSX-x86_64.sh</a></td>
+      <td class="s">40.3M</td>
+      <td>2020-06-16 14:57:58</td>
+      <td>0e2961e20a2239c140766456388beba6630f0c869020d2bd1870c3d040980b45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-Linux-x86_64.sh">Miniconda3-py38_4.8.3-Linux-x86_64.sh</a></td>
+      <td class="s">88.7M</td>
+      <td>2020-06-16 14:57:56</td>
+      <td>879457af6a0bf5b34b48c12de31d4df0ee2f06a8e68768e5758c3293b2daf688</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-Linux-x86_64.sh">Miniconda3-py37_4.8.3-Linux-x86_64.sh</a></td>
+      <td class="s">84.8M</td>
+      <td>2020-06-16 14:57:55</td>
+      <td>bb2e3cedd2e78a8bb6872ab3ab5b1266a90f8c7004a22d8dc2ea5effeb6a439a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-Windows-x86.exe">Miniconda3-py38_4.8.3-Windows-x86.exe</a></td>
+      <td class="s">49.6M</td>
+      <td>2020-06-16 14:57:54</td>
+      <td>415920293ae005a17afaef4c275bd910b06c07d8adf5e0cbc9c69f0f890df976</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-Windows-x86_64.exe">Miniconda3-py38_4.8.3-Windows-x86_64.exe</a></td>
+      <td class="s">55.7M</td>
+      <td>2020-06-16 14:57:53</td>
+      <td>1f4ff67f051c815b6008f144fdc4c3092af2805301d248b56281c36c1f4333e5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-MacOSX-x86_64.sh">Miniconda3-py38_4.8.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">53.2M</td>
+      <td>2020-06-16 14:57:53</td>
+      <td>9b9a353fadab6aa82ac0337c367c23ef842f97868dcbb2ff25ec3aa463afc871</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-MacOSX-x86_64.sh">Miniconda3-py37_4.8.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">52.3M</td>
+      <td>2020-06-16 14:57:52</td>
+      <td>ccc1bded923a790cd61cd17c83c3dcc374dc0415cfa7fb1f71e6a2438236543d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-Linux-ppc64le.sh">Miniconda2-py27_4.8.3-Linux-ppc64le.sh</a></td>
+      <td class="s">51.9M</td>
+      <td>2020-06-16 14:57:51</td>
+      <td>23473678afb15a6ed87045ce6490463420aed9c249607fb389a788e95335bb28</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-Linux-ppc64le.sh">Miniconda2-latest-Linux-ppc64le.sh</a></td>
+      <td class="s">51.9M</td>
+      <td>2020-06-16 14:57:51</td>
+      <td>23473678afb15a6ed87045ce6490463420aed9c249607fb389a788e95335bb28</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-Linux-ppc64le.sh">Miniconda3-py38_4.8.3-Linux-ppc64le.sh</a></td>
+      <td class="s">92.1M</td>
+      <td>2020-06-16 14:57:50</td>
+      <td>362705630a9e85faf29c471faa8b0a48eabfe2bf87c52e4c180825f9215d313c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-Windows-x86.exe">Miniconda2-py27_4.8.3-Windows-x86.exe</a></td>
+      <td class="s">47.7M</td>
+      <td>2020-06-16 14:57:49</td>
+      <td>c8049d26f8b6b954b57bcd4e99ad72d1ffa13f4a6b218e64e641504437b2617b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-Windows-x86.exe">Miniconda2-latest-Windows-x86.exe</a></td>
+      <td class="s">47.7M</td>
+      <td>2020-06-16 14:57:49</td>
+      <td>c8049d26f8b6b954b57bcd4e99ad72d1ffa13f4a6b218e64e641504437b2617b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-Windows-x86_64.exe">Miniconda3-py37_4.8.3-Windows-x86_64.exe</a></td>
+      <td class="s">54.6M</td>
+      <td>2020-06-16 14:57:48</td>
+      <td>6003dbd4d1a9f0c9e64943468d00cf9f6dd2d34cfa0d00c58fe9d175d64c056c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-Windows-x86.exe">Miniconda3-py37_4.8.3-Windows-x86.exe</a></td>
+      <td class="s">48.3M</td>
+      <td>2020-06-16 14:57:48</td>
+      <td>e4b8fc4802c6481f37a409ac3099aa1016aa3abf68671036670c0ff6a1526b44</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-Windows-x86_64.exe">Miniconda2-py27_4.8.3-Windows-x86_64.exe</a></td>
+      <td class="s">54.1M</td>
+      <td>2020-06-16 14:57:46</td>
+      <td>6973025404832944e074bf02bda8c4594980eeed4707bb51baa8fbdba4bf326c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-Windows-x86_64.exe">Miniconda2-latest-Windows-x86_64.exe</a></td>
+      <td class="s">54.1M</td>
+      <td>2020-06-16 14:57:46</td>
+      <td>6973025404832944e074bf02bda8c4594980eeed4707bb51baa8fbdba4bf326c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-Linux-ppc64le.sh">Miniconda3-py37_4.8.3-Linux-ppc64le.sh</a></td>
+      <td class="s">88.1M</td>
+      <td>2020-06-16 14:57:45</td>
+      <td>bcd33ea9240e2720ec004af43194c3fe6d39581e4a957a26621e00c232ca5ca1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-Linux-x86_64.sh">Miniconda2-py27_4.8.3-Linux-x86_64.sh</a></td>
+      <td class="s">48.7M</td>
+      <td>2020-06-16 14:57:45</td>
+      <td>b820dde1a0ba868c4c948fe6ace7300a252b33b5befd078a15d4a017476b8979</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-Linux-x86_64.sh">Miniconda2-latest-Linux-x86_64.sh</a></td>
+      <td class="s">48.7M</td>
+      <td>2020-06-16 14:57:45</td>
+      <td>b820dde1a0ba868c4c948fe6ace7300a252b33b5befd078a15d4a017476b8979</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-py27_4.8.3-MacOSX-x86_64.pkg">Miniconda2-py27_4.8.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">48.4M</td>
+      <td>2020-06-16 14:56:46</td>
+      <td>9ca4313e8162a939c7a5a4f48d657722594f8db9a98472803d63c3a7f66fa1da</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-MacOSX-x86_64.pkg">Miniconda2-latest-MacOSX-x86_64.pkg</a></td>
+      <td class="s">48.4M</td>
+      <td>2020-06-16 14:56:46</td>
+      <td>9ca4313e8162a939c7a5a4f48d657722594f8db9a98472803d63c3a7f66fa1da</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.3-MacOSX-x86_64.pkg">Miniconda3-py38_4.8.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">61.3M</td>
+      <td>2020-06-16 14:56:45</td>
+      <td>2a0e87c353eba5f71b01bd379b3ce9a21855fa42fc3bb854a33f0ea37bfc0ec1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.3-MacOSX-x86_64.pkg">Miniconda3-py37_4.8.3-MacOSX-x86_64.pkg</a></td>
+      <td class="s">60.4M</td>
+      <td>2020-06-16 14:56:44</td>
+      <td>4a132568b095dfd728838af2dd0da5e27ea3ddb21bdfadaa89c9ffeda7786234</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.2-MacOSX-x86_64.pkg">Miniconda3-py38_4.8.2-MacOSX-x86_64.pkg</a></td>
+      <td class="s">62.3M</td>
+      <td>2020-03-11 10:40:18</td>
+      <td>6c8cd328e74767d8633704bdd361e7eb10a37e32c2d3ff3dd2ab95b93d4f47d3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.2-Windows-x86_64.exe">Miniconda3-py38_4.8.2-Windows-x86_64.exe</a></td>
+      <td class="s">52.7M</td>
+      <td>2020-03-11 10:40:08</td>
+      <td>2eb98bb5b8f350934c2acbec9e7a5315f208869a41bda817835810018ba7ae55</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.2-MacOSX-x86_64.sh">Miniconda3-py38_4.8.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">51.3M</td>
+      <td>2020-03-11 10:39:58</td>
+      <td>443f6b9b5ff34b9b841203dd1168c6f9ffe507577d113f123ef9c36fca469228</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.2-Linux-x86_64.sh">Miniconda3-py38_4.8.2-Linux-x86_64.sh</a></td>
+      <td class="s">85.7M</td>
+      <td>2020-03-11 10:39:44</td>
+      <td>5bbb193fd201ebe25f4aeb3c58ba83feced6a25982ef4afa86d5506c3656c142</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py38_4.8.2-Linux-ppc64le.sh">Miniconda3-py38_4.8.2-Linux-ppc64le.sh</a></td>
+      <td class="s">50.5M</td>
+      <td>2020-03-11 10:39:28</td>
+      <td>e9d8f15b598a65753329690479a288d209707d2326d3ec63cb7b00dbb96dea2d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-MacOSX-x86_64.pkg">Miniconda3-py37_4.8.2-MacOSX-x86_64.pkg</a></td>
+      <td class="s">61.3M</td>
+      <td>2020-03-11 10:39:17</td>
+      <td>f3ede3a58d82fb5dcbca52d291a9edb5cd962d84d823a20693dd4bb27506cdd0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-Windows-x86.exe">Miniconda3-py37_4.8.2-Windows-x86.exe</a></td>
+      <td class="s">52.2M</td>
+      <td>2020-03-11 10:38:51</td>
+      <td>ca74cb6eb0731db2b972c0fb512e29661a84c3f01ac6133121b4372eb1c41f46</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-Windows-x86_64.exe">Miniconda3-py37_4.8.2-Windows-x86_64.exe</a></td>
+      <td class="s">51.6M</td>
+      <td>2020-03-11 10:38:26</td>
+      <td>1701955cd637d1dad5a84958fd470649b79de973d1570541eb52857664b5056c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-MacOSX-x86_64.sh">Miniconda3-py37_4.8.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">50.3M</td>
+      <td>2020-03-11 10:37:45</td>
+      <td>d1fca4f74f9971c27220122723843f6c879a5d13ff59c01fca17ef62a1576732</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-Linux-x86_64.sh">Miniconda3-py37_4.8.2-Linux-x86_64.sh</a></td>
+      <td class="s">81.1M</td>
+      <td>2020-03-11 10:37:27</td>
+      <td>957d2f0f0701c3d1335e3b39f235d197837ad69a944fa6f5d8ad2c686b69df3b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-py37_4.8.2-Linux-ppc64le.sh">Miniconda3-py37_4.8.2-Linux-ppc64le.sh</a></td>
+      <td class="s">50.1M</td>
+      <td>2020-03-11 10:37:04</td>
+      <td>8e854ef9dc66f47b309acbf7845cee7671fea1c7fde05471c0c82b9a79723825</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-MacOSX-x86_64.sh">Miniconda3-4.7.12.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">49.4M</td>
+      <td>2019-10-25 14:32:09</td>
+      <td>5cf91dde8f6024061c8b9239a1b4c34380238297adbdb9ef2061eb9d1a7f69bc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-Linux-x86_64.sh">Miniconda3-4.7.12.1-Linux-x86_64.sh</a></td>
+      <td class="s">68.5M</td>
+      <td>2019-10-25 14:32:09</td>
+      <td>bfe34e1fa28d6d75a7ad05fd02fa5472275673d5f5621b77380898dee1be15d2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-Linux-ppc64le.sh">Miniconda3-4.7.12.1-Linux-ppc64le.sh</a></td>
+      <td class="s">78.0M</td>
+      <td>2019-10-25 14:32:09</td>
+      <td>f46c0cbd84031141b83fb89111d63b57e3bfaa5b68b8a8a98e1daa403090cafa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-Windows-x86.exe">Miniconda2-4.7.12.1-Windows-x86.exe</a></td>
+      <td class="s">48.7M</td>
+      <td>2019-10-25 14:32:09</td>
+      <td>0d106228d6a4610b599df965dd6d9bb659329a17e3d693e3274b20291a7c6f94</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-MacOSX-x86_64.pkg">Miniconda2-4.7.12.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">47.8M</td>
+      <td>2019-10-25 14:32:09</td>
+      <td>fcc30b2e18f7a292b34b2e24ad855786a66423f860157fa2b77e48b6392f0abb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-Windows-x86_64.exe">Miniconda3-4.7.12.1-Windows-x86_64.exe</a></td>
+      <td class="s">51.5M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>f18060cc0bb50ae75e4d602b7ce35197c8e31e81288d069b758594f1bb46ab45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-Windows-x86.exe">Miniconda3-4.7.12.1-Windows-x86.exe</a></td>
+      <td class="s">54.0M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>7c30778941d2bba03531ba269a78a108b01fa366530290376e7c3b467f3c66ba</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12.1-MacOSX-x86_64.pkg">Miniconda3-4.7.12.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">59.8M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>9927f1de5151a1a6431b02846fbca089e8b97a55a244f02ffc3207522092907b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-Windows-x86_64.exe">Miniconda2-4.7.12.1-Windows-x86_64.exe</a></td>
+      <td class="s">50.9M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>8647c54058f11842c37854edeff4d20bc1fbdad8b88d9d34d76fda1630e64846</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-MacOSX-x86_64.sh">Miniconda2-4.7.12.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">39.4M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>0db8f4037e40e13eb1d2adc89e054dfb165470cc77be45ef2bf9cb31c8b72f39</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-Linux-x86_64.sh">Miniconda2-4.7.12.1-Linux-x86_64.sh</a></td>
+      <td class="s">46.0M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>383fe7b6c2574e425eee3c65533a5101e68a2d525e66356844a80aa02a556695</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12.1-Linux-ppc64le.sh">Miniconda2-4.7.12.1-Linux-ppc64le.sh</a></td>
+      <td class="s">50.9M</td>
+      <td>2019-10-25 14:32:08</td>
+      <td>3567394a890435a7d2f95b7eff4356d4b0fc777274564dbfd421804c3273576e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-MacOSX-x86_64.sh">Miniconda3-4.7.12-MacOSX-x86_64.sh</a></td>
+      <td class="s">48.2M</td>
+      <td>2019-10-16 14:11:27</td>
+      <td>a879d93f42bdc796a4b975a11d109dfacc11a7ba6c4106aedf657d5e1fd79410</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-Windows-x86.exe">Miniconda2-4.7.12-Windows-x86.exe</a></td>
+      <td class="s">48.0M</td>
+      <td>2019-10-16 14:11:27</td>
+      <td>a636f00fe9ff218825c8f256962ef7a108529936d1cb7ce9270192cabc542d3c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-Windows-x86_64.exe">Miniconda3-4.7.12-Windows-x86_64.exe</a></td>
+      <td class="s">50.6M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>6263b5c45038a624eb265341eae5180a87c0fe0a97f1ce4ff0b9b9d91807cfd3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-Windows-x86.exe">Miniconda3-4.7.12-Windows-x86.exe</a></td>
+      <td class="s">53.2M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>ff851cfe7cb4c21adbed48cb7f74d7e2ec457d76c02269132e6093e0fe8838c4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-MacOSX-x86_64.pkg">Miniconda3-4.7.12-MacOSX-x86_64.pkg</a></td>
+      <td class="s">59.8M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>6636f7a41d54136f2623d1ff5be2543b142b5810d7734f57bf47d1931d7c0b03</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-Linux-x86_64.sh">Miniconda3-4.7.12-Linux-x86_64.sh</a></td>
+      <td class="s">67.2M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>a23fcffe97690d3bbcd34cda798c3a3318e0f35d863c5d4aca3fc983fe8450b7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-MacOSX-x86_64.sh">Miniconda2-4.7.12-MacOSX-x86_64.sh</a></td>
       <td class="s">38.1M</td>
-      <td>2015-04-15 17:02:53</td>
-      <td>13def18b525796ad0758731cb6656687</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>3159ea8f0ef8d394e17b2e363444e22b579e631675d468b8bce49047763ca435</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-MacOSX-x86_64.pkg">Miniconda2-4.7.12-MacOSX-x86_64.pkg</a></td>
+      <td class="s">47.8M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>7d113df5704aecbff25429410e22b2fc55cd729053b5c20edc7f7470d07b38fb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-Linux-x86_64.sh">Miniconda2-4.7.12-Linux-x86_64.sh</a></td>
+      <td class="s">44.8M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>2248d5f2eeeff69b142a6ccf3148357b8e42f9c4141ab97a17c9e27f6149c417</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-Linux-ppc64le.sh">Miniconda2-4.7.12-Linux-ppc64le.sh</a></td>
+      <td class="s">49.5M</td>
+      <td>2019-10-16 14:11:26</td>
+      <td>20c87539b7ad638a45b6fa2dbc06caa610299f3e0d7e22b126573ec362e09253</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.12-Linux-ppc64le.sh">Miniconda3-4.7.12-Linux-ppc64le.sh</a></td>
+      <td class="s">76.8M</td>
+      <td>2019-10-16 14:11:25</td>
+      <td>311bbf29c673c2cae705c21e9d957403e7b83d45af4b3ca6f4d2cb070c1a845a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.12-Windows-x86_64.exe">Miniconda2-4.7.12-Windows-x86_64.exe</a></td>
+      <td class="s">50.0M</td>
+      <td>2019-10-16 14:11:25</td>
+      <td>63b8220df057aa91bbb5ab71b3f8f7ea8489a5f0b46d49a36f7804b30683717b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-Windows-x86.exe">Miniconda2-4.7.10-Windows-x86.exe</a></td>
+      <td class="s">66.3M</td>
+      <td>2019-07-29 09:15:40</td>
+      <td>a90d5b689f8a57c0da85ad77d3efa683a23da9ddb19429587635d222d5d1005c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-Linux-ppc64le.sh">Miniconda3-4.7.10-Linux-ppc64le.sh</a></td>
+      <td class="s">82.6M</td>
+      <td>2019-07-29 09:15:39</td>
+      <td>04767846005091ac4fc1f1423b2bdfd1dbb1913a183924705ad5ae2b4dfbe16d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-Windows-x86_64.exe">Miniconda2-4.7.10-Windows-x86_64.exe</a></td>
+      <td class="s">71.7M</td>
+      <td>2019-07-29 09:15:39</td>
+      <td>9cf92cb336fd29c4fabbf22523d71a52623bf5ed7895d6cd079d569af5e4b7cd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-MacOSX-x86_64.pkg">Miniconda2-4.7.10-MacOSX-x86_64.pkg</a></td>
+      <td class="s">56.4M</td>
+      <td>2019-07-29 09:15:39</td>
+      <td>97de47ce5028d382d436997911138db2fa473644de549dc6d888bbc2f41a1a8f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-Linux-x86_64.sh">Miniconda2-4.7.10-Linux-x86_64.sh</a></td>
+      <td class="s">49.7M</td>
+      <td>2019-07-29 09:15:39</td>
+      <td>9b1c7899f3bfcd520203eb7d51bfe456e25e5700dfa877c09bd2dbb028c305d8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-Windows-x86_64.exe">Miniconda3-4.7.10-Windows-x86_64.exe</a></td>
+      <td class="s">72.6M</td>
+      <td>2019-07-29 09:15:38</td>
+      <td>a3a8921c2dec37f4ef37b9fa7b337dba237ccacec56bed3d8b8c300ed852c84f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-Windows-x86.exe">Miniconda3-4.7.10-Windows-x86.exe</a></td>
+      <td class="s">67.4M</td>
+      <td>2019-07-29 09:15:38</td>
+      <td>789a0cafbc4c43fb53facced1a32203865bc1600e5baf70e97e0ce3d64aebd4b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-MacOSX-x86_64.pkg">Miniconda3-4.7.10-MacOSX-x86_64.pkg</a></td>
+      <td class="s">68.0M</td>
+      <td>2019-07-29 09:15:38</td>
+      <td>e51804f0a55b1aac2200bbe21f06fe519536071ec14c8cb6d29f1ae7ec5dbfaf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-MacOSX-x86_64.sh">Miniconda3-4.7.10-MacOSX-x86_64.sh</a></td>
+      <td class="s">52.0M</td>
+      <td>2019-07-29 09:15:37</td>
+      <td>c8b31ea37b0b6a3e2fb19990ef895ab5cf1c095f8e9138defac95ee88e70920d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.7.10-Linux-x86_64.sh">Miniconda3-4.7.10-Linux-x86_64.sh</a></td>
+      <td class="s">71.8M</td>
+      <td>2019-07-29 09:15:37</td>
+      <td>8a324adcc9eaf1c09e22a992bb6234d91a94146840ee6b11c114ecadafc68121</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-MacOSX-x86_64.sh">Miniconda2-4.7.10-MacOSX-x86_64.sh</a></td>
+      <td class="s">42.3M</td>
+      <td>2019-07-29 09:15:37</td>
+      <td>9e73501268c2a288fdb0f3ddee01f1162a29dc2671f63b659ae447d61da08810</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.7.10-Linux-ppc64le.sh">Miniconda2-4.7.10-Linux-ppc64le.sh</a></td>
+      <td class="s">58.9M</td>
+      <td>2019-07-29 09:15:37</td>
+      <td>af569a405980b67a07afbd1d583b8e59346e9762ba68ea98836b3d129c6be276</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-Windows-x86.exe">Miniconda3-4.6.14-Windows-x86.exe</a></td>
+      <td class="s">55.0M</td>
+      <td>2019-04-19 10:23:50</td>
+      <td>f886fa1656ecf3b096296c5751c3ba2f229e203702c9127adf4c1dfb81b6bc2e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-MacOSX-x86_64.pkg">Miniconda3-4.6.14-MacOSX-x86_64.pkg</a></td>
+      <td class="s">49.9M</td>
+      <td>2019-04-19 10:23:49</td>
+      <td>526aaa0122ba830192ce64ae450024743757e25c07ebb81716a0e4f1f552662e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-MacOSX-x86_64.pkg">Miniconda2-4.6.14-MacOSX-x86_64.pkg</a></td>
+      <td class="s">38.0M</td>
+      <td>2019-04-19 10:23:49</td>
+      <td>01191a76267f0487be2feb2704f8f3e464ba6127d48ab5c527b561a9fde43e20</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-Windows-x86_64.exe">Miniconda3-4.6.14-Windows-x86_64.exe</a></td>
+      <td class="s">58.4M</td>
+      <td>2019-04-19 10:23:48</td>
+      <td>142a80c6420617b2aab65c5c56517275023910dc56049255245714a34e550631</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-Linux-x86_64.sh">Miniconda3-4.6.14-Linux-x86_64.sh</a></td>
+      <td class="s">67.1M</td>
+      <td>2019-04-19 10:23:47</td>
+      <td>0d6b23895a91294a4924bd685a3a1f48e35a17970a073cd2f684ffe2c31fc4be</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-Linux-ppc64le.sh">Miniconda3-4.6.14-Linux-ppc64le.sh</a></td>
+      <td class="s">67.0M</td>
+      <td>2019-04-19 10:23:46</td>
+      <td>5efde65e6689b8ad1a5ad9ae6be7f55097cd5d4c4a7aec2d20a9fb5919c5b9aa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-Windows-x86.exe">Miniconda2-4.6.14-Windows-x86.exe</a></td>
+      <td class="s">57.0M</td>
+      <td>2019-04-19 10:23:45</td>
+      <td>0d3c7a6cf2ede3163a999a9a2c9a350726d1ff6cb24b6adc9ce2b68cddbf323f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-Windows-x86_64.exe">Miniconda2-4.6.14-Windows-x86_64.exe</a></td>
+      <td class="s">61.3M</td>
+      <td>2019-04-19 10:23:44</td>
+      <td>0b4c4469c77b352ec69d2f9158d513d7b0427b43468831c12595a37d94eb1672</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-Linux-x86_64.sh">Miniconda2-4.6.14-Linux-x86_64.sh</a></td>
+      <td class="s">43.0M</td>
+      <td>2019-04-19 10:23:43</td>
+      <td>3e20425afa1a2a4c45ee30bd168b90ca30a3fdf8598b61cb68432886aadc6f4d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.6.14-MacOSX-x86_64.sh">Miniconda3-4.6.14-MacOSX-x86_64.sh</a></td>
+      <td class="s">44.0M</td>
+      <td>2019-04-19 10:23:42</td>
+      <td>2ec958508139289df3b5e2c10257311af4f0ebf39242f61d39f11e7fa14ebb40</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-MacOSX-x86_64.sh">Miniconda2-4.6.14-MacOSX-x86_64.sh</a></td>
+      <td class="s">33.0M</td>
+      <td>2019-04-19 10:23:42</td>
+      <td>5e760d1634a88db72d2b25604249e794e70642072af19a0701de8b4206aa5b3b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.6.14-Linux-ppc64le.sh">Miniconda2-4.6.14-Linux-ppc64le.sh</a></td>
+      <td class="s">42.9M</td>
+      <td>2019-04-17 16:59:37</td>
+      <td>59fdc17eb81f9720cff613ea7ad7f944b0fc2f855ad139c855dea4fe24bb8790</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-Linux-x86_64.sh">Miniconda3-4.5.12-Linux-x86_64.sh</a></td>
+      <td class="s">66.6M</td>
+      <td>2019-01-02 10:05:18</td>
+      <td>e5e5b4cd2a918e0e96b395534222773f7241dc59d776db1b9f7fedfcb489157a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-Windows-x86.exe">Miniconda2-4.5.12-Windows-x86.exe</a></td>
+      <td class="s">55.0M</td>
+      <td>2019-01-02 10:05:17</td>
+      <td>cb95bafc8b00c03c0491e8c5aebff5b3fe7ee9b2c6b7201b0c57641430f7ae78</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-MacOSX-x86_64.pkg">Miniconda2-4.5.12-MacOSX-x86_64.pkg</a></td>
+      <td class="s">38.4M</td>
+      <td>2019-01-02 10:05:17</td>
+      <td>40173aee6d6c37741866ea33c7ac7e18be6732f9f854892c4db1e78d6017d1fc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-latest-Linux-x86.sh">Miniconda2-latest-Linux-x86.sh</a></td>
+      <td class="s">39.0M</td>
+      <td>2019-01-02 10:05:16</td>
+      <td>2e20ac4379ca5262e7612f84ad26b1a2f2782d0994facdecb28e0baf51749979</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-Windows-x86_64.exe">Miniconda2-4.5.12-Windows-x86_64.exe</a></td>
+      <td class="s">59.2M</td>
+      <td>2019-01-02 10:05:16</td>
+      <td>c1c0e732362ffff726f4f7b3745238bd871f590229300a68427f2fbb6b6ddbfe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-Linux-x86.sh">Miniconda2-4.5.12-Linux-x86.sh</a></td>
+      <td class="s">39.0M</td>
+      <td>2019-01-02 10:05:16</td>
+      <td>2e20ac4379ca5262e7612f84ad26b1a2f2782d0994facdecb28e0baf51749979</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-Linux-ppc64le.sh">Miniconda2-4.5.12-Linux-ppc64le.sh</a></td>
+      <td class="s">42.9M</td>
+      <td>2019-01-02 10:05:16</td>
+      <td>482a83a500b3cbfb67569f5549e0dfb1b03c0500e6683f513b12d53dc2f74890</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-Windows-x86_64.exe">Miniconda3-4.5.12-Windows-x86_64.exe</a></td>
+      <td class="s">56.1M</td>
+      <td>2019-01-02 10:05:15</td>
+      <td>39880230ce0bb5f3b414979baf5dd804e1387a5ec3e7ab1ca3d20b800fe83fd4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-Linux-x86_64.sh">Miniconda2-4.5.12-Linux-x86_64.sh</a></td>
+      <td class="s">42.8M</td>
+      <td>2019-01-02 10:05:15</td>
+      <td>bb03ebb9057b0ffcdd5b0192ef44b4c414a5cc25e05d3f319b66e44d2a3b0146</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-Windows-x86.exe">Miniconda3-4.5.12-Windows-x86.exe</a></td>
+      <td class="s">52.5M</td>
+      <td>2019-01-02 10:05:14</td>
+      <td>ced4ae82d5b95575bf4a54dbc49de945a2851c26f0d8de395ef637ac8cb90810</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-MacOSX-x86_64.sh">Miniconda3-4.5.12-MacOSX-x86_64.sh</a></td>
+      <td class="s">43.3M</td>
+      <td>2019-01-02 10:05:14</td>
+      <td>8ebb463ddf46dd003616b2f6b678403a708e2c54dcc58e212bd35e257761912c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-MacOSX-x86_64.pkg">Miniconda3-4.5.12-MacOSX-x86_64.pkg</a></td>
+      <td class="s">49.7M</td>
+      <td>2019-01-02 10:05:14</td>
+      <td>383ebce78cb62aa8e9d9d411627ed0b917db6f1da4aa16e9cec557a5ab2d01db</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.12-Linux-x86.sh">Miniconda3-4.5.12-Linux-x86.sh</a></td>
+      <td class="s">62.7M</td>
+      <td>2019-01-02 10:05:14</td>
+      <td>f387eded3fa4ddc3104b7775e62d59065b30205c2758a8b86b4c27144adafcc4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.12-MacOSX-x86_64.sh">Miniconda2-4.5.12-MacOSX-x86_64.sh</a></td>
+      <td class="s">33.1M</td>
+      <td>2019-01-02 10:05:14</td>
+      <td>d6d931a970c09cdfc968becbf7d423bdcdcd9d92c622bfc5bd86c69202298bfc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-Windows-x86.exe">Miniconda3-4.5.11-Windows-x86.exe</a></td>
+      <td class="s">49.0M</td>
+      <td>2018-09-04 11:57:28</td>
+      <td>9810b7a2b8da97930f5a2c1e9b436f4db86448060fa230034ff97059103f6dca</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-Windows-x86_64.exe">Miniconda3-4.5.11-Windows-x86_64.exe</a></td>
+      <td class="s">52.8M</td>
+      <td>2018-09-04 11:57:27</td>
+      <td>9369e2073a51b7b13c59de5136832187dfe670bd6c219714681dba70ca00cecf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-MacOSX-x86_64.sh">Miniconda3-4.5.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">36.3M</td>
+      <td>2018-09-04 11:57:27</td>
+      <td>eb87312ae5b8cd33d6c9fe66a454dc46fbb4d5fd133683a4a483546b9c05ea6e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-MacOSX-x86_64.pkg">Miniconda3-4.5.11-MacOSX-x86_64.pkg</a></td>
+      <td class="s">41.7M</td>
+      <td>2018-09-04 11:57:27</td>
+      <td>004998fe33512f5509c669b37256a7eaafbb156c6748c23be9d618f7960d1775</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-Linux-x86.sh">Miniconda3-4.5.11-Linux-x86.sh</a></td>
+      <td class="s">56.5M</td>
+      <td>2018-09-04 11:57:27</td>
+      <td>5dca8f7aaeeab9506f801c7c8b561a1e7e00aadc3a21008f3c72f82766f6fec6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-Linux-x86_64.sh">Miniconda3-4.5.11-Linux-x86_64.sh</a></td>
+      <td class="s">59.7M</td>
+      <td>2018-09-04 11:57:26</td>
+      <td>ea4594241e13a2671c5b158b3b813f0794fe58d514795fbf72a1aad24db918cf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.11-Linux-ppc64le.sh">Miniconda3-4.5.11-Linux-ppc64le.sh</a></td>
+      <td class="s">60.1M</td>
+      <td>2018-09-04 11:57:26</td>
+      <td>b12027bf7c4cec7138335bf511862ee003b168f6bdc0d6fe4dd5a21c135f7161</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-Windows-x86_64.exe">Miniconda2-4.5.11-Windows-x86_64.exe</a></td>
+      <td class="s">54.5M</td>
+      <td>2018-09-04 11:57:26</td>
+      <td>b21be0019fabd72e6bfda8cc0a4457350c83e557af8b00a27b9f721201abc0da</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-Windows-x86.exe">Miniconda2-4.5.11-Windows-x86.exe</a></td>
+      <td class="s">50.5M</td>
+      <td>2018-09-04 11:57:26</td>
+      <td>98be1eedbda445789b840d8870c626a56d987dada469c3411d05675f6941bd6e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-MacOSX-x86_64.sh">Miniconda2-4.5.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">30.4M</td>
+      <td>2018-09-04 11:57:25</td>
+      <td>fb525a264d104001158c64f15c7bd9d3429aa045c00215b38d7eda78def2b5e0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-MacOSX-x86_64.pkg">Miniconda2-4.5.11-MacOSX-x86_64.pkg</a></td>
+      <td class="s">35.2M</td>
+      <td>2018-09-04 11:57:25</td>
+      <td>60617ac276878577f2bcc381899cd1f2d498f4577d5fec144c280f75abf41d69</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-Linux-x86_64.sh">Miniconda2-4.5.11-Linux-x86_64.sh</a></td>
+      <td class="s">39.9M</td>
+      <td>2018-09-04 11:57:25</td>
+      <td>0e23e8d0a1a14445f78960a66b363b464b889ee3b0e3f275b7ffb836df1cb0c6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-Linux-x86.sh">Miniconda2-4.5.11-Linux-x86.sh</a></td>
+      <td class="s">36.1M</td>
+      <td>2018-09-04 11:57:25</td>
+      <td>3dda7f209f2e3d1cb14ce3ad7cdc6ce4f98868fc41bd56d99fb7414f2ca4e632</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.11-Linux-ppc64le.sh">Miniconda2-4.5.11-Linux-ppc64le.sh</a></td>
+      <td class="s">39.7M</td>
+      <td>2018-09-04 11:57:24</td>
+      <td>51da02384607db072b8fd1364bd42c8d7fe00ca70409d36db118ba5db6bb8816</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-Windows-x86.exe">Miniconda3-4.5.4-Windows-x86.exe</a></td>
+      <td class="s">51.1M</td>
+      <td>2018-06-07 00:10:06</td>
+      <td>76f8a89b8a8e3d0a3e153f440ddc6fb558d8745c99b25deb678da787172c5e0e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-Windows-x86.exe">Miniconda2-4.5.4-Windows-x86.exe</a></td>
+      <td class="s">51.8M</td>
+      <td>2018-06-07 00:09:59</td>
+      <td>5a8b2ad03632190d847395c789a10a7b37bddea2eac75ec9992ff1425291cce2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-Windows-x86_64.exe">Miniconda3-4.5.4-Windows-x86_64.exe</a></td>
+      <td class="s">54.8M</td>
+      <td>2018-06-06 23:52:12</td>
+      <td>e347afe9c9a1bf4cf12dd2090e91030796f89e2c75eba04cf396b23b22201683</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-Windows-x86_64.exe">Miniconda2-4.5.4-Windows-x86_64.exe</a></td>
+      <td class="s">55.9M</td>
+      <td>2018-06-06 23:52:04</td>
+      <td>45a9f7f20d34e72cf9fc77ec78049f844c562153db8558c79e16751106a4fa45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-MacOSX-x86_64.pkg">Miniconda3-4.5.4-MacOSX-x86_64.pkg</a></td>
+      <td class="s">40.2M</td>
+      <td>2018-06-06 23:12:28</td>
+      <td>f71d6cea74624914d4ff64424a25d941f88125c6d83fb355186d66ecad5962bf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-MacOSX-x86_64.pkg">Miniconda2-4.5.4-MacOSX-x86_64.pkg</a></td>
+      <td class="s">34.5M</td>
+      <td>2018-06-06 23:12:27</td>
+      <td>39a1e3480031f807df68407406a0a979d29d8715c1027771b1e64eb932525199</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-MacOSX-x86_64.sh">Miniconda3-4.5.4-MacOSX-x86_64.sh</a></td>
+      <td class="s">34.9M</td>
+      <td>2018-06-06 23:12:26</td>
+      <td>2c69be05571061bb0ee348324d41d97395c2d736f25e75a1e56d6c9a4f08eaf8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-MacOSX-x86_64.sh">Miniconda2-4.5.4-MacOSX-x86_64.sh</a></td>
+      <td class="s">29.8M</td>
+      <td>2018-06-06 23:12:26</td>
+      <td>2ce4dbc2e9d0844de6c4444953542ece1c43ae5c8af50d7faec321ba40b19a5d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-Linux-ppc64le.sh">Miniconda3-4.5.4-Linux-ppc64le.sh</a></td>
+      <td class="s">54.9M</td>
+      <td>2018-06-06 23:07:24</td>
+      <td>72701b57569d0e4e2c3db52fdc8fd8aafa8549a2b5e843c49f50fb483e8fdd15</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-Linux-ppc64le.sh">Miniconda2-4.5.4-Linux-ppc64le.sh</a></td>
+      <td class="s">36.9M</td>
+      <td>2018-06-06 23:07:18</td>
+      <td>7a9e3f3f59c8b1e8853354ff10d120d7aea1899ff075e91fe7416abe2bcbf0c0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-Linux-x86.sh">Miniconda3-4.5.4-Linux-x86.sh</a></td>
+      <td class="s">53.7M</td>
+      <td>2018-06-06 22:27:35</td>
+      <td>6de3d2d440e831647f46ece81560a6f60b3e3736cfe6f5973f45d1407529fb8f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-Linux-x86.sh">Miniconda2-4.5.4-Linux-x86.sh</a></td>
+      <td class="s">35.5M</td>
+      <td>2018-06-06 22:27:33</td>
+      <td>9c20b3831cc755a94f16792ce474d5fa44ced25c0d39b4f93426452f0df09862</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.4-Linux-x86_64.sh">Miniconda3-4.5.4-Linux-x86_64.sh</a></td>
+      <td class="s">55.8M</td>
+      <td>2018-06-06 22:24:39</td>
+      <td>80ecc86f8c2f131c5170e43df489514f80e3971dd105c075935470bbf2476dea</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.4-Linux-x86_64.sh">Miniconda2-4.5.4-Linux-x86_64.sh</a></td>
+      <td class="s">38.1M</td>
+      <td>2018-06-06 22:24:38</td>
+      <td>77d95c99996495b9e44db3c3b7d7981143d32d5e9a58709c51d35bf695fda67d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-Windows-x86_64.exe">Miniconda3-4.5.1-Windows-x86_64.exe</a></td>
+      <td class="s">52.4M</td>
+      <td>2018-05-02 13:05:55</td>
+      <td>d0afadc4b945605f20c0feab6d61bb9531a5d449201d33a89195a980df4aa6c4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-Windows-x86_64.exe">Miniconda2-4.5.1-Windows-x86_64.exe</a></td>
+      <td class="s">53.2M</td>
+      <td>2018-05-02 13:05:55</td>
+      <td>b21c715c143b9f6bc75a913a4c1d643a48040323b5e41706b0ed118a3edb7e1d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-Linux-x86.sh">Miniconda3-4.5.1-Linux-x86.sh</a></td>
+      <td class="s">54.1M</td>
+      <td>2018-05-02 13:05:43</td>
+      <td>d28710601b43aad777ea5fa3637b7dad8f013aac997892a0e7871aa7e91a847e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-Linux-x86_64.sh">Miniconda3-4.5.1-Linux-x86_64.sh</a></td>
+      <td class="s">56.1M</td>
+      <td>2018-05-02 13:05:42</td>
+      <td>4b857c96d7aad4b09063224e88f4f62e778a5f1f2a1b211340ba765ce6aa21e5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-Linux-x86.sh">Miniconda2-4.5.1-Linux-x86.sh</a></td>
+      <td class="s">35.8M</td>
+      <td>2018-05-02 13:05:42</td>
+      <td>23610a72b992e5489cdb080db9636674e95d4c90eb0e2cfca6ada69780dcc6f7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-Linux-x86_64.sh">Miniconda2-4.5.1-Linux-x86_64.sh</a></td>
+      <td class="s">38.4M</td>
+      <td>2018-05-02 13:05:41</td>
+      <td>3b7ccfc29a4e89190172bed29c213ed8535cd887db34bcc14f35f6181c30c21d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-MacOSX-x86_64.sh">Miniconda3-4.5.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">35.3M</td>
+      <td>2018-05-02 13:05:15</td>
+      <td>bb94719517dae7cfa1e605787835013faf3da0c3de60c1c3c2accc9fc4334e66</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-MacOSX-x86_64.pkg">Miniconda3-4.5.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">40.8M</td>
+      <td>2018-05-02 13:05:14</td>
+      <td>73ea5b79ef02322b0a4d489f6e59b45f325853851f95828b15f6e5955872194d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-MacOSX-x86_64.sh">Miniconda2-4.5.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">30.1M</td>
+      <td>2018-05-02 13:05:14</td>
+      <td>a13f17a5e0880210f0b37cb4892d41cc46e6ed8697236de10936780394cf0081</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-MacOSX-x86_64.pkg">Miniconda2-4.5.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">34.8M</td>
+      <td>2018-05-02 13:05:14</td>
+      <td>f5faf91a6eef3c8375d050d26a873110f06dc3ab060a7456ef526695475365dd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-Windows-x86.exe">Miniconda3-4.5.1-Windows-x86.exe</a></td>
+      <td class="s">48.8M</td>
+      <td>2018-05-02 13:04:49</td>
+      <td>7653010f9afc4ee9e0010369837c2271a9e6554e4a9467580dd8c392c92b5c25</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.5.1-Linux-ppc64le.sh">Miniconda3-4.5.1-Linux-ppc64le.sh</a></td>
+      <td class="s">54.8M</td>
+      <td>2018-05-02 13:04:48</td>
+      <td>c8169aecb469557a425b4f1838cfd55f0853c3716429368884ffb010ab08bdbd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-Windows-x86.exe">Miniconda2-4.5.1-Windows-x86.exe</a></td>
+      <td class="s">49.3M</td>
+      <td>2018-05-02 13:04:48</td>
+      <td>8b90b5ea3370145803140534036852a03d7ff6f93130ba5e48aff03b91967241</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.5.1-Linux-ppc64le.sh">Miniconda2-4.5.1-Linux-ppc64le.sh</a></td>
+      <td class="s">36.6M</td>
+      <td>2018-05-02 13:04:48</td>
+      <td>38dc6eb5ca6f977e37c9f95f4f0db0893904ef7b1ce4ded0f7d1261ae66551c0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-Windows-x86_64.exe">Miniconda3-4.4.10-Windows-x86_64.exe</a></td>
+      <td class="s">53.8M</td>
+      <td>2018-02-20 13:04:25</td>
+      <td>39fc8ce44979f79c4a1d1d55efeea495e493928968bf1613d27c95b1d02a0385</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-Windows-x86.exe">Miniconda3-4.4.10-Windows-x86.exe</a></td>
+      <td class="s">50.4M</td>
+      <td>2018-02-20 13:04:25</td>
+      <td>d2ff1b784a649b545c67846fd713707f0b9eaf45dde7aed09002989673f1d651</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-MacOSX-x86_64.sh">Miniconda3-4.4.10-MacOSX-x86_64.sh</a></td>
+      <td class="s">34.9M</td>
+      <td>2018-02-20 13:04:25</td>
+      <td>b8c8f4a72eeef6d9ec8752c93843f70d8d540da6682a9e95ed7a72b4c436b755</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-MacOSX-x86_64.pkg">Miniconda3-4.4.10-MacOSX-x86_64.pkg</a></td>
+      <td class="s">40.2M</td>
+      <td>2018-02-20 13:04:25</td>
+      <td>ac70920375a5f119469b2a6fbb58fdd7a96a2279ea7a85860d64a001a727df21</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-Linux-x86.sh">Miniconda3-4.4.10-Linux-x86.sh</a></td>
+      <td class="s">53.0M</td>
+      <td>2018-02-20 13:04:25</td>
+      <td>41f042399fa7c4f2ee5966874e627428669f74fa0037241c2917c4153a50c4cd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-Linux-x86_64.sh">Miniconda3-4.4.10-Linux-x86_64.sh</a></td>
+      <td class="s">55.6M</td>
+      <td>2018-02-20 13:04:24</td>
+      <td>0c2e9b992b2edd87eddf954a96e5feae86dd66d69b1f6706a99bd7fa75e7a891</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.4.10-Linux-ppc64le.sh">Miniconda3-4.4.10-Linux-ppc64le.sh</a></td>
+      <td class="s">54.6M</td>
+      <td>2018-02-20 13:04:24</td>
+      <td>cade3cd133ae0681bec46aca21dc8365797b9849ffd340bd20b9505d4a92e1fb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-Windows-x86_64.exe">Miniconda2-4.4.10-Windows-x86_64.exe</a></td>
+      <td class="s">54.5M</td>
+      <td>2018-02-20 13:04:24</td>
+      <td>59c95d04a21b023718adb7fd213addd097a37d08c6d288e9a149b77cfe838441</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-Windows-x86.exe">Miniconda2-4.4.10-Windows-x86.exe</a></td>
+      <td class="s">50.7M</td>
+      <td>2018-02-20 13:04:24</td>
+      <td>2d016dac8edca35e198451a776e104a8656ffb1ac52238714648ceb49fc60eaa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-MacOSX-x86_64.sh">Miniconda2-4.4.10-MacOSX-x86_64.sh</a></td>
+      <td class="s">29.7M</td>
+      <td>2018-02-20 13:04:24</td>
+      <td>bfacfe82fc494b05855d66dcf3321309a0bdb619b8b1f1284caf282f26a4a565</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-MacOSX-x86_64.pkg">Miniconda2-4.4.10-MacOSX-x86_64.pkg</a></td>
+      <td class="s">34.4M</td>
+      <td>2018-02-20 13:04:23</td>
+      <td>2dde483279dfacfe25faacc35e41c45e37beacdb0cf0fb27730399b88086abd6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-Linux-x86_64.sh">Miniconda2-4.4.10-Linux-x86_64.sh</a></td>
+      <td class="s">38.0M</td>
+      <td>2018-02-20 13:04:23</td>
+      <td>4e4ff02c9256ba22d59a1c1a52c723ca4c4ec28fed3bc3b6da68b9d910fe417c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-Linux-x86.sh">Miniconda2-4.4.10-Linux-x86.sh</a></td>
+      <td class="s">35.0M</td>
+      <td>2018-02-20 13:04:23</td>
+      <td>ea33b992ed11868abb2d99ce5e8e889ca4610e3b6847a2e4cfbcd5fe1bc53744</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.4.10-Linux-ppc64le.sh">Miniconda2-4.4.10-Linux-ppc64le.sh</a></td>
+      <td class="s">36.9M</td>
+      <td>2018-02-20 13:04:23</td>
+      <td>517a1a9bf74f5bea0e1cd941f8069fda04a442d8629652534f0f61eed8c1dd51</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-Windows-x86_64.exe">Miniconda3-4.3.31-Windows-x86_64.exe</a></td>
+      <td class="s">55.8M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>bebfeb141d8f4a426019d878d526249cff6f6e93bbb1b64b522d3aad4fd2bb30</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-Windows-x86.exe">Miniconda3-4.3.31-Windows-x86.exe</a></td>
+      <td class="s">51.9M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>bef086271d3dc9907cdc413249eac02f19c3fbae73b09701fcfb012747205dc5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-MacOSX-x86_64.sh">Miniconda3-4.3.31-MacOSX-x86_64.sh</a></td>
+      <td class="s">34.3M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>06f83df72237feb68816e3d272472c55e377edae330374c32e71a799f16f0d2f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-MacOSX-x86_64.pkg">Miniconda3-4.3.31-MacOSX-x86_64.pkg</a></td>
+      <td class="s">39.6M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>4b1d0e1bc0386fc4c97d5387f8e21c08c507a9448cb0f47a776c1e69be6a2994</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-Linux-x86_64.sh">Miniconda3-4.3.31-Linux-x86_64.sh</a></td>
+      <td class="s">55.0M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>5551f01f436b6409d467412c33e12ecc4f43b5e029290870f8fdeca403c274e6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.31-Linux-x86.sh">Miniconda3-4.3.31-Linux-x86.sh</a></td>
+      <td class="s">52.5M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>df552bb9046db1f4b68c048e2693dcf52f936de63481589fbaa23c4d161562cf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-Windows-x86_64.exe">Miniconda2-4.3.31-Windows-x86_64.exe</a></td>
+      <td class="s">56.0M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>a06d838bec15a8a757824175c038f9989c0b9235f925b0a7d8ca8eecc294d091</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-Windows-x86.exe">Miniconda2-4.3.31-Windows-x86.exe</a></td>
+      <td class="s">52.4M</td>
+      <td>2017-12-19 07:17:32</td>
+      <td>34571aa76f3ed83bb0953a1a7b7d760006f6cb82c01830780069ad5a60466510</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-MacOSX-x86_64.sh">Miniconda2-4.3.31-MacOSX-x86_64.sh</a></td>
+      <td class="s">29.2M</td>
+      <td>2017-12-19 07:17:31</td>
+      <td>16600fd3e742d02acebe0af6009585ba2581746b2b2b3044e9031f7da31b574a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-MacOSX-x86_64.pkg">Miniconda2-4.3.31-MacOSX-x86_64.pkg</a></td>
+      <td class="s">33.8M</td>
+      <td>2017-12-19 07:17:31</td>
+      <td>909a7c6c458d36411854a172cc222d61e97f146b70b9cf53b872dc413c479737</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-Linux-x86_64.sh">Miniconda2-4.3.31-Linux-x86_64.sh</a></td>
+      <td class="s">37.5M</td>
+      <td>2017-12-19 07:17:31</td>
+      <td>2a7c1f2248e1b91ef6a0404e93040ded367593acff22e6b6f343ea85ee0c78d6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.31-Linux-x86.sh">Miniconda2-4.3.31-Linux-x86.sh</a></td>
+      <td class="s">34.5M</td>
+      <td>2017-12-19 07:17:31</td>
+      <td>c17f4bda2e1cbf9350ab7b075b7cb896f64b7acea9c925d072cd55a9a20a6b26</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30.2-Windows-x86.exe">Miniconda3-4.3.30.2-Windows-x86.exe</a></td>
+      <td class="s">51.5M</td>
+      <td>2017-11-20 19:13:57</td>
+      <td>2abb184c17b1aaa715cdb8e072026bc166f272ed3427d2d7126111d5f1ed0015</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30.2-Windows-x86.exe">Miniconda2-4.3.30.2-Windows-x86.exe</a></td>
+      <td class="s">52.1M</td>
+      <td>2017-11-20 19:13:50</td>
+      <td>616798b8673dd8ad24f999bc6e0784a9d76ce64409f7b7d92f5bbb4a353a4220</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30.2-Windows-x86_64.exe">Miniconda3-4.3.30.2-Windows-x86_64.exe</a></td>
+      <td class="s">55.5M</td>
+      <td>2017-11-20 19:13:22</td>
+      <td>b63b41044a0ef456689c7747dc97615c9ca1a1e29ec28b2e643c6b7fae4d7058</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30.2-Windows-x86_64.exe">Miniconda2-4.3.30.2-Windows-x86_64.exe</a></td>
+      <td class="s">55.7M</td>
+      <td>2017-11-20 19:13:15</td>
+      <td>ce9e384ca6701e5150386f0bd1ba1dac39f60ec646018bb607494061bb30cd87</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30.1-MacOSX-x86_64.pkg">Miniconda3-4.3.30.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">36.7M</td>
+      <td>2017-10-26 12:42:51</td>
+      <td>6d96c134b4fe5b80948bc908562127e03dc1d1fd86bb86549d0f6689778a2b84</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30.1-MacOSX-x86_64.pkg">Miniconda2-4.3.30.1-MacOSX-x86_64.pkg</a></td>
+      <td class="s">31.4M</td>
+      <td>2017-10-26 12:42:51</td>
+      <td>cd8059c3f6c2104983deda5f80ee1aeb893a3af8e720a7225ee8648979f53384</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30.1-MacOSX-x86_64.sh">Miniconda3-4.3.30.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">31.6M</td>
+      <td>2017-10-26 12:42:50</td>
+      <td>43d05d914139e6249498fe24cf97390a16eb95b56fc05b7f39470ff8b176d1af</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30.1-MacOSX-x86_64.sh">Miniconda2-4.3.30.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">26.9M</td>
+      <td>2017-10-26 12:42:50</td>
+      <td>1d4eb025ce58e6f0d5e19b39191ca17dee1fe3b2fd7d425a7418d99fe01fd65e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-Windows-x86_64.exe">Miniconda3-4.3.30-Windows-x86_64.exe</a></td>
+      <td class="s">52.1M</td>
+      <td>2017-10-19 19:21:17</td>
+      <td>f8c5d392a0e863d3e38054dd28e400c9123c666c0343082420dd9c6590b2e425</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-Windows-x86_64.exe">Miniconda2-4.3.30-Windows-x86_64.exe</a></td>
+      <td class="s">52.6M</td>
+      <td>2017-10-19 19:21:10</td>
+      <td>9e67187213871504ad3bd9863326f82b02294cdb8fe6ec89bf94f417d47a92b8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-Windows-x86.exe">Miniconda3-4.3.30-Windows-x86.exe</a></td>
+      <td class="s">45.8M</td>
+      <td>2017-10-19 19:20:46</td>
+      <td>bd5d7ba3248471af51360dfda9f36c3ca97edc235cd0302470a1ed198505f238</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-Windows-x86.exe">Miniconda2-4.3.30-Windows-x86.exe</a></td>
+      <td class="s">48.9M</td>
+      <td>2017-10-19 19:20:41</td>
+      <td>b54a970985efed2ce98eb60de1a23525b9d7e6cca2b3b882ee236760a7800fb2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-Linux-x86.sh">Miniconda3-4.3.30-Linux-x86.sh</a></td>
+      <td class="s">49.2M</td>
+      <td>2017-10-19 17:59:07</td>
+      <td>5d0c59c3d93b56dea90af1be96a9f36aa7f35605d9f821e8b86c1aa31d3b4e4b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-Linux-x86.sh">Miniconda2-4.3.30-Linux-x86.sh</a></td>
+      <td class="s">31.4M</td>
+      <td>2017-10-19 17:59:06</td>
+      <td>3727dcc1561be246c052d6be210b5fd748bf32407cb7e06d0322fe4f79c77482</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-Linux-x86_64.sh">Miniconda3-4.3.30-Linux-x86_64.sh</a></td>
+      <td class="s">51.7M</td>
+      <td>2017-10-19 17:52:40</td>
+      <td>66c822dfe76636b4cc2ae5604816e0e723aa01620f50087f06410ecf5bfdf38c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-Linux-x86_64.sh">Miniconda2-4.3.30-Linux-x86_64.sh</a></td>
+      <td class="s">34.5M</td>
+      <td>2017-10-19 17:52:40</td>
+      <td>0891000ca28359e63aa77e613c01f7a88855dedfc0ddc8be31829f3139318cf3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-MacOSX-x86_64.pkg">Miniconda2-4.3.30-MacOSX-x86_64.pkg</a></td>
+      <td class="s">31.3M</td>
+      <td>2017-10-19 17:47:35</td>
+      <td>5d83e6929b729839c7d501544a7c28188e16766ce611e82b7fbcde405da11773</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-MacOSX-x86_64.sh">Miniconda3-4.3.30-MacOSX-x86_64.sh</a></td>
+      <td class="s">31.5M</td>
+      <td>2017-10-19 17:47:34</td>
+      <td>f8b09aa53b7f66ed62d6dd0fec66fa0aead203d5def28f9f125df93af8dbd78a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.30-MacOSX-x86_64.pkg">Miniconda3-4.3.30-MacOSX-x86_64.pkg</a></td>
+      <td class="s">36.7M</td>
+      <td>2017-10-19 17:47:34</td>
+      <td>dd3855b4bc766978c82580ac707cdfa2e1955854361b505696acfd3ec1af015a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.30-MacOSX-x86_64.sh">Miniconda2-4.3.30-MacOSX-x86_64.sh</a></td>
+      <td class="s">26.9M</td>
+      <td>2017-10-19 17:47:34</td>
+      <td>1fa6f0ae3b65fc09ba5156c43a3901c4aad0510735c31f58d1be2a71009416f9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27.1-Linux-x86_64.sh">Miniconda3-4.3.27.1-Linux-x86_64.sh</a></td>
+      <td class="s">51.6M</td>
+      <td>2017-10-02 08:52:08</td>
+      <td>640f505f06f87d75bebc629e4a677ebb185ea9a34eb6d7c199db0753ffc42f62</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27.1-Linux-x86_64.sh">Miniconda2-4.3.27.1-Linux-x86_64.sh</a></td>
+      <td class="s">34.4M</td>
+      <td>2017-10-02 08:52:08</td>
+      <td>f7bb442faeed33330564bfc33188a9dcd4ebe2ab3771aa89a823c03e67197e1d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27.1-Linux-x86.sh">Miniconda3-4.3.27.1-Linux-x86.sh</a></td>
+      <td class="s">49.2M</td>
+      <td>2017-10-01 04:00:02</td>
+      <td>15fb3364174544d16f452f50eedc32a8a90e27d2fccddff7313654259322105b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27.1-Linux-x86.sh">Miniconda2-4.3.27.1-Linux-x86.sh</a></td>
+      <td class="s">31.4M</td>
+      <td>2017-10-01 04:00:02</td>
+      <td>3d80246ff3942599669f86c10468e25af482cdd1197c3168027ef6680c857f95</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-Linux-ppc64le.sh">Miniconda3-4.3.27-Linux-ppc64le.sh</a></td>
+      <td class="s">34.4M</td>
+      <td>2017-09-27 12:00:12</td>
+      <td>77704ce287bf6ffa2ac352ea6f821f29d15780f1d83cde22732e9e4e063b9dad</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-Linux-ppc64le.sh">Miniconda2-4.3.27-Linux-ppc64le.sh</a></td>
+      <td class="s">28.2M</td>
+      <td>2017-09-27 12:00:12</td>
+      <td>b0e05d29d05b9fa295fddca7e1726a0d22f6888fff432ea12555e8c7ad06e40b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-Windows-x86_64.exe">Miniconda3-4.3.27-Windows-x86_64.exe</a></td>
+      <td class="s">49.1M</td>
+      <td>2017-09-26 16:55:40</td>
+      <td>9ae0d3db053c42373be7addf78c27757ed07aa83b8b93eb11bb421ec79d98432</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-Windows-x86.exe">Miniconda3-4.3.27-Windows-x86.exe</a></td>
+      <td class="s">45.5M</td>
+      <td>2017-09-26 16:55:34</td>
+      <td>2a9ab0d419669936a49dee74b74ae1eda721b9e607062b259d4bcdf6a4f73fa2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-Windows-x86_64.exe">Miniconda2-4.3.27-Windows-x86_64.exe</a></td>
+      <td class="s">52.1M</td>
+      <td>2017-09-26 16:55:26</td>
+      <td>bbc81924f2b526da4c432d2c6e26006e2d5b816a7d5b5d8dc0459dcf7028cdc3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-Windows-x86.exe">Miniconda2-4.3.27-Windows-x86.exe</a></td>
+      <td class="s">48.6M</td>
+      <td>2017-09-26 16:55:24</td>
+      <td>761662f4592503d13c08d0eddecb942044125efa5f1d0acfad72a32dd9dbe613</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-MacOSX-x86_64.sh">Miniconda3-4.3.27-MacOSX-x86_64.sh</a></td>
+      <td class="s">31.5M</td>
+      <td>2017-09-26 16:26:32</td>
+      <td>768651bc018eba0e698659dae94fc858b21081334c483c80a069883820208f18</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-MacOSX-x86_64.pkg">Miniconda3-4.3.27-MacOSX-x86_64.pkg</a></td>
+      <td class="s">36.5M</td>
+      <td>2017-09-26 16:26:32</td>
+      <td>0e2a1222d592daf3308079adbbda1e103d4106cef68a4334de68f4fe5beddc45</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-Linux-x86_64.sh">Miniconda3-4.3.27-Linux-x86_64.sh</a></td>
+      <td class="s">51.0M</td>
+      <td>2017-09-26 16:26:32</td>
+      <td>371814c483f63e9ec70b3e578d5ac51133fa91ae10d9fdf063f3ffc9d605f1b2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.27-Linux-x86.sh">Miniconda3-4.3.27-Linux-x86.sh</a></td>
+      <td class="s">48.7M</td>
+      <td>2017-09-26 16:26:32</td>
+      <td>1845d381a527e82bb08765e9517e5036de2a4dcab338cde4da5da71a63cf6415</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-MacOSX-x86_64.sh">Miniconda2-4.3.27-MacOSX-x86_64.sh</a></td>
+      <td class="s">26.8M</td>
+      <td>2017-09-26 16:26:31</td>
+      <td>7e3d2bc3e48f1daca127062a59e518df37f279aa750ca595c2c8c9569eff2fba</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-MacOSX-x86_64.pkg">Miniconda2-4.3.27-MacOSX-x86_64.pkg</a></td>
+      <td class="s">31.2M</td>
+      <td>2017-09-26 16:26:31</td>
+      <td>59f505af5249ee5ba241efd966b0e71d8bf139f692f4502d20bf9216a13f2a0d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-Linux-x86_64.sh">Miniconda2-4.3.27-Linux-x86_64.sh</a></td>
+      <td class="s">33.8M</td>
+      <td>2017-09-26 16:26:31</td>
+      <td>fbf576da37b515157600e5f5ce264a302b101b72a7cbc97285c8dec323118c51</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.27-Linux-x86.sh">Miniconda2-4.3.27-Linux-x86.sh</a></td>
+      <td class="s">30.9M</td>
+      <td>2017-09-26 16:26:31</td>
+      <td>35048f9513bb3311208ec751837e806c1ffda4ff837ac68a482360865eb3e18e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.21-Windows-x86_64.exe">Miniconda3-4.3.21-Windows-x86_64.exe</a></td>
+      <td class="s">57.8M</td>
+      <td>2017-06-02 11:25:10</td>
+      <td>52604127193b8239595e22be5570769ce0244488c05ff9e527f13e96a3075d72</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.21-Windows-x86.exe">Miniconda3-4.3.21-Windows-x86.exe</a></td>
+      <td class="s">53.9M</td>
+      <td>2017-06-02 11:25:00</td>
+      <td>d6831b8c90f76d0cb169edb0237d904783b6bfaef32fa69f19196d3bb31f1b31</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.21-Windows-x86_64.exe">Miniconda2-4.3.21-Windows-x86_64.exe</a></td>
+      <td class="s">51.4M</td>
+      <td>2017-06-02 11:24:51</td>
+      <td>f49083a33072cea0335c679ac33927becf17100abf6176394e6aa7b1a3328cb4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.21-Windows-x86.exe">Miniconda2-4.3.21-Windows-x86.exe</a></td>
+      <td class="s">47.7M</td>
+      <td>2017-06-02 11:24:42</td>
+      <td>8f3ef7b1c74f7c2b43685e9302a955a4a1b31fde843613aa961d0d0e52dfb163</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.21-MacOSX-x86_64.sh">Miniconda3-4.3.21-MacOSX-x86_64.sh</a></td>
+      <td class="s">24.3M</td>
+      <td>2017-06-02 11:15:22</td>
+      <td>0f12382bbcd89c4141b0ace621813876723b569daa270b77d9c61323d2d5a881</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.21-MacOSX-x86_64.sh">Miniconda2-4.3.21-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.4M</td>
+      <td>2017-06-02 11:15:20</td>
+      <td>ec996889bed2f4bfbd6775222dcd5e1633e50b203e56643944611501a79b8037</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.21-Linux-x86.sh">Miniconda3-4.3.21-Linux-x86.sh</a></td>
+      <td class="s">28.9M</td>
+      <td>2017-06-02 11:13:39</td>
+      <td>f6a3190b1ada3f7d7a0eb8080cc927216d6c910f2adb5ffdc21817cb71a4fe68</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.21-Linux-x86.sh">Miniconda2-4.3.21-Linux-x86.sh</a></td>
+      <td class="s">23.5M</td>
+      <td>2017-06-02 11:13:37</td>
+      <td>180b46832849ecba5cfb19e1cd60a38f98e02ac2fd1517648771af8f049b7d50</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.21-Linux-x86_64.sh">Miniconda3-4.3.21-Linux-x86_64.sh</a></td>
+      <td class="s">33.4M</td>
+      <td>2017-06-02 11:12:07</td>
+      <td>e9089c735b4ae53cb1035b1a97cec9febe6decf76868383292af589218304a90</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.21-Linux-x86_64.sh">Miniconda2-4.3.21-Linux-x86_64.sh</a></td>
+      <td class="s">27.8M</td>
+      <td>2017-06-02 11:12:06</td>
+      <td>5097d5ec484a345c8785655113b19b88bfcd69af5f25a36c832ce498f02ea052</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-Windows-x86_64.exe">Miniconda3-4.3.14-Windows-x86_64.exe</a></td>
+      <td class="s">57.8M</td>
+      <td>2017-05-12 14:18:25</td>
+      <td>7e7deb4870a46373a238851549b365a1445d341ddae70db19e0eb4c511254023</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-Windows-x86.exe">Miniconda3-4.3.14-Windows-x86.exe</a></td>
+      <td class="s">53.8M</td>
+      <td>2017-05-12 14:18:16</td>
+      <td>65d07fc7b218a78ea37500e57619b5dd65b38e0912af3c66e13f8c81381a7522</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-Windows-x86_64.exe">Miniconda2-4.3.14-Windows-x86_64.exe</a></td>
+      <td class="s">51.2M</td>
+      <td>2017-05-12 14:17:54</td>
+      <td>90106b95080f180a0fe86c7d100e4b60605bb60922b87b5ff636376742493564</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-Windows-x86.exe">Miniconda2-4.3.14-Windows-x86.exe</a></td>
+      <td class="s">47.5M</td>
+      <td>2017-05-12 14:17:47</td>
+      <td>a042c9f0dbcb3e66c3bc6a54d4f652a9713635b4f72f339eb61707c2c5fe0fba</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-MacOSX-x86_64.sh">Miniconda3-4.3.14-MacOSX-x86_64.sh</a></td>
+      <td class="s">24.0M</td>
+      <td>2017-05-12 14:11:46</td>
+      <td>fa5bf41893336138e262ada14ae7a67824df62c6c87351bb250bde203c253d67</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-MacOSX-x86_64.sh">Miniconda2-4.3.14-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.1M</td>
+      <td>2017-05-12 14:11:45</td>
+      <td>de5ec11463073f2d9cb4c7ea18e128ba24142d9065926a977262e61c66f61ae8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-Linux-x86.sh">Miniconda3-4.3.14-Linux-x86.sh</a></td>
+      <td class="s">28.6M</td>
+      <td>2017-05-12 14:11:36</td>
+      <td>4e3bf0348537770b2768de1e013ebccf2b4d66ce6e7a2942b254a53d3486c394</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-Linux-x86.sh">Miniconda2-4.3.14-Linux-x86.sh</a></td>
+      <td class="s">23.3M</td>
+      <td>2017-05-12 14:11:33</td>
+      <td>3ff873687fa5cd40f3d32ac8578003b97e98090b8fc1fa969bcfd087897f598d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-Linux-x86_64.sh">Miniconda3-4.3.14-Linux-x86_64.sh</a></td>
+      <td class="s">33.1M</td>
+      <td>2017-05-12 14:11:25</td>
+      <td>902f31a46b4a05477a9862485be5f84af761a444f8813345ff8dad8f6d3bccb2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-Linux-x86_64.sh">Miniconda2-4.3.14-Linux-x86_64.sh</a></td>
+      <td class="s">27.5M</td>
+      <td>2017-05-12 14:11:24</td>
+      <td>2dc629843be954fc747f08ffbcb973b5473f6818464b82a00260c38f687e02f1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.14-Linux-ppc64le.sh">Miniconda3-4.3.14-Linux-ppc64le.sh</a></td>
+      <td class="s">33.2M</td>
+      <td>2017-03-17 15:39:57</td>
+      <td>be578feee5120bfa9aa7d8ed4672095aff49d8bd468f67552d8466a465baf049</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.14-Linux-ppc64le.sh">Miniconda2-4.3.14-Linux-ppc64le.sh</a></td>
+      <td class="s">27.2M</td>
+      <td>2017-03-17 15:39:53</td>
+      <td>a5febee24866070b5f4b24069e3b4cabafcd71c4432bfa91b8f942a7c7e8e887</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.11-Windows-x86_64.exe">Miniconda3-4.3.11-Windows-x86_64.exe</a></td>
+      <td class="s">57.8M</td>
+      <td>2017-02-14 11:24:07</td>
+      <td>df801d2967244f7cf55f34a14b76a14c8ca3d492903bfd91d482780329f2ee83</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.11-Windows-x86.exe">Miniconda3-4.3.11-Windows-x86.exe</a></td>
+      <td class="s">53.8M</td>
+      <td>2017-02-14 11:23:59</td>
+      <td>046ffeb9cf46742d343993e52a957808625a292cea43c498e59475069682ab06</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.11-Windows-x86_64.exe">Miniconda2-4.3.11-Windows-x86_64.exe</a></td>
+      <td class="s">51.2M</td>
+      <td>2017-02-14 11:23:52</td>
+      <td>7973065245ac5ade819a6bd6d7070dca008eef60c7d95b9d7ce7bd5630205925</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.11-Windows-x86.exe">Miniconda2-4.3.11-Windows-x86.exe</a></td>
+      <td class="s">47.5M</td>
+      <td>2017-02-14 11:23:45</td>
+      <td>20ef1327d3d6ffd5f30b21ac5a93cc39846cfa5fd1214fb98719984369cc2687</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.11-MacOSX-x86_64.sh">Miniconda3-4.3.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">24.0M</td>
+      <td>2017-02-14 11:20:38</td>
+      <td>81f127e36249064d0f87b5d5dfa4d6094c6d5998f36a7bc80cb5028b4e32b7a2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.11-MacOSX-x86_64.sh">Miniconda2-4.3.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.1M</td>
+      <td>2017-02-14 11:20:38</td>
+      <td>2bfcf0c6ca25003ec5ff72c44b74cf4b417401706f9a2c8198d1632fc2378df6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.11-Linux-x86.sh">Miniconda3-4.3.11-Linux-x86.sh</a></td>
+      <td class="s">28.5M</td>
+      <td>2017-02-14 11:18:58</td>
+      <td>ebda072999dd24bbede7cf3d99fb781187aa9148f71826edadbac0a55ce278cb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.11-Linux-x86.sh">Miniconda2-4.3.11-Linux-x86.sh</a></td>
+      <td class="s">23.2M</td>
+      <td>2017-02-14 11:18:56</td>
+      <td>755a96e6ae8261acd1ce34745d89c0bef83e1ea51f8ef2f3493869ef0d71b3b5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.3.11-Linux-x86_64.sh">Miniconda3-4.3.11-Linux-x86_64.sh</a></td>
+      <td class="s">33.1M</td>
+      <td>2017-02-14 11:18:45</td>
+      <td>b9fe70ce7b6fa8df05abfb56995959b897d0365299f5046063bc236843474fb8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.3.11-Linux-x86_64.sh">Miniconda2-4.3.11-Linux-x86_64.sh</a></td>
+      <td class="s">27.5M</td>
+      <td>2017-02-14 11:18:44</td>
+      <td>fbc77646cc62e39f4aa5dd1dda1c94cc4e0bc3be580b10aa2ca2ae0013456a87</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.15-MacOSX-x86_64.sh">Miniconda2-4.2.15-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.4M</td>
+      <td>2017-01-12 13:27:24</td>
+      <td>7a0c593200e682b1b08c1f0388d744af2d58fb2b7764bc4e9a835bcca4ae12a5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-Linux-ppc64le.sh">Miniconda3-4.2.12-Linux-ppc64le.sh</a></td>
+      <td class="s">31.1M</td>
+      <td>2016-11-04 15:03:09</td>
+      <td>bfe81e19827eb3228f83729a27bd01f6623c60f33ad0f5b74d8a8dbde9e6004d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-Linux-ppc64le.sh">Miniconda2-4.2.12-Linux-ppc64le.sh</a></td>
+      <td class="s">25.5M</td>
+      <td>2016-11-04 15:02:58</td>
+      <td>c877293b146907ab85922c228c468cce59e5b70b771fce78f62c58d2c7121e29</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-Windows-x86_64.exe">Miniconda3-4.2.12-Windows-x86_64.exe</a></td>
+      <td class="s">48.7M</td>
+      <td>2016-11-03 14:06:09</td>
+      <td>235f037ff31d2c621f398235fc3dd2f0e3556693a3278c01777f4e0e713f9e61</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-Windows-x86.exe">Miniconda3-4.2.12-Windows-x86.exe</a></td>
+      <td class="s">46.3M</td>
+      <td>2016-11-03 14:06:03</td>
+      <td>947cc7a845a65ecb9b55dbbe4c4f372a7517e6216e3b0186e870fd1422743bf2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-Windows-x86_64.exe">Miniconda2-4.2.12-Windows-x86_64.exe</a></td>
+      <td class="s">45.2M</td>
+      <td>2016-11-03 14:05:56</td>
+      <td>637aa0721faedfbbfd96bd472636d530e79ac29afd291e95a5a404676241d994</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-Windows-x86.exe">Miniconda2-4.2.12-Windows-x86.exe</a></td>
+      <td class="s">42.3M</td>
+      <td>2016-11-03 14:05:50</td>
+      <td>c15eddf71aa6cac2b931aa7b3f2ca25cb9017bc9420dc3ffecc289e7a5501b6e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-MacOSX-x86_64.sh">Miniconda3-4.2.12-MacOSX-x86_64.sh</a></td>
+      <td class="s">23.8M</td>
+      <td>2016-11-03 14:05:03</td>
+      <td>da15fd52352dcefc944a32cd54c8ec3cfc68cfbbadcb86dbea72fe681c7a7a70</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-MacOSX-x86_64.sh">Miniconda2-4.2.12-MacOSX-x86_64.sh</a></td>
+      <td class="s">20.5M</td>
+      <td>2016-11-03 14:05:03</td>
+      <td>d889ef459de2f63d28ce6b892f56a5fca8a51a0e1f220513462209e256011b65</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-Linux-x86.sh">Miniconda3-4.2.12-Linux-x86.sh</a></td>
+      <td class="s">27.7M</td>
+      <td>2016-11-03 14:04:59</td>
+      <td>64dae61d366ada1d5c6baf345a466c95b68eb6df574ee454fc234a7a99943702</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-Linux-x86.sh">Miniconda2-4.2.12-Linux-x86.sh</a></td>
+      <td class="s">22.5M</td>
+      <td>2016-11-03 14:04:57</td>
+      <td>426552641ee76c2344bc1c8c09eea49e8c2b45906262103b7ebe89eadc9b28a7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.12-Linux-x86_64.sh">Miniconda3-4.2.12-Linux-x86_64.sh</a></td>
+      <td class="s">32.3M</td>
+      <td>2016-11-03 14:04:49</td>
+      <td>c59b3dd3cad550ac7596e0d599b91e75d88826db132e4146030ef471bb434e9a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.12-Linux-x86_64.sh">Miniconda2-4.2.12-Linux-x86_64.sh</a></td>
+      <td class="s">26.5M</td>
+      <td>2016-11-03 14:04:46</td>
+      <td>db2648aad11f3ad59416007d54ef1657bf3ce6a635e8b7a0f253d40cb5cd753d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.11-Windows-x86_64.exe">Miniconda3-4.2.11-Windows-x86_64.exe</a></td>
+      <td class="s">48.7M</td>
+      <td>2016-10-25 19:11:26</td>
+      <td>8395aef91bd25ce24c6a2c580907cafe03a1e2951362df0d04106ca59de9cbcf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.11-Windows-x86.exe">Miniconda3-4.2.11-Windows-x86.exe</a></td>
+      <td class="s">46.3M</td>
+      <td>2016-10-25 19:11:19</td>
+      <td>2a0b50dfda5b77b4de41cfdde51c0e69f2c8d8c0ac995e37b874ef1a62794a88</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.11-Windows-x86_64.exe">Miniconda2-4.2.11-Windows-x86_64.exe</a></td>
+      <td class="s">45.2M</td>
+      <td>2016-10-25 19:11:13</td>
+      <td>73aaf771e98566db7e196768bce94096f14862ad795ec8226e894ce32b80d2af</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.11-Windows-x86.exe">Miniconda2-4.2.11-Windows-x86.exe</a></td>
+      <td class="s">42.3M</td>
+      <td>2016-10-25 19:11:06</td>
+      <td>c6920a5e3ba735f490237edbdc78f1ccc43d9515bbe663e089d639889867b91a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.11-MacOSX-x86_64.sh">Miniconda3-4.2.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">23.8M</td>
+      <td>2016-10-24 12:55:07</td>
+      <td>ba684c87b82abeac5574cf6515c2d2a7c763b6b0c2925455004ac3e537e837d5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.11-MacOSX-x86_64.sh">Miniconda2-4.2.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">20.5M</td>
+      <td>2016-10-24 12:55:07</td>
+      <td>13608acd13dd7a3cd08ee24c87357587333be4558c383f0d09c96bcb67bf9db2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.11-Linux-x86.sh">Miniconda3-4.2.11-Linux-x86.sh</a></td>
+      <td class="s">27.7M</td>
+      <td>2016-10-24 12:54:50</td>
+      <td>0414911b768136f08505547455cebc2f670e02f06ab8618716963ac08d878fa1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.11-Linux-x86.sh">Miniconda2-4.2.11-Linux-x86.sh</a></td>
+      <td class="s">22.4M</td>
+      <td>2016-10-24 12:54:49</td>
+      <td>758c5eb9d90ebfbbf6dcfbb08ecfc08b53f2ce4c7db628d2104028daa689c2c0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.2.11-Linux-x86_64.sh">Miniconda3-4.2.11-Linux-x86_64.sh</a></td>
+      <td class="s">32.3M</td>
+      <td>2016-10-24 12:54:38</td>
+      <td>726189d0831a1d1f95f39c404be7c147139d4f250cd4d9be31a7f3603e4e66c5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.2.11-Linux-x86_64.sh">Miniconda2-4.2.11-Linux-x86_64.sh</a></td>
+      <td class="s">26.5M</td>
+      <td>2016-10-24 12:54:38</td>
+      <td>fe4fc2f2ac9de449797bcad5a82b4c36499c234c96c2a9f7f90796b17dc59704</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.1.11-Windows-x86_64.exe">Miniconda3-4.1.11-Windows-x86_64.exe</a></td>
+      <td class="s">38.4M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>fad96a34b7cc4089162c8178e692a939c3210c5d1b829ae7dca9756199f8c1d6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.1.11-Windows-x86.exe">Miniconda3-4.1.11-Windows-x86.exe</a></td>
+      <td class="s">36.8M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>50f54da198e4e8b89fe1f7280f9956cf03294e05a3c6350b053181287534cdcf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.1.11-MacOSX-x86_64.sh">Miniconda3-4.1.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">23.7M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>c4e3ba528721278f74e68ef070493a27d920ba10432dd2c2d563774799eda79c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.1.11-Linux-x86_64.sh">Miniconda3-4.1.11-Linux-x86_64.sh</a></td>
+      <td class="s">32.4M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>efd6a9362fc6b4085f599a881d20e57de628da8c1a898c08ec82874f3bad41bf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.1.11-Linux-x86.sh">Miniconda3-4.1.11-Linux-x86.sh</a></td>
+      <td class="s">27.8M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>4e89584027016060ce4e1dc40b8cb9e1c2dfd0d9f99335fca48d419ec90753c5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.1.11-Windows-x86_64.exe">Miniconda2-4.1.11-Windows-x86_64.exe</a></td>
+      <td class="s">30.4M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>f36681fd12abc405f37da3c5a76c26646c0fecc9eb6c4c59863177ec0cee29f5</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.1.11-Windows-x86.exe">Miniconda2-4.1.11-Windows-x86.exe</a></td>
+      <td class="s">29.3M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>d2b15e16f998337caf472ce4e3afef491a37585a47fa2281b1918495cef04d0e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.1.11-MacOSX-x86_64.sh">Miniconda2-4.1.11-MacOSX-x86_64.sh</a></td>
+      <td class="s">20.3M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>a974389c7aab8058f14fa7d4bc00e5bb5316a3da4b0ca1463b854701532297d7</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.1.11-Linux-x86_64.sh">Miniconda2-4.1.11-Linux-x86_64.sh</a></td>
+      <td class="s">26.5M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>4cdd4707c8bd2959551e40c6d4561ebec2711e034a04305e2dd1f88f038edb04</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.1.11-Linux-x86.sh">Miniconda2-4.1.11-Linux-x86.sh</a></td>
+      <td class="s">22.4M</td>
+      <td>2016-07-28 21:33:00</td>
+      <td>5c4f6e121ddcbd24c7f7d3e7a6ce06c60cf2c98b14895620f1d7805d75bc5a9f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.0.5-Windows-x86_64.exe">Miniconda3-4.0.5-Windows-x86_64.exe</a></td>
+      <td class="s">39.0M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>5d335c51eb8e106d5a456b466c2f7cdb2477f515b3fc9e8fe6c237766bf064b9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.0.5-Windows-x86.exe">Miniconda3-4.0.5-Windows-x86.exe</a></td>
+      <td class="s">36.0M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>b3ea2182b6b079471b284a5d224a90fac9e8ee289b644d15214f1a2aa2fc56ae</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.0.5-MacOSX-x86_64.sh">Miniconda3-4.0.5-MacOSX-x86_64.sh</a></td>
+      <td class="s">23.4M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>5673d23ed00515dbb7d236bc0db239c875db54ba1cd0976d907d0552dc58928f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.0.5-Linux-x86_64.sh">Miniconda3-4.0.5-Linux-x86_64.sh</a></td>
+      <td class="s">31.4M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>a7bcd0425d8b6688753946b59681572f63c2241aed77bf0ec6de4c5edc5ceeac</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-4.0.5-Linux-x86.sh">Miniconda3-4.0.5-Linux-x86.sh</a></td>
+      <td class="s">30.0M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>3c06b31b0f70d21f4f62021b8db98929faa3a99ebe6b5b1a2999576d16c30e35</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.0.5-Windows-x86_64.exe">Miniconda2-4.0.5-Windows-x86_64.exe</a></td>
+      <td class="s">30.0M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>1d7619de16342fe6f054f655113cdb710dbbbdb2f5ea84244b6199921757d7bd</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.0.5-Windows-x86.exe">Miniconda2-4.0.5-Windows-x86.exe</a></td>
+      <td class="s">29.0M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>3eb35a29241baffe8f288245cf88d2b70824aaa6a60914a14933379601ea8f4f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.0.5-MacOSX-x86_64.sh">Miniconda2-4.0.5-MacOSX-x86_64.sh</a></td>
+      <td class="s">20.3M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>7471adcdf7ff1f4e7464617992f57fb7f6f58dbc16ce2455d441dc2c2660e350</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.0.5-Linux-x86_64.sh">Miniconda2-4.0.5-Linux-x86_64.sh</a></td>
+      <td class="s">25.9M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>ada5b7942e519829bc5e8e638d525e009676a7a598cf3dd80f041f6d5e39ddbb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-4.0.5-Linux-x86.sh">Miniconda2-4.0.5-Linux-x86.sh</a></td>
+      <td class="s">24.7M</td>
+      <td>2016-03-29 19:32:26</td>
+      <td>fc85229837ef2f0571e0c369e6de8ae7339b6cd9f16449efce0a2a01f0bec110</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.19.0-Windows-x86_64.exe">Miniconda3-3.19.0-Windows-x86_64.exe</a></td>
+      <td class="s">34.6M</td>
+      <td>2015-12-17 14:20:29</td>
+      <td>bc34d7c309ea2abb8b147d035f20eb8f2f3f088ae65e00e322857a1fe8083f41</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.19.0-Windows-x86.exe">Miniconda3-3.19.0-Windows-x86.exe</a></td>
+      <td class="s">32.4M</td>
+      <td>2015-12-17 14:20:24</td>
+      <td>94ad42be18d05716ab05a8e207be17a7303d4d98ce682a431d39ef508b3d48bb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.19.0-Windows-x86_64.exe">Miniconda2-3.19.0-Windows-x86_64.exe</a></td>
+      <td class="s">24.3M</td>
+      <td>2015-12-17 14:20:20</td>
+      <td>bce3356bbf88534169e84fc0accfdca621ef80dfd1967b5204fc3eb5a7d82c90</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.19.0-Windows-x86.exe">Miniconda2-3.19.0-Windows-x86.exe</a></td>
+      <td class="s">23.2M</td>
+      <td>2015-12-17 14:20:16</td>
+      <td>47be860b630e4f51f604734071a617f82f12aaf090ad1e99516eb2b50f836e8d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.19.0-MacOSX-x86_64.sh">Miniconda3-3.19.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">22.6M</td>
+      <td>2015-12-17 14:18:55</td>
+      <td>40ec9c2726262addd330c24f62853de47430482965f0bb8cba47d8cd995bec29</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.19.0-MacOSX-x86_64.sh">Miniconda2-3.19.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">19.6M</td>
+      <td>2015-12-17 14:18:55</td>
+      <td>32915acbfc8491e9fbe12b90a611a76b84e15f2cdef5272f576bfe77a4ef7061</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.19.0-Linux-x86.sh">Miniconda3-3.19.0-Linux-x86.sh</a></td>
+      <td class="s">28.3M</td>
+      <td>2015-12-17 14:18:09</td>
+      <td>9789463cad35cdb3ee4cda5a9c3767cad21491faacc071fcd60eb38a9f75098e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.19.0-Linux-x86.sh">Miniconda2-3.19.0-Linux-x86.sh</a></td>
+      <td class="s">23.0M</td>
+      <td>2015-12-17 14:18:08</td>
+      <td>869d65bed0927ff78973947f619558ed8be282851632449631d1923e3ac814d6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.19.0-Linux-x86_64.sh">Miniconda3-3.19.0-Linux-x86_64.sh</a></td>
+      <td class="s">29.6M</td>
+      <td>2015-12-17 14:16:41</td>
+      <td>9ea57c0fdf481acf89d816184f969b04bc44dea27b258c4e86b1e3a25ff26aa0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.19.0-Linux-x86_64.sh">Miniconda2-3.19.0-Linux-x86_64.sh</a></td>
+      <td class="s">24.2M</td>
+      <td>2015-12-17 14:16:41</td>
+      <td>646b4d5398f8d76a0664375ee6226611c43ee3d49de3eb03efe7480e3c3b9ebf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.9-Windows-x86_64.exe">Miniconda3-3.18.9-Windows-x86_64.exe</a></td>
+      <td class="s">34.5M</td>
+      <td>2015-12-10 14:22:37</td>
+      <td>09326c3d9f33fd609d89a1e975eee85f0f00bfe8132bdab5cbb28eeac122d891</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.9-Windows-x86.exe">Miniconda3-3.18.9-Windows-x86.exe</a></td>
+      <td class="s">32.0M</td>
+      <td>2015-12-10 14:22:32</td>
+      <td>c5d36b816d07a0119acece100cb9dc5a126dfbcee136b29ea0082a1265924e91</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.9-Windows-x86_64.exe">Miniconda2-3.18.9-Windows-x86_64.exe</a></td>
+      <td class="s">24.2M</td>
+      <td>2015-12-10 14:22:27</td>
+      <td>35d1a0ea2213931f1d675ee846aade9296f40a68fd2a156463b74de0cb248799</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.9-Windows-x86.exe">Miniconda2-3.18.9-Windows-x86.exe</a></td>
+      <td class="s">23.1M</td>
+      <td>2015-12-10 14:22:24</td>
+      <td>31b68258731ecc6ca4ea43fb5d95bd93c595c605fd53b46fd7a8c45343b7706b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.8-MacOSX-x86_64.sh">Miniconda3-3.18.8-MacOSX-x86_64.sh</a></td>
+      <td class="s">22.5M</td>
+      <td>2015-12-10 14:19:16</td>
+      <td>0059f855205e736288198cdd5bf0ba6d9912a1a30c9d70f6aaa65ffc9f1d491d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.8-MacOSX-x86_64.sh">Miniconda2-3.18.8-MacOSX-x86_64.sh</a></td>
+      <td class="s">19.5M</td>
+      <td>2015-12-10 14:19:16</td>
+      <td>6e11e63f5e3b44947273a4652a18d5e59000ee59f8aa106d3bb3b7f0c3a309a8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.9-Linux-x86.sh">Miniconda3-3.18.9-Linux-x86.sh</a></td>
+      <td class="s">28.2M</td>
+      <td>2015-12-10 14:18:49</td>
+      <td>a939f162a6ac8b23515cc0f28d5c132506d6fe7292956bb8b807a3c2414226fc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.9-Linux-x86.sh">Miniconda2-3.18.9-Linux-x86.sh</a></td>
+      <td class="s">22.9M</td>
+      <td>2015-12-10 14:18:47</td>
+      <td>ea70c7aded8cf4087fd77eeb180523c2071b5b6c381380caa078826c27baf510</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.9-Linux-x86_64.sh">Miniconda3-3.18.9-Linux-x86_64.sh</a></td>
+      <td class="s">29.6M</td>
+      <td>2015-12-10 14:18:09</td>
+      <td>009bdf6896cfbeaa2a8e21d3687bd9b7c468bac883d07948a4bc0db3dcaecafe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.9-Linux-x86_64.sh">Miniconda2-3.18.9-Linux-x86_64.sh</a></td>
+      <td class="s">24.2M</td>
+      <td>2015-12-10 14:18:08</td>
+      <td>48cd7bf8f6e44392df701cc771b2b5f169db4f80d459c17601f283d082e3d277</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.3-Windows-x86_64.exe">Miniconda3-3.18.3-Windows-x86_64.exe</a></td>
+      <td class="s">40.4M</td>
+      <td>2015-11-03 13:25:08</td>
+      <td>97b8be6ac861bd3b161926dce04a05bc7e69be128ec474adf156670b64890520</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.3-Windows-x86.exe">Miniconda3-3.18.3-Windows-x86.exe</a></td>
+      <td class="s">29.4M</td>
+      <td>2015-11-03 13:24:55</td>
+      <td>49148d1d7ae1846ec7b5e9bd0958e62376d87a9ae4da9aea3365df70b0e014ca</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.3-Windows-x86_64.exe">Miniconda2-3.18.3-Windows-x86_64.exe</a></td>
+      <td class="s">21.7M</td>
+      <td>2015-11-03 13:24:44</td>
+      <td>991c6269bd7b2d3851cb29bb217ba33b5c361ce3eaee7e38cfb0fad1fc5bd308</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.3-Windows-x86.exe">Miniconda2-3.18.3-Windows-x86.exe</a></td>
+      <td class="s">20.4M</td>
+      <td>2015-11-03 13:24:36</td>
+      <td>1907788f66e0624413e5005745ccbfdf4ceb3b01134508914599c3dacaae46f8</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.3-MacOSX-x86_64.sh">Miniconda3-3.18.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">20.7M</td>
+      <td>2015-11-03 11:30:21</td>
+      <td>b81c9b27eb9a91e3183e51000dbf986bfe91f99acfa1a4e3bc849ddacc7bf934</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.3-MacOSX-x86_64.sh">Miniconda2-3.18.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">17.7M</td>
+      <td>2015-11-03 11:30:20</td>
+      <td>c90b37e4ba866ac2195ddf9ffe5549311279041def27ade29f661f5707d43c94</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.3-Linux-x86.sh">Miniconda3-3.18.3-Linux-x86.sh</a></td>
+      <td class="s">26.4M</td>
+      <td>2015-11-03 11:29:34</td>
+      <td>7f6b432daacfbe67ac5fd5b3e3bc5bca75642e4e099e967b1353a5b0a828b036</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.3-Linux-x86.sh">Miniconda2-3.18.3-Linux-x86.sh</a></td>
+      <td class="s">21.2M</td>
+      <td>2015-11-03 11:29:32</td>
+      <td>1eceb3a763ab784af41a46dfd96a520659957b5fefdc1f4d53f00de43b539be0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.18.3-Linux-x86_64.sh">Miniconda3-3.18.3-Linux-x86_64.sh</a></td>
+      <td class="s">27.7M</td>
+      <td>2015-11-03 11:28:58</td>
+      <td>6eee19f7ac958578b0da4124f58b09f23422fa6f6b26af8b594a47f08cc61af4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda2-3.18.3-Linux-x86_64.sh">Miniconda2-3.18.3-Linux-x86_64.sh</a></td>
+      <td class="s">22.4M</td>
+      <td>2015-11-03 11:28:58</td>
+      <td>dd16e093aec2346af4e8f383a9dedb9a3d6c1a0cb7637b180e1e0790dfa55e81</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Windows-x86_64.exe">Miniconda3-3.16.0-Windows-x86_64.exe</a></td>
+      <td class="s">41.2M</td>
+      <td>2015-08-24 13:38:13</td>
+      <td>24ff0dfc2dbb56a0d9c565f5d8a10b0757c7714e0b039ed497d844dccf21f1dc</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Windows-x86.exe">Miniconda3-3.16.0-Windows-x86.exe</a></td>
+      <td class="s">38.5M</td>
+      <td>2015-08-24 13:38:07</td>
+      <td>8499997e2ff5926a2305d31ee0f94d119610b189d3cb9a7e1f5fa791da6c04a3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Windows-x86_64.exe">Miniconda-3.16.0-Windows-x86_64.exe</a></td>
+      <td class="s">34.8M</td>
+      <td>2015-08-24 13:38:02</td>
+      <td>d53b42a80b6d3dd26ceed345d784906fd7a2cc569d7d28ed2339a8d7ca6c080c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Windows-x86.exe">Miniconda-3.16.0-Windows-x86.exe</a></td>
+      <td class="s">31.7M</td>
+      <td>2015-08-24 13:37:57</td>
+      <td>365957d1dc4209de3ce60a06f16fbe04f1567496bb0a2cff665a0acf00a5b22d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-MacOSX-x86_64.sh">Miniconda3-3.16.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">26.3M</td>
+      <td>2015-08-24 13:36:11</td>
+      <td>36fe954548a6900249270f9632b76252e247313cc9d551c096d7e1f526a88631</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-MacOSX-x86_64.sh">Miniconda-3.16.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">18.4M</td>
+      <td>2015-08-24 13:36:10</td>
+      <td>e93517696d4ede4f8ff21ea42272f24508023b83f1e2e2c989d1b32ab19347a9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Linux-x86.sh">Miniconda3-3.16.0-Linux-x86.sh</a></td>
+      <td class="s">32.3M</td>
+      <td>2015-08-24 13:35:30</td>
+      <td>faedb7a75584d48d563f0f9b449cb00bf8d05ddb3e1ede1936bf522f03f0e1e2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Linux-x86.sh">Miniconda-3.16.0-Linux-x86.sh</a></td>
+      <td class="s">22.3M</td>
+      <td>2015-08-24 13:35:28</td>
+      <td>57e9659848e6322cb18c1c4a5c844a4f7dc5e784dbd8977245769ff9db28dade</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Linux-x86_64.sh">Miniconda3-3.16.0-Linux-x86_64.sh</a></td>
+      <td class="s">33.3M</td>
+      <td>2015-08-24 13:34:48</td>
+      <td>3becbcdd36761711850cffa11064b87cfe067dbeb4a5eda544dc341af482de87</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Linux-x86_64.sh">Miniconda-3.16.0-Linux-x86_64.sh</a></td>
+      <td class="s">23.0M</td>
+      <td>2015-08-24 13:34:47</td>
+      <td>b1facded0d33850e3a467d6e4589830be477bd4f819407b99b033a4d22601e4d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-MacOSX-x86.sh">Miniconda3-3.16.0-MacOSX-x86.sh</a></td>
+      <td class="s">26.0M</td>
+      <td>2015-08-24 13:34:40</td>
+      <td>fbf458b76ecc7d76367933d86e215920f2e1d144c689630324a0360d9c017949</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-MacOSX-x86.sh">Miniconda-3.16.0-MacOSX-x86.sh</a></td>
+      <td class="s">18.3M</td>
+      <td>2015-08-24 13:34:39</td>
+      <td>ba7475a167cf7221842e92817a9575546465aa56433bc509dab639c22bbe79ad</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Linux-ppc64le.sh">Miniconda3-3.16.0-Linux-ppc64le.sh</a></td>
+      <td class="s">33.6M</td>
+      <td>2015-08-24 12:42:21</td>
+      <td>57d4265f568aea09c437f42d5f1811a12cfe0883126fac5a480b63766032d58d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-latest-Linux-armv7l.sh">Miniconda-latest-Linux-armv7l.sh</a></td>
+      <td class="s">19.8M</td>
+      <td>2015-08-24 12:34:00</td>
+      <td>02b493c3e95b836b900dd84b8625e245fd11ac4c4360199178f76fa9e25af357</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Linux-ppc64le.sh">Miniconda-3.16.0-Linux-ppc64le.sh</a></td>
+      <td class="s">23.0M</td>
+      <td>2015-08-24 12:20:06</td>
+      <td>e0dc7085c716db447b8871c13d797ce1a05384975422fd5d0bbf5495072b5494</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.16.0-Linux-armv7l.sh">Miniconda3-3.16.0-Linux-armv7l.sh</a></td>
+      <td class="s">29.9M</td>
+      <td>2015-08-24 11:01:17</td>
+      <td>21797d303260e1f0fb89f1157b4ff1b6b58865e8b710aecdddacd8c2658ded2f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.16.0-Linux-armv7l.sh">Miniconda-3.16.0-Linux-armv7l.sh</a></td>
+      <td class="s">19.8M</td>
+      <td>2015-08-24 11:01:14</td>
+      <td>02b493c3e95b836b900dd84b8625e245fd11ac4c4360199178f76fa9e25af357</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.10.1-Windows-x86_64.exe">Miniconda3-3.10.1-Windows-x86_64.exe</a></td>
       <td class="s">40.8M</td>
       <td>2015-04-15 17:04:42</td>
-      <td>a3535b0e4a8960af54fbe86df0942234</td>
+      <td>5bfe40f872b48e8fb59df216d7d74ccaeac9238d5ca390f6f183e663ed5a6d74</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.9.1-Linux-x86.sh">Miniconda-3.9.1-Linux-x86.sh</a></td>
-      <td class="s">21.4M</td>
-      <td>2015-02-25 11:28:41</td>
-      <td>a11497512cfefa906b0c3db80f454ea1</td>
+      <td><a href="Miniconda3-3.10.1-Windows-x86.exe">Miniconda3-3.10.1-Windows-x86.exe</a></td>
+      <td class="s">38.1M</td>
+      <td>2015-04-15 17:02:53</td>
+      <td>008dda3f62faa43e97e1d0ec5d16fe8c9cb70351af633404e618788dd341f78f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.9.1-Linux-x86_64.sh">Miniconda-3.9.1-Linux-x86_64.sh</a></td>
-      <td class="s">22.4M</td>
-      <td>2015-02-25 11:27:32</td>
-      <td>be663ce46530cd8572dd9d55fef100d2</td>
+      <td><a href="Miniconda-3.10.1-Windows-x86_64.exe">Miniconda-3.10.1-Windows-x86_64.exe</a></td>
+      <td class="s">33.7M</td>
+      <td>2015-04-15 17:01:10</td>
+      <td>62a5d82bd2877659da64ca490b74cc4f25c68e734e0f2e26ca1d25938aa7ad30</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.9.1-MacOSX-x86_64.sh">Miniconda-3.9.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">18.0M</td>
-      <td>2015-02-25 11:29:20</td>
-      <td>b4b0bb7845763678a6e162186dce7c2f</td>
+      <td><a href="Miniconda-3.10.1-Windows-x86.exe">Miniconda-3.10.1-Windows-x86.exe</a></td>
+      <td class="s">31.0M</td>
+      <td>2015-04-15 16:59:47</td>
+      <td>ae99a003592030c3860dd33bfdce0e8a079bfc305917ffa20eb7d58be3798dbd</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.9.1-Windows-x86.exe">Miniconda-3.9.1-Windows-x86.exe</a></td>
-      <td class="s">30.9M</td>
-      <td>2015-02-25 11:31:26</td>
-      <td>afae70155b34c13724042b1b45bb7efe</td>
+      <td><a href="Miniconda3-3.10.1-MacOSX-x86_64.sh">Miniconda3-3.10.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.9M</td>
+      <td>2015-04-15 16:55:50</td>
+      <td>58ba40cbd1cf5bba680f94321d2ce22685a2b06ad9252044f06a0018fe99bd62</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.9.1-Windows-x86_64.exe">Miniconda-3.9.1-Windows-x86_64.exe</a></td>
-      <td class="s">33.6M</td>
-      <td>2015-02-25 11:31:34</td>
-      <td>2c4598f97d4a54f7c7aa542f41cdebb6</td>
+      <td><a href="Miniconda-3.10.1-MacOSX-x86_64.sh">Miniconda-3.10.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">17.9M</td>
+      <td>2015-04-15 16:55:49</td>
+      <td>61a1e468a79cca45a518b1760033e7af89108bf88487afead79f96e3229b422a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.9.1-Linux-x86.sh">Miniconda3-3.9.1-Linux-x86.sh</a></td>
-      <td class="s">31.2M</td>
-      <td>2015-02-25 11:28:40</td>
-      <td>597e208a1ddad6a2fdcbe1422421d4a5</td>
+      <td><a href="Miniconda3-3.10.1-Linux-x86.sh">Miniconda3-3.10.1-Linux-x86.sh</a></td>
+      <td class="s">32.0M</td>
+      <td>2015-04-15 16:54:05</td>
+      <td>e9b751fa8bc5372731512e058fa3867ad9e54983b48d462b4c8f7a031953c2bc</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.9.1-Linux-x86_64.sh">Miniconda3-3.9.1-Linux-x86_64.sh</a></td>
-      <td class="s">32.4M</td>
-      <td>2015-02-25 11:27:32</td>
-      <td>f199154a080de0f9ad29d68a99809791</td>
+      <td><a href="Miniconda-3.10.1-Linux-x86.sh">Miniconda-3.10.1-Linux-x86.sh</a></td>
+      <td class="s">21.9M</td>
+      <td>2015-04-15 16:54:01</td>
+      <td>509ee56f1590705472fdac4a00aa7191f79a6a09daf4af088e92f93c648d815e</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.9.1-MacOSX-x86_64.sh">Miniconda3-3.9.1-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.8M</td>
-      <td>2015-02-25 11:29:22</td>
-      <td>3f7012df1fbf707712c3c39f583a4f8b</td>
+      <td><a href="Miniconda3-3.10.1-Linux-x86_64.sh">Miniconda3-3.10.1-Linux-x86_64.sh</a></td>
+      <td class="s">32.9M</td>
+      <td>2015-04-15 16:51:59</td>
+      <td>cbd86f49008319416d1e57f9ac43a42445058f06aaeebe5ab974769887a8628b</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.9.1-Windows-x86.exe">Miniconda3-3.9.1-Windows-x86.exe</a></td>
-      <td class="s">37.7M</td>
-      <td>2015-02-25 11:31:43</td>
-      <td>0260f44643d0eb60da02b77b78081384</td>
+      <td><a href="Miniconda-3.10.1-Linux-x86_64.sh">Miniconda-3.10.1-Linux-x86_64.sh</a></td>
+      <td class="s">22.7M</td>
+      <td>2015-04-15 16:51:55</td>
+      <td>363f56f5608d1552325549e7371fcf460c5ed45484eb300058e3b99c997808b5</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.9.1-Windows-x86_64.exe">Miniconda3-3.9.1-Windows-x86_64.exe</a></td>
       <td class="s">40.5M</td>
       <td>2015-02-25 11:31:53</td>
-      <td>6cd0a34e9f97a2ca5c4922b82cacbbcc</td>
+      <td>f4a2a13957c41fecb3b4672433eb97b0dc8c1969e3eb39fdd65fca6e65b7bfcd</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.8.3-Linux-x86.sh">Miniconda-3.8.3-Linux-x86.sh</a></td>
-      <td class="s">21.4M</td>
-      <td>2015-01-28 11:38:41</td>
-      <td>c08e2b88d7a1949012cffad7b72abefa</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.8.3-Linux-x86_64.sh">Miniconda-3.8.3-Linux-x86_64.sh</a></td>
-      <td class="s">22.4M</td>
-      <td>2015-01-28 11:38:13</td>
-      <td>57321cab5bf40433219226412ac35a93</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.8.3-MacOSX-x86_64.sh">Miniconda-3.8.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">17.9M</td>
-      <td>2015-01-28 11:39:07</td>
-      <td>a392000ea7d307f0ae44c521b5e98d7e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.8.3-Windows-x86.exe">Miniconda-3.8.3-Windows-x86.exe</a></td>
-      <td class="s">30.9M</td>
-      <td>2015-01-28 11:42:52</td>
-      <td>bf2d04163e53957e083cc26215fc1360</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.8.3-Windows-x86_64.exe">Miniconda-3.8.3-Windows-x86_64.exe</a></td>
-      <td class="s">33.6M</td>
-      <td>2015-01-28 11:43:01</td>
-      <td>2f44c998f5fa15677d3f8504bdaefd3d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.8.3-Linux-x86.sh">Miniconda3-3.8.3-Linux-x86.sh</a></td>
-      <td class="s">31.2M</td>
-      <td>2015-01-28 11:38:40</td>
-      <td>802ece39120d6ad5a71858b379014555</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.8.3-Linux-x86_64.sh">Miniconda3-3.8.3-Linux-x86_64.sh</a></td>
-      <td class="s">32.4M</td>
-      <td>2015-01-28 11:38:13</td>
-      <td>3f84711e0bf848efc11de9a2ee952a8d</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.8.3-MacOSX-x86_64.sh">Miniconda3-3.8.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.8M</td>
-      <td>2015-01-28 11:39:09</td>
-      <td>21db8b88beb0b35574785461a5bc69d9</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.8.3-Windows-x86.exe">Miniconda3-3.8.3-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-3.9.1-Windows-x86.exe">Miniconda3-3.9.1-Windows-x86.exe</a></td>
       <td class="s">37.7M</td>
-      <td>2015-01-28 11:43:09</td>
-      <td>9dadec7277bdd290550ed4db41921d51</td>
+      <td>2015-02-25 11:31:43</td>
+      <td>9bd48daf52a360bb4022bddd73d2cb14405c791debd757fcc24872c879202923</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.9.1-Windows-x86_64.exe">Miniconda-3.9.1-Windows-x86_64.exe</a></td>
+      <td class="s">33.6M</td>
+      <td>2015-02-25 11:31:34</td>
+      <td>57902e33cfcdf89c43d836e2130ef53e1897e901323d8d43eaf264736a52c56a</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.9.1-Windows-x86.exe">Miniconda-3.9.1-Windows-x86.exe</a></td>
+      <td class="s">30.9M</td>
+      <td>2015-02-25 11:31:26</td>
+      <td>57ba596cf351a08e0f828eca95adad58856bd97f00710863be47abd9da5f40a6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.9.1-MacOSX-x86_64.sh">Miniconda3-3.9.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.8M</td>
+      <td>2015-02-25 11:29:22</td>
+      <td>e32523e3fdf0addab008e816c54eb6ae6eb6d62b1122d1e0dc4f4313a97b0591</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.9.1-MacOSX-x86_64.sh">Miniconda-3.9.1-MacOSX-x86_64.sh</a></td>
+      <td class="s">18.0M</td>
+      <td>2015-02-25 11:29:20</td>
+      <td>ea529626cfb3519eebee83c40965f0a58375e0826c6777b759eb0c42ca9970d2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.9.1-Linux-x86.sh">Miniconda-3.9.1-Linux-x86.sh</a></td>
+      <td class="s">21.4M</td>
+      <td>2015-02-25 11:28:41</td>
+      <td>f3cdc8d774acce05462eb07d2676162c519e1e5d35c98d1dc3d6eb7b262da0b2</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.9.1-Linux-x86.sh">Miniconda3-3.9.1-Linux-x86.sh</a></td>
+      <td class="s">31.2M</td>
+      <td>2015-02-25 11:28:40</td>
+      <td>1a9f8abfc63080c2d764039335a24465388533cca86472224c994ed8d32c4d48</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.9.1-Linux-x86_64.sh">Miniconda3-3.9.1-Linux-x86_64.sh</a></td>
+      <td class="s">32.4M</td>
+      <td>2015-02-25 11:27:32</td>
+      <td>6c6b44acdd0bc4229377ee10d52c8ac6160c336d9cdd669db7371aa9344e1ac3</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.9.1-Linux-x86_64.sh">Miniconda-3.9.1-Linux-x86_64.sh</a></td>
+      <td class="s">22.4M</td>
+      <td>2015-02-25 11:27:32</td>
+      <td>64f2b5047f944bb9b06e46c7281e9edffd412981c93e31d4c111287a1d30fef4</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.8.3-Windows-x86_64.exe">Miniconda3-3.8.3-Windows-x86_64.exe</a></td>
       <td class="s">40.5M</td>
       <td>2015-01-28 11:43:20</td>
-      <td>8b56bd04b6b13de9a2a46d764b6661af</td>
+      <td>dd28b79f90cc62791c4c32fbc2ed21742a6148e247780132677a935f19897918</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.7.3-Linux-x86.sh">Miniconda-3.7.3-Linux-x86.sh</a></td>
-      <td class="s">19.7M</td>
-      <td>2014-11-21 16:21:37</td>
-      <td>276354c0fce2401d73cefd4a2eb7bf30</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.3-Linux-x86_64.sh">Miniconda-3.7.3-Linux-x86_64.sh</a></td>
-      <td class="s">20.7M</td>
-      <td>2014-11-21 16:21:25</td>
-      <td>82d416a6fd8e0eeb72d0be5813a1b608</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.3-MacOSX-x86_64.sh">Miniconda-3.7.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">16.3M</td>
-      <td>2014-11-21 16:22:02</td>
-      <td>ae4d8ba12d6c653485cdd10542d0415c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.3-Windows-x86.exe">Miniconda-3.7.3-Windows-x86.exe</a></td>
-      <td class="s">29.2M</td>
-      <td>2014-11-21 16:24:15</td>
-      <td>00847b7ff9ba0d2407a4ab2deb9cd105</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.3-Windows-x86_64.exe">Miniconda-3.7.3-Windows-x86_64.exe</a></td>
-      <td class="s">31.9M</td>
-      <td>2014-11-21 16:24:26</td>
-      <td>9ce16c7f662e86c83b004d214992085a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.7.3-Linux-x86.sh">Miniconda3-3.7.3-Linux-x86.sh</a></td>
-      <td class="s">31.0M</td>
-      <td>2014-11-21 16:21:37</td>
-      <td>2faebe5bc28e11d173632e2818ff7d41</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.7.3-Linux-x86_64.sh">Miniconda3-3.7.3-Linux-x86_64.sh</a></td>
-      <td class="s">32.2M</td>
-      <td>2014-11-21 16:21:25</td>
-      <td>68368851a067cd89c5c7315409843b5b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.7.3-MacOSX-x86_64.sh">Miniconda3-3.7.3-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.6M</td>
-      <td>2014-11-21 16:22:03</td>
-      <td>1780192a95b94ebb9b5462928026821b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.7.3-Windows-x86.exe">Miniconda3-3.7.3-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-3.8.3-Windows-x86.exe">Miniconda3-3.8.3-Windows-x86.exe</a></td>
       <td class="s">37.7M</td>
-      <td>2014-11-21 16:24:38</td>
-      <td>d988d11d9860d7438866e704db2f974f</td>
+      <td>2015-01-28 11:43:09</td>
+      <td>961d4a14a7e7f99e1c6a154b9b643e54869289171b86085d10048352d0645688</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.8.3-Windows-x86_64.exe">Miniconda-3.8.3-Windows-x86_64.exe</a></td>
+      <td class="s">33.6M</td>
+      <td>2015-01-28 11:43:01</td>
+      <td>1747833f0f81042443e1d4af101b2514b5f18f0fada08c9c15f15a6b0e961114</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.8.3-Windows-x86.exe">Miniconda-3.8.3-Windows-x86.exe</a></td>
+      <td class="s">30.9M</td>
+      <td>2015-01-28 11:42:52</td>
+      <td>7212455c734fe5db440896a54c91a5d4bffa9c9fee6fd9c5fc59976d3892023b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.8.3-MacOSX-x86_64.sh">Miniconda3-3.8.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.8M</td>
+      <td>2015-01-28 11:39:09</td>
+      <td>86be2f1d55755670e0a21902584768b69732b31e87af22d1cca856f3d9e5c20d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.8.3-MacOSX-x86_64.sh">Miniconda-3.8.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">17.9M</td>
+      <td>2015-01-28 11:39:07</td>
+      <td>e19e16b7969fb256d68f7de3a4e02331ba04e1c48a262d2b9f66db106e016257</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.8.3-Linux-x86.sh">Miniconda-3.8.3-Linux-x86.sh</a></td>
+      <td class="s">21.4M</td>
+      <td>2015-01-28 11:38:41</td>
+      <td>253a95fac2dbcc01ad5ce5a78d241a362482e1fbb24b1000ea5e217f55825cb6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.8.3-Linux-x86.sh">Miniconda3-3.8.3-Linux-x86.sh</a></td>
+      <td class="s">31.2M</td>
+      <td>2015-01-28 11:38:40</td>
+      <td>2345cf595864ee0a139f6dd1572070442445baace0dec7a4937267169708f929</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.8.3-Linux-x86_64.sh">Miniconda3-3.8.3-Linux-x86_64.sh</a></td>
+      <td class="s">32.4M</td>
+      <td>2015-01-28 11:38:13</td>
+      <td>26483a27b56d3567596b866076cb6de75c4b7e376fe359720ec27fca2c05ceec</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.8.3-Linux-x86_64.sh">Miniconda-3.8.3-Linux-x86_64.sh</a></td>
+      <td class="s">22.4M</td>
+      <td>2015-01-28 11:38:13</td>
+      <td>7ac19397731ffb212ed5534c29cd25f5f4c0c81669707ba6da8635cf1431c114</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.7.3-Windows-x86_64.exe">Miniconda3-3.7.3-Windows-x86_64.exe</a></td>
       <td class="s">40.4M</td>
       <td>2014-11-21 16:24:53</td>
-      <td>f9cbe87fd42ae29f449646ece18031f1</td>
+      <td>f4914b26caa96e2fcb3a15a08b72033a60699f560add65f99de82cbec0d41b45</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.7.0-Linux-x86.sh">Miniconda-3.7.0-Linux-x86.sh</a></td>
-      <td class="s">19.7M</td>
-      <td>2014-09-22 14:57:28</td>
-      <td>25d3bc08eca3d504ec56f30c598cb7fd</td>
+      <td><a href="Miniconda3-3.7.3-Windows-x86.exe">Miniconda3-3.7.3-Windows-x86.exe</a></td>
+      <td class="s">37.7M</td>
+      <td>2014-11-21 16:24:38</td>
+      <td>d9dca16e86fd87fe18780d0fe7a53e0b5993dd6eff8954f6adb98861cd7ab8ec</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.7.0-Linux-x86_64.sh">Miniconda-3.7.0-Linux-x86_64.sh</a></td>
-      <td class="s">20.7M</td>
-      <td>2014-09-22 14:57:18</td>
-      <td>efb03496433f1dfab008ef114093b4b2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.0-MacOSX-x86_64.sh">Miniconda-3.7.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">16.3M</td>
-      <td>2014-09-22 14:57:39</td>
-      <td>2656c37fd8a1a384650d7f09407a0893</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.0-Windows-x86.exe">Miniconda-3.7.0-Windows-x86.exe</a></td>
-      <td class="s">29.2M</td>
-      <td>2014-09-22 14:59:14</td>
-      <td>20b806934cc3aafea0eede333df8835c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.7.0-Windows-x86_64.exe">Miniconda-3.7.0-Windows-x86_64.exe</a></td>
+      <td><a href="Miniconda-3.7.3-Windows-x86_64.exe">Miniconda-3.7.3-Windows-x86_64.exe</a></td>
       <td class="s">31.9M</td>
-      <td>2014-09-22 14:59:25</td>
-      <td>6c3453c2b3eb46e487847bedd1a2ff62</td>
+      <td>2014-11-21 16:24:26</td>
+      <td>9f6fa59af2d71b9c470037a504975281847bd54758ac655bd19e698fdcc330a7</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.7.0-Linux-x86.sh">Miniconda3-3.7.0-Linux-x86.sh</a></td>
+      <td><a href="Miniconda-3.7.3-Windows-x86.exe">Miniconda-3.7.3-Windows-x86.exe</a></td>
+      <td class="s">29.2M</td>
+      <td>2014-11-21 16:24:15</td>
+      <td>610b444424297a92d1b7ed2b68d4e43e98378588f71d4697c16c10fdb862da05</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.7.3-MacOSX-x86_64.sh">Miniconda3-3.7.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.6M</td>
+      <td>2014-11-21 16:22:03</td>
+      <td>f379128606f50a54b93896c3aeeebebd97b2fedd43ee0c103c744ce3c384757b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.3-MacOSX-x86_64.sh">Miniconda-3.7.3-MacOSX-x86_64.sh</a></td>
+      <td class="s">16.3M</td>
+      <td>2014-11-21 16:22:02</td>
+      <td>dbb09fbac5669b70d40c3c05d758140a4f0497af2ef78a4484fc3e22f140ff08</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.7.3-Linux-x86.sh">Miniconda3-3.7.3-Linux-x86.sh</a></td>
       <td class="s">31.0M</td>
-      <td>2014-09-22 14:57:28</td>
-      <td>c4e8ff08b58b08531910a2c68792878c</td>
+      <td>2014-11-21 16:21:37</td>
+      <td>1a2dfaf1dd5b015567f98bb063f03458e5222ad71fa6977a7ee27a1ed1630205</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.7.0-Linux-x86_64.sh">Miniconda3-3.7.0-Linux-x86_64.sh</a></td>
-      <td class="s">32.1M</td>
-      <td>2014-09-22 14:57:18</td>
-      <td>ef3d05b48f8cb4f8d07b864f0f5ce2a8</td>
+      <td><a href="Miniconda-3.7.3-Linux-x86.sh">Miniconda-3.7.3-Linux-x86.sh</a></td>
+      <td class="s">19.7M</td>
+      <td>2014-11-21 16:21:37</td>
+      <td>7ab9d9f6c86a8acaa41f43397f88b446072501e879233bf9d82d3ae6bd2656dc</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.7.0-MacOSX-x86_64.sh">Miniconda3-3.7.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.4M</td>
-      <td>2014-09-22 14:57:40</td>
-      <td>3d5267a3599de1c588205546e7d7facf</td>
+      <td><a href="Miniconda3-3.7.3-Linux-x86_64.sh">Miniconda3-3.7.3-Linux-x86_64.sh</a></td>
+      <td class="s">32.2M</td>
+      <td>2014-11-21 16:21:25</td>
+      <td>7350456b684858e2f4112573ee58d3030e74a259dae6da8d90ec124cba20902b</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.7.0-Windows-x86.exe">Miniconda3-3.7.0-Windows-x86.exe</a></td>
-      <td class="s">37.5M</td>
-      <td>2014-09-22 14:59:37</td>
-      <td>dd0288c0cbd7bc6149a8aabec64d9aac</td>
+      <td><a href="Miniconda-3.7.3-Linux-x86_64.sh">Miniconda-3.7.3-Linux-x86_64.sh</a></td>
+      <td class="s">20.7M</td>
+      <td>2014-11-21 16:21:25</td>
+      <td>c6912c358c3b449bd4cc50cb3deb7c0c31784e6cefbb469990b3f3487bc5a5a1</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.7.0-Windows-x86_64.exe">Miniconda3-3.7.0-Windows-x86_64.exe</a></td>
       <td class="s">40.2M</td>
       <td>2014-09-22 14:59:54</td>
-      <td>2e074bf6d25255c05a923d5bc6f0265e</td>
+      <td>7f33770a7b49c8f24519062ab93d5ce92bf55fc4641505a0c7122d116452adcb</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.6.0-Linux-x86.sh">Miniconda-3.6.0-Linux-x86.sh</a></td>
-      <td class="s">19.0M</td>
-      <td>2014-08-11 14:28:04</td>
-      <td>a4fd29caa00dd83d7af2296d6b4ff149</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.6.0-Linux-x86_64.sh">Miniconda-3.6.0-Linux-x86_64.sh</a></td>
-      <td class="s">19.8M</td>
-      <td>2014-08-11 14:25:23</td>
-      <td>68d91f43c4b31f1f71fdc6e92045c730</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.6.0-MacOSX-x86_64.sh">Miniconda-3.6.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">16.1M</td>
-      <td>2014-08-11 14:29:43</td>
-      <td>10839548e3fb4ec17136dc23a94b76df</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.6.0-Windows-x86.exe">Miniconda-3.6.0-Windows-x86.exe</a></td>
-      <td class="s">29.2M</td>
-      <td>2014-08-11 14:30:31</td>
-      <td>791bf9ccff04b460ad9c05cab343bbc2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.6.0-Windows-x86_64.exe">Miniconda-3.6.0-Windows-x86_64.exe</a></td>
-      <td class="s">31.8M</td>
-      <td>2014-08-11 14:30:40</td>
-      <td>6641efa7fedb14306c8bc77e3682d04e</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.6.0-Linux-x86.sh">Miniconda3-3.6.0-Linux-x86.sh</a></td>
-      <td class="s">29.5M</td>
-      <td>2014-08-11 14:28:04</td>
-      <td>616f370627aea430c1d8e1bd162410a1</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.6.0-Linux-x86_64.sh">Miniconda3-3.6.0-Linux-x86_64.sh</a></td>
-      <td class="s">30.0M</td>
-      <td>2014-08-11 14:25:22</td>
-      <td>44d033d714ab52e594e920d3b0523547</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.6.0-MacOSX-x86_64.sh">Miniconda3-3.6.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.1M</td>
-      <td>2014-08-11 14:29:44</td>
-      <td>bb56c7912c32b540537af98b49abf052</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.6.0-Windows-x86.exe">Miniconda3-3.6.0-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-3.7.0-Windows-x86.exe">Miniconda3-3.7.0-Windows-x86.exe</a></td>
       <td class="s">37.5M</td>
-      <td>2014-08-11 14:30:53</td>
-      <td>65ad0305606d4df36536da3b199a40f8</td>
+      <td>2014-09-22 14:59:37</td>
+      <td>c63c2ec84bb5d3486d2283952cbe653021c396702f217554854190f979dc70a0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.0-Windows-x86_64.exe">Miniconda-3.7.0-Windows-x86_64.exe</a></td>
+      <td class="s">31.9M</td>
+      <td>2014-09-22 14:59:25</td>
+      <td>3f7c75d620373a57ab2bb82cef145472138bd7083f0f63aff24f2a1cea74e79f</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.0-Windows-x86.exe">Miniconda-3.7.0-Windows-x86.exe</a></td>
+      <td class="s">29.2M</td>
+      <td>2014-09-22 14:59:14</td>
+      <td>90da1dff94075448c2f7441b6ac259935fa54d7aeeb75248059b057fd5ee8f43</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.7.0-MacOSX-x86_64.sh">Miniconda3-3.7.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.4M</td>
+      <td>2014-09-22 14:57:40</td>
+      <td>fd4df5a944801019ef56a348bdcb483a7fdbf376c98aeacb25a78e5bc9bb4158</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.0-MacOSX-x86_64.sh">Miniconda-3.7.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">16.3M</td>
+      <td>2014-09-22 14:57:39</td>
+      <td>9a8e731a2a3bd6ab3d5b7304c3c783c04582386142fe39ceb7d5bfabdd74d8eb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.7.0-Linux-x86.sh">Miniconda3-3.7.0-Linux-x86.sh</a></td>
+      <td class="s">31.0M</td>
+      <td>2014-09-22 14:57:28</td>
+      <td>d5143303a8159a5b7388cc1d09aa6d9bc029c2c5f8cb53230a5fcf07d9ee149c</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.0-Linux-x86.sh">Miniconda-3.7.0-Linux-x86.sh</a></td>
+      <td class="s">19.7M</td>
+      <td>2014-09-22 14:57:28</td>
+      <td>cada23bbaab6f21053d45f6d76cf311dffb2f234659fcef0b6a33a6d769317cb</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.7.0-Linux-x86_64.sh">Miniconda3-3.7.0-Linux-x86_64.sh</a></td>
+      <td class="s">32.1M</td>
+      <td>2014-09-22 14:57:18</td>
+      <td>dba631db9938216af83ca9793605a73fae8b8e5ef966c15b9e89c09bf405de26</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.7.0-Linux-x86_64.sh">Miniconda-3.7.0-Linux-x86_64.sh</a></td>
+      <td class="s">20.7M</td>
+      <td>2014-09-22 14:57:18</td>
+      <td>ed6fd3f85dc43ca10e41355bf3efc40bffd64f2364aecad24ac68a9f1009a469</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.6.0-Windows-x86_64.exe">Miniconda3-3.6.0-Windows-x86_64.exe</a></td>
       <td class="s">40.2M</td>
       <td>2014-08-11 14:31:04</td>
-      <td>7a2f705ca9fe7c671d406c8d9efac080</td>
+      <td>e92db89d02dd01754d32c7c3b1b604cb5f123968536bc333b2367027a19652fa</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.5.5-Windows-x86.exe">Miniconda-3.5.5-Windows-x86.exe</a></td>
-      <td class="s">29.1M</td>
-      <td>2014-06-27 15:50:20</td>
-      <td>67a6efb324491928f9aaa447ab5491ac</td>
+      <td><a href="Miniconda3-3.6.0-Windows-x86.exe">Miniconda3-3.6.0-Windows-x86.exe</a></td>
+      <td class="s">37.5M</td>
+      <td>2014-08-11 14:30:53</td>
+      <td>b06b1651123f7e0fe8a1c1069733adae72406970de48e3d48bf256dcef091724</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.5.5-Windows-x86_64.exe">Miniconda-3.5.5-Windows-x86_64.exe</a></td>
-      <td class="s">31.7M</td>
-      <td>2014-06-27 15:50:30</td>
-      <td>b6285db92cc042a44b2afaaf1a99b8cc</td>
+      <td><a href="Miniconda-3.6.0-Windows-x86_64.exe">Miniconda-3.6.0-Windows-x86_64.exe</a></td>
+      <td class="s">31.8M</td>
+      <td>2014-08-11 14:30:40</td>
+      <td>2db05a717daec0ff0ec62a81ea24259ad0edd772094d9135e4297aedf0c3c57a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.5.5-Windows-x86.exe">Miniconda3-3.5.5-Windows-x86.exe</a></td>
-      <td class="s">37.4M</td>
-      <td>2014-06-27 15:50:41</td>
-      <td>2aae7daffbbd4a3f2b775c85a1500a47</td>
+      <td><a href="Miniconda-3.6.0-Windows-x86.exe">Miniconda-3.6.0-Windows-x86.exe</a></td>
+      <td class="s">29.2M</td>
+      <td>2014-08-11 14:30:31</td>
+      <td>82cc9dd360c50215470b0f4f8a022255ed00c7cbe2b3ea9a0e94c2c1d23a13fa</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.6.0-MacOSX-x86_64.sh">Miniconda3-3.6.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.1M</td>
+      <td>2014-08-11 14:29:44</td>
+      <td>85dcecc22f9f975e768c204c90f08bd8881ffab42faee04f5eb0ca6dd9940169</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.6.0-MacOSX-x86_64.sh">Miniconda-3.6.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">16.1M</td>
+      <td>2014-08-11 14:29:43</td>
+      <td>37d4ef6d104c034d05d93e4c1b7c48f29f846c30466c012e75decac9fda71891</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.6.0-Linux-x86.sh">Miniconda3-3.6.0-Linux-x86.sh</a></td>
+      <td class="s">29.5M</td>
+      <td>2014-08-11 14:28:04</td>
+      <td>4c5dfbdde115697180a77c22a852a83315d13ab28e80f491d329a68d16011002</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.6.0-Linux-x86.sh">Miniconda-3.6.0-Linux-x86.sh</a></td>
+      <td class="s">19.0M</td>
+      <td>2014-08-11 14:28:04</td>
+      <td>481f42a1b64251392042e7125bd44e4f7995122116baa13aa4c0025bd0c4d7c9</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.6.0-Linux-x86_64.sh">Miniconda-3.6.0-Linux-x86_64.sh</a></td>
+      <td class="s">19.8M</td>
+      <td>2014-08-11 14:25:23</td>
+      <td>0f9a82b1fc201e0e6e1d34c81c814c27755f7382ff103a3d504b34cfd8bff5a6</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.6.0-Linux-x86_64.sh">Miniconda3-3.6.0-Linux-x86_64.sh</a></td>
+      <td class="s">30.0M</td>
+      <td>2014-08-11 14:25:22</td>
+      <td>d1ff39a36ab1ec2da8730da908dd78edc5f41014d55317dde4c1f1cd34cbe72b</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.5.5-Windows-x86_64.exe">Miniconda3-3.5.5-Windows-x86_64.exe</a></td>
       <td class="s">40.1M</td>
       <td>2014-06-27 15:50:56</td>
-      <td>6c6643ae90028d89e3ef72889bf8bb36</td>
+      <td>19538585fead6633b67f8291cf040263bba420d5c32c0e17ab42cc432efa8cf1</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.5.5-Windows-x86.exe">Miniconda3-3.5.5-Windows-x86.exe</a></td>
+      <td class="s">37.4M</td>
+      <td>2014-06-27 15:50:41</td>
+      <td>25efc1529f350bece08ddcb826ec392db194ee70ae5ffc690bdf33b0304ff15b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.5.5-Windows-x86_64.exe">Miniconda-3.5.5-Windows-x86_64.exe</a></td>
+      <td class="s">31.7M</td>
+      <td>2014-06-27 15:50:30</td>
+      <td>3f8478b9d430572c8ca42a94a2c0d05579b0bddf33e25828ae5e87230a57bc1b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.5.5-Windows-x86.exe">Miniconda-3.5.5-Windows-x86.exe</a></td>
+      <td class="s">29.1M</td>
+      <td>2014-06-27 15:50:20</td>
+      <td>e2ac05be56d8d28695ba35c60fde26caad3ab583f89e9a5b2b9c6b9ec8b58fa9</td>
     </tr>
     <tr>
       <td><a href="Miniconda-3.5.5-Linux-armv6l.sh">Miniconda-3.5.5-Linux-armv6l.sh</a></td>
       <td class="s">14.7M</td>
       <td>2014-06-16 14:54:53</td>
-      <td>2f37cb775ec3e482280a7bd6b97ee501</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.5.5-Linux-x86.sh">Miniconda-3.5.5-Linux-x86.sh</a></td>
-      <td class="s">18.9M</td>
-      <td>2014-06-11 11:54:56</td>
-      <td>6d6849ba446003bef0a3868786088bc2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.5.5-Linux-x86_64.sh">Miniconda-3.5.5-Linux-x86_64.sh</a></td>
-      <td class="s">19.8M</td>
-      <td>2014-06-11 11:54:24</td>
-      <td>01b39f6b143102e6e0008a12533c1fc9</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.5.5-MacOSX-x86_64.sh">Miniconda-3.5.5-MacOSX-x86_64.sh</a></td>
-      <td class="s">16.2M</td>
-      <td>2014-06-11 11:55:35</td>
-      <td>03a66f2d3d2be40ea241527a2f1bfe5a</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.5.5-Linux-x86.sh">Miniconda3-3.5.5-Linux-x86.sh</a></td>
-      <td class="s">29.5M</td>
-      <td>2014-06-11 11:54:55</td>
-      <td>40bdbf416164b609f726a1c8cb5957a5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.5.5-Linux-x86_64.sh">Miniconda3-3.5.5-Linux-x86_64.sh</a></td>
-      <td class="s">30.0M</td>
-      <td>2014-06-11 11:54:24</td>
-      <td>fa75786e104855cd2710edbea5458c2d</td>
+      <td>b17cc99fdbe8fe54d2c5749d582eac5ffbf5675fbc91a2ae71a981cdb9ee8cc9</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.5.5-MacOSX-x86_64.sh">Miniconda3-3.5.5-MacOSX-x86_64.sh</a></td>
       <td class="s">25.1M</td>
       <td>2014-06-11 11:55:36</td>
-      <td>be0381f6bb8cb655d4fd21c65b390fc1</td>
+      <td>aefc7b1ed2c4e42418bfc2dfcf3ae05b7b23d8adb9472c3d3f38ddf24b493e9f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.5.2-Linux-x86.sh">Miniconda-3.5.2-Linux-x86.sh</a></td>
-      <td class="s">18.8M</td>
-      <td>2014-05-28 16:06:50</td>
-      <td>8f1f5a1b5c0c49f76a5b5c5e7e0d17ed</td>
+      <td><a href="Miniconda-3.5.5-MacOSX-x86_64.sh">Miniconda-3.5.5-MacOSX-x86_64.sh</a></td>
+      <td class="s">16.2M</td>
+      <td>2014-06-11 11:55:35</td>
+      <td>b4205131297ba395fb8445388575a2923598e5a514a6efa50d7e1e1b00af19f3</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.5.2-Linux-x86_64.sh">Miniconda-3.5.2-Linux-x86_64.sh</a></td>
-      <td class="s">19.7M</td>
-      <td>2014-05-28 16:06:33</td>
-      <td>eede513115957241511aa10e30852391</td>
+      <td><a href="Miniconda-3.5.5-Linux-x86.sh">Miniconda-3.5.5-Linux-x86.sh</a></td>
+      <td class="s">18.9M</td>
+      <td>2014-06-11 11:54:56</td>
+      <td>a6fedef9aca9d17ee2387a1a5424bdd32eeb04544647cec9cede380e3a19631c</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.5.2-MacOSX-x86_64.sh">Miniconda-3.5.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">16.1M</td>
-      <td>2014-05-28 16:07:13</td>
-      <td>f2a75c523407f6c0f471f99acb37f5ae</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.5.2-Windows-x86.exe">Miniconda-3.5.2-Windows-x86.exe</a></td>
-      <td class="s">28.6M</td>
-      <td>2014-05-28 16:08:49</td>
-      <td>bad3fbd884d79f70b4e3c390c86332f0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.5.2-Windows-x86_64.exe">Miniconda-3.5.2-Windows-x86_64.exe</a></td>
-      <td class="s">31.1M</td>
-      <td>2014-05-28 16:08:59</td>
-      <td>c195a26d199168e25a27c8072905cf18</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.5.2-Linux-x86.sh">Miniconda3-3.5.2-Linux-x86.sh</a></td>
+      <td><a href="Miniconda3-3.5.5-Linux-x86.sh">Miniconda3-3.5.5-Linux-x86.sh</a></td>
       <td class="s">29.5M</td>
-      <td>2014-05-28 16:06:50</td>
-      <td>9da8badd124d118229360bc57435ae05</td>
+      <td>2014-06-11 11:54:55</td>
+      <td>0e7db4875148441e12bcc9abe070a08114c14979883375d09acccb1ce2d20d61</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.5.2-Linux-x86_64.sh">Miniconda3-3.5.2-Linux-x86_64.sh</a></td>
+      <td><a href="Miniconda3-3.5.5-Linux-x86_64.sh">Miniconda3-3.5.5-Linux-x86_64.sh</a></td>
       <td class="s">30.0M</td>
-      <td>2014-05-28 16:06:33</td>
-      <td>031445086d58cbe47c10c650e9442a2b</td>
+      <td>2014-06-11 11:54:24</td>
+      <td>a4d0a7a613e1d0ae5e703ab72eab544caa9c86109e13712a9c99bbc6fb411c5a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.5.2-MacOSX-x86_64.sh">Miniconda3-3.5.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">25.1M</td>
-      <td>2014-05-28 16:07:15</td>
-      <td>38ebc1f05f1649838ee2b6a89f4774e4</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.5.2-Windows-x86.exe">Miniconda3-3.5.2-Windows-x86.exe</a></td>
-      <td class="s">37.3M</td>
-      <td>2014-05-28 16:09:11</td>
-      <td>47f5179ef381eef6b25ed4ca8f31e351</td>
+      <td><a href="Miniconda-3.5.5-Linux-x86_64.sh">Miniconda-3.5.5-Linux-x86_64.sh</a></td>
+      <td class="s">19.8M</td>
+      <td>2014-06-11 11:54:24</td>
+      <td>7f62ac2f3fb9e5067cbb13cadd81664e62042eefbd971cbffaf433fa584bdb06</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.5.2-Windows-x86_64.exe">Miniconda3-3.5.2-Windows-x86_64.exe</a></td>
       <td class="s">40.0M</td>
       <td>2014-05-28 16:09:23</td>
-      <td>f46cec1140f9fbf16740efd11738c1d2</td>
+      <td>f992e79c831cec1ac4fc9fbd0b192740a31bc9ac1b3b6533361cf8ea29856afa</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.4.2-Linux-x86.sh">Miniconda-3.4.2-Linux-x86.sh</a></td>
-      <td class="s">18.3M</td>
-      <td>2014-04-25 14:11:41</td>
-      <td>0865f66f4cf675fe431d8ec8afe195f4</td>
+      <td><a href="Miniconda3-3.5.2-Windows-x86.exe">Miniconda3-3.5.2-Windows-x86.exe</a></td>
+      <td class="s">37.3M</td>
+      <td>2014-05-28 16:09:11</td>
+      <td>621e003251e5033497e43ad6592ac19972960f3ba591a838084d19b62fb283c5</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.4.2-Linux-x86_64.sh">Miniconda-3.4.2-Linux-x86_64.sh</a></td>
-      <td class="s">19.2M</td>
-      <td>2014-04-25 14:11:23</td>
-      <td>5a6e8379549bae8fde44cb23c0b42169</td>
+      <td><a href="Miniconda-3.5.2-Windows-x86_64.exe">Miniconda-3.5.2-Windows-x86_64.exe</a></td>
+      <td class="s">31.1M</td>
+      <td>2014-05-28 16:08:59</td>
+      <td>c760555a06563af472536051790d51644a27e24b5d8c744f7016b3ed3935535e</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.4.2-MacOSX-x86_64.sh">Miniconda-3.4.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">15.2M</td>
-      <td>2014-04-25 14:12:10</td>
-      <td>c2b6938a6110369e1499a3475272ba70</td>
+      <td><a href="Miniconda-3.5.2-Windows-x86.exe">Miniconda-3.5.2-Windows-x86.exe</a></td>
+      <td class="s">28.6M</td>
+      <td>2014-05-28 16:08:49</td>
+      <td>efdea051eac2e0e8e3811f1256f1dd4b565d5c65f8007e96d59c9852d8349651</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.4.2-Windows-x86.exe">Miniconda-3.4.2-Windows-x86.exe</a></td>
-      <td class="s">28.1M</td>
-      <td>2014-04-25 14:14:02</td>
-      <td>cf896bd9ed39856e9442d3c35940f212</td>
+      <td><a href="Miniconda3-3.5.2-MacOSX-x86_64.sh">Miniconda3-3.5.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">25.1M</td>
+      <td>2014-05-28 16:07:15</td>
+      <td>149861f665d7e5cf5bc6f4e992a0e9f8706fc22e2b9e11ae6781b29ee56c568c</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.4.2-Windows-x86_64.exe">Miniconda-3.4.2-Windows-x86_64.exe</a></td>
-      <td class="s">30.5M</td>
-      <td>2014-04-25 14:14:12</td>
-      <td>82c36c17f2f62e20a4a03376af90cd61</td>
+      <td><a href="Miniconda-3.5.2-MacOSX-x86_64.sh">Miniconda-3.5.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">16.1M</td>
+      <td>2014-05-28 16:07:13</td>
+      <td>ab8114374b0de8df6ea8fc9911c9d65d2bbf3ee259b9550c21fb9b53c8ee6cab</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.4.2-Linux-x86.sh">Miniconda3-3.4.2-Linux-x86.sh</a></td>
-      <td class="s">26.0M</td>
-      <td>2014-04-25 14:11:40</td>
-      <td>09921892e4848ba70e00ec67c158fb7b</td>
+      <td><a href="Miniconda3-3.5.2-Linux-x86.sh">Miniconda3-3.5.2-Linux-x86.sh</a></td>
+      <td class="s">29.5M</td>
+      <td>2014-05-28 16:06:50</td>
+      <td>058056082193f16478e09364d6b3b8935e2a80e3e1581fd055ae9a08f994ed1a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.4.2-Linux-x86_64.sh">Miniconda3-3.4.2-Linux-x86_64.sh</a></td>
-      <td class="s">26.5M</td>
-      <td>2014-04-25 14:11:23</td>
-      <td>abde84f95daf3322b3d6b57213485c16</td>
+      <td><a href="Miniconda-3.5.2-Linux-x86.sh">Miniconda-3.5.2-Linux-x86.sh</a></td>
+      <td class="s">18.8M</td>
+      <td>2014-05-28 16:06:50</td>
+      <td>2bdccd44776a0fbc87f284f5fcd2d5b2d041aee48fa714506c8fb26ea85c13b6</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.4.2-MacOSX-x86_64.sh">Miniconda3-3.4.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.9M</td>
-      <td>2014-04-25 14:12:11</td>
-      <td>6086784df9f872865791e8364f67d452</td>
+      <td><a href="Miniconda3-3.5.2-Linux-x86_64.sh">Miniconda3-3.5.2-Linux-x86_64.sh</a></td>
+      <td class="s">30.0M</td>
+      <td>2014-05-28 16:06:33</td>
+      <td>0c36400ac5b141a695dfa4717779c8469aae197b219fec990dba14be660c3d99</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.4.2-Windows-x86.exe">Miniconda3-3.4.2-Windows-x86.exe</a></td>
-      <td class="s">33.0M</td>
-      <td>2014-04-25 14:14:22</td>
-      <td>0911a391b580924f29604aa150f994d0</td>
+      <td><a href="Miniconda-3.5.2-Linux-x86_64.sh">Miniconda-3.5.2-Linux-x86_64.sh</a></td>
+      <td class="s">19.7M</td>
+      <td>2014-05-28 16:06:33</td>
+      <td>d6eb7016d033a89165ce53da7933c9cc1961bf41985d48feff17dc005974f213</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.4.2-Windows-x86_64.exe">Miniconda3-3.4.2-Windows-x86_64.exe</a></td>
       <td class="s">35.6M</td>
       <td>2014-04-25 14:14:32</td>
-      <td>b1e921aab75c81010e238dfcce8840fb</td>
+      <td>8347090acb8067282f4d647625662a255aa53aa966c05bf176ff0248ec92bd6f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.3.0-Linux-x86.sh">Miniconda-3.3.0-Linux-x86.sh</a></td>
-      <td class="s">18.2M</td>
-      <td>2014-03-19 11:09:37</td>
-      <td>734f0f18f5c8705e0b849c97573559e9</td>
+      <td><a href="Miniconda3-3.4.2-Windows-x86.exe">Miniconda3-3.4.2-Windows-x86.exe</a></td>
+      <td class="s">33.0M</td>
+      <td>2014-04-25 14:14:22</td>
+      <td>677a53e17ae0565bbf7c5073822b7e31219308ac88db27f7262aee843d2097ea</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.3.0-Linux-x86_64.sh">Miniconda-3.3.0-Linux-x86_64.sh</a></td>
-      <td class="s">19.1M</td>
-      <td>2014-03-19 11:09:13</td>
-      <td>d68136816b4483391651fb4efd34725f</td>
+      <td><a href="Miniconda-3.4.2-Windows-x86_64.exe">Miniconda-3.4.2-Windows-x86_64.exe</a></td>
+      <td class="s">30.5M</td>
+      <td>2014-04-25 14:14:12</td>
+      <td>31872e9bdc3be87c36dce3a6631afe53eb2364cc89d6ce04c8534edbf1ced2f1</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.3.0-MacOSX-x86_64.sh">Miniconda-3.3.0-MacOSX-x86_64.sh</a></td>
+      <td><a href="Miniconda-3.4.2-Windows-x86.exe">Miniconda-3.4.2-Windows-x86.exe</a></td>
+      <td class="s">28.1M</td>
+      <td>2014-04-25 14:14:02</td>
+      <td>2dbb7f9931b64f78464decffae63cb55bee14f8ca2ee15a2b4fc953569dd29df</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.4.2-MacOSX-x86_64.sh">Miniconda3-3.4.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.9M</td>
+      <td>2014-04-25 14:12:11</td>
+      <td>8dbad17efb24dc04473fef911239a09e9bf4219cdcfef7b9e263f5f129a8f38d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.4.2-MacOSX-x86_64.sh">Miniconda-3.4.2-MacOSX-x86_64.sh</a></td>
       <td class="s">15.2M</td>
-      <td>2014-03-19 11:10:04</td>
-      <td>7624c9643f4e8bcc6bbd5924b3ad15fd</td>
+      <td>2014-04-25 14:12:10</td>
+      <td>f428977cbef0d5b78379d886735c75e446a482ecb6b5605837d6c2738ddcd074</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.3.0-Windows-x86.exe">Miniconda-3.3.0-Windows-x86.exe</a></td>
-      <td class="s">28.0M</td>
-      <td>2014-03-19 11:12:02</td>
-      <td>3700aa46510eedbc80f4e34e08a76a0e</td>
+      <td><a href="Miniconda-3.4.2-Linux-x86.sh">Miniconda-3.4.2-Linux-x86.sh</a></td>
+      <td class="s">18.3M</td>
+      <td>2014-04-25 14:11:41</td>
+      <td>f198359f0b34f7efa704235d24126160930b7ea7205127880f3acb0a47999413</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.3.0-Windows-x86_64.exe">Miniconda-3.3.0-Windows-x86_64.exe</a></td>
-      <td class="s">30.4M</td>
-      <td>2014-03-19 11:12:12</td>
-      <td>fb233a781415865a0a33e4e8c67f2243</td>
+      <td><a href="Miniconda3-3.4.2-Linux-x86.sh">Miniconda3-3.4.2-Linux-x86.sh</a></td>
+      <td class="s">26.0M</td>
+      <td>2014-04-25 14:11:40</td>
+      <td>9629cb8f1d633d1bfff59985fa93493eae3c18590893631bc5c1ae57d880e659</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.3.0-Linux-x86.sh">Miniconda3-3.3.0-Linux-x86.sh</a></td>
-      <td class="s">25.9M</td>
-      <td>2014-03-19 11:09:38</td>
-      <td>8b9b12ca8e497bd02be9ddd6e0647935</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.3.0-Linux-x86_64.sh">Miniconda3-3.3.0-Linux-x86_64.sh</a></td>
+      <td><a href="Miniconda3-3.4.2-Linux-x86_64.sh">Miniconda3-3.4.2-Linux-x86_64.sh</a></td>
       <td class="s">26.5M</td>
-      <td>2014-03-19 11:09:14</td>
-      <td>fba5c08c20697c9cae9ffeee192d18a2</td>
+      <td>2014-04-25 14:11:23</td>
+      <td>ea2eb831c89fedb8cd5e7d1cc4d299726684b8d8ccd0fdf16f039bd316dccf78</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.3.0-MacOSX-x86_64.sh">Miniconda3-3.3.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.8M</td>
-      <td>2014-03-19 11:10:05</td>
-      <td>8868b209e1eb5a5b465497214c0e738c</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.3.0-Windows-x86.exe">Miniconda3-3.3.0-Windows-x86.exe</a></td>
-      <td class="s">32.9M</td>
-      <td>2014-03-19 11:12:22</td>
-      <td>85b017f06047b26566d551c38bc1b61b</td>
+      <td><a href="Miniconda-3.4.2-Linux-x86_64.sh">Miniconda-3.4.2-Linux-x86_64.sh</a></td>
+      <td class="s">19.2M</td>
+      <td>2014-04-25 14:11:23</td>
+      <td>97d4e234f6abca0c53c606b8a7a73b909cc05a7703c512f4ea855de83b753db1</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.3.0-Windows-x86_64.exe">Miniconda3-3.3.0-Windows-x86_64.exe</a></td>
       <td class="s">35.5M</td>
       <td>2014-03-19 11:12:33</td>
-      <td>f8bff006b9bd5a302b89acfda400edcf</td>
+      <td>c95878f925c91703a290151baecb10647f6c4e89c1ca8c898b77a09a25f52ece</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.5-Linux-x86.sh">Miniconda-3.0.5-Linux-x86.sh</a></td>
-      <td class="s">18.0M</td>
-      <td>2014-02-18 10:14:08</td>
-      <td>84b1bce275b97c028040e8e6188ac57f</td>
+      <td><a href="Miniconda3-3.3.0-Windows-x86.exe">Miniconda3-3.3.0-Windows-x86.exe</a></td>
+      <td class="s">32.9M</td>
+      <td>2014-03-19 11:12:22</td>
+      <td>2200ee15b0b36a3547f03b9a08f1d222747bdc95898b48cf8a50d27f80c394ba</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.5-Linux-x86_64.sh">Miniconda-3.0.5-Linux-x86_64.sh</a></td>
-      <td class="s">18.9M</td>
-      <td>2014-02-18 10:13:04</td>
-      <td>28f942356a1de3383fc619896620a9dd</td>
+      <td><a href="Miniconda-3.3.0-Windows-x86_64.exe">Miniconda-3.3.0-Windows-x86_64.exe</a></td>
+      <td class="s">30.4M</td>
+      <td>2014-03-19 11:12:12</td>
+      <td>f8e391ee4948b3aab877fda2f2669e63905ce7d5654e163ab3dc5817ccc1f6c2</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.5-MacOSX-x86_64.sh">Miniconda-3.0.5-MacOSX-x86_64.sh</a></td>
-      <td class="s">15.1M</td>
-      <td>2014-02-18 10:13:57</td>
-      <td>33d33d00d69c91bdaded4e68d1db7fff</td>
+      <td><a href="Miniconda-3.3.0-Windows-x86.exe">Miniconda-3.3.0-Windows-x86.exe</a></td>
+      <td class="s">28.0M</td>
+      <td>2014-03-19 11:12:02</td>
+      <td>c256359f4ab7d5e3cb30bbd53830c99e5219d4994528d82225acdbf6d5bcd138</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.5-Windows-x86.exe">Miniconda-3.0.5-Windows-x86.exe</a></td>
-      <td class="s">27.1M</td>
-      <td>2014-02-18 10:16:15</td>
-      <td>1ba74df1e641b424d0a71c034a92bd32</td>
+      <td><a href="Miniconda3-3.3.0-MacOSX-x86_64.sh">Miniconda3-3.3.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.8M</td>
+      <td>2014-03-19 11:10:05</td>
+      <td>131b6a351987caab78410082e81d9cb51db262301cb9b8f09656bc94cddc51e4</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.5-Windows-x86_64.exe">Miniconda-3.0.5-Windows-x86_64.exe</a></td>
-      <td class="s">29.0M</td>
-      <td>2014-02-18 10:16:25</td>
-      <td>5df8d17d918dd03a7ae56f99ab046c04</td>
+      <td><a href="Miniconda-3.3.0-MacOSX-x86_64.sh">Miniconda-3.3.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">15.2M</td>
+      <td>2014-03-19 11:10:04</td>
+      <td>9e9a65c69a1f4ec3b4df05f477b517dfa1088182344bfe8009f58d0b4bd00e5c</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.5-Linux-x86.sh">Miniconda3-3.0.5-Linux-x86.sh</a></td>
-      <td class="s">25.7M</td>
-      <td>2014-02-18 10:14:08</td>
-      <td>3235ea10e993e1462538c7cf8a8bcfe9</td>
+      <td><a href="Miniconda3-3.3.0-Linux-x86.sh">Miniconda3-3.3.0-Linux-x86.sh</a></td>
+      <td class="s">25.9M</td>
+      <td>2014-03-19 11:09:38</td>
+      <td>80957b9c4b8d5674e13693cdf6be3e73ff1a109fa26faaefd4f0dbeb11a57295</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.5-Linux-x86_64.sh">Miniconda3-3.0.5-Linux-x86_64.sh</a></td>
-      <td class="s">26.2M</td>
-      <td>2014-02-18 10:13:04</td>
-      <td>9e0c7d7bb79536a68d8e4cac6dff2e1d</td>
+      <td><a href="Miniconda-3.3.0-Linux-x86.sh">Miniconda-3.3.0-Linux-x86.sh</a></td>
+      <td class="s">18.2M</td>
+      <td>2014-03-19 11:09:37</td>
+      <td>415119946afab438ee2ec9d9cd063977da780029d5561d2558101233913f226a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.5-MacOSX-x86_64.sh">Miniconda3-3.0.5-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.7M</td>
-      <td>2014-02-18 10:13:58</td>
-      <td>b25f069c240aa83731024932c7f3da6d</td>
+      <td><a href="Miniconda3-3.3.0-Linux-x86_64.sh">Miniconda3-3.3.0-Linux-x86_64.sh</a></td>
+      <td class="s">26.5M</td>
+      <td>2014-03-19 11:09:14</td>
+      <td>07fbf1b54c7a03a524a34ec0078d4c39499fe7cdf3dce209e686ef5e0433722f</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.5-Windows-x86.exe">Miniconda3-3.0.5-Windows-x86.exe</a></td>
-      <td class="s">31.9M</td>
-      <td>2014-02-18 10:16:34</td>
-      <td>6c7346d75e6aae4613ed8ad338c195fc</td>
+      <td><a href="Miniconda-3.3.0-Linux-x86_64.sh">Miniconda-3.3.0-Linux-x86_64.sh</a></td>
+      <td class="s">19.1M</td>
+      <td>2014-03-19 11:09:13</td>
+      <td>e071ff3ffb9b4df65edf5e780d576c901753fecccd10e5af629138036aa51de3</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.0.5-Windows-x86_64.exe">Miniconda3-3.0.5-Windows-x86_64.exe</a></td>
       <td class="s">34.0M</td>
       <td>2014-02-18 10:16:46</td>
-      <td>1f110e33db1013de5f9096b896b2c174</td>
+      <td>68a2e65e470d7b8efad62e1b6d5af249463b8462d234e3af1e6926bcdbbb50ce</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.4-Linux-x86.sh">Miniconda-3.0.4-Linux-x86.sh</a></td>
-      <td class="s">18.0M</td>
-      <td>2014-02-14 11:38:53</td>
-      <td>fb9405ef9a398c617ee9a766ff338d0b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.4-Linux-x86_64.sh">Miniconda-3.0.4-Linux-x86_64.sh</a></td>
-      <td class="s">18.9M</td>
-      <td>2014-02-14 11:38:36</td>
-      <td>80d2e0597c370f752fd1559309fd1ed0</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.4-MacOSX-x86_64.sh">Miniconda-3.0.4-MacOSX-x86_64.sh</a></td>
-      <td class="s">15.1M</td>
-      <td>2014-02-14 11:39:17</td>
-      <td>70e4a415ebb37659498a2d28b8e2467b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.4-Windows-x86.exe">Miniconda-3.0.4-Windows-x86.exe</a></td>
-      <td class="s">27.1M</td>
-      <td>2014-02-14 11:41:24</td>
-      <td>5b2f4ce33c3a717f5183f0a7dc4d8bdb</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.4-Windows-x86_64.exe">Miniconda-3.0.4-Windows-x86_64.exe</a></td>
-      <td class="s">29.0M</td>
-      <td>2014-02-14 11:41:33</td>
-      <td>356c8b2e3c238c0abf1d7e8d146c6fa2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.0.4-Linux-x86.sh">Miniconda3-3.0.4-Linux-x86.sh</a></td>
-      <td class="s">25.7M</td>
-      <td>2014-02-14 11:38:53</td>
-      <td>44a8119a2b6890055d9d746f12693ba5</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.0.4-Linux-x86_64.sh">Miniconda3-3.0.4-Linux-x86_64.sh</a></td>
-      <td class="s">26.2M</td>
-      <td>2014-02-14 11:38:36</td>
-      <td>eb2f2994f5fef8c2c0d6a05aa4d2852b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.0.4-MacOSX-x86_64.sh">Miniconda3-3.0.4-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.7M</td>
-      <td>2014-02-14 11:39:18</td>
-      <td>d69a8e4a140439d3c1220dce40a51d7b</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.0.4-Windows-x86.exe">Miniconda3-3.0.4-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-3.0.5-Windows-x86.exe">Miniconda3-3.0.5-Windows-x86.exe</a></td>
       <td class="s">31.9M</td>
-      <td>2014-02-14 11:41:44</td>
-      <td>cddfaf516d18be2f75009a1c42567cc8</td>
+      <td>2014-02-18 10:16:34</td>
+      <td>564af9e6d843fad05a3f304dbb51bb9610eda6e94d56f8d75e23f5a9b4061bc4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.5-Windows-x86_64.exe">Miniconda-3.0.5-Windows-x86_64.exe</a></td>
+      <td class="s">29.0M</td>
+      <td>2014-02-18 10:16:25</td>
+      <td>927ebbc104fd0cc5dab4cd7db182f0afa2926e932c42416e4b4adcfe2e448835</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.5-Windows-x86.exe">Miniconda-3.0.5-Windows-x86.exe</a></td>
+      <td class="s">27.1M</td>
+      <td>2014-02-18 10:16:15</td>
+      <td>8026c4481241d9a963affc8ea9e0eea33aa67faf488f97cc1084f6bce9666e85</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.5-Linux-x86.sh">Miniconda3-3.0.5-Linux-x86.sh</a></td>
+      <td class="s">25.7M</td>
+      <td>2014-02-18 10:14:08</td>
+      <td>014d0e44b752d9e91373a3c56252b62c0f29b628a8584f8b5515c7c3d8acc6be</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.5-Linux-x86.sh">Miniconda-3.0.5-Linux-x86.sh</a></td>
+      <td class="s">18.0M</td>
+      <td>2014-02-18 10:14:08</td>
+      <td>7f1b78d7380c664f65d811e76f3515c46689947634752e711693202a7451b85b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.5-MacOSX-x86_64.sh">Miniconda3-3.0.5-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.7M</td>
+      <td>2014-02-18 10:13:58</td>
+      <td>7c088951665e2c35574f6dde81189467d80806caff47872887525ed3d0b4dbd0</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.5-MacOSX-x86_64.sh">Miniconda-3.0.5-MacOSX-x86_64.sh</a></td>
+      <td class="s">15.1M</td>
+      <td>2014-02-18 10:13:57</td>
+      <td>5ba297923cb06ed7077c4ee5e4213bc7db2878dbec9ccba1d4c9c61d5e2697ee</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.5-Linux-x86_64.sh">Miniconda3-3.0.5-Linux-x86_64.sh</a></td>
+      <td class="s">26.2M</td>
+      <td>2014-02-18 10:13:04</td>
+      <td>eaf8c5005645eecd18cc09d2da2a69314057a9e36eadc5084120bc1deffa332b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.5-Linux-x86_64.sh">Miniconda-3.0.5-Linux-x86_64.sh</a></td>
+      <td class="s">18.9M</td>
+      <td>2014-02-18 10:13:04</td>
+      <td>5439a10dc7ff66fa48f5b40290adfad01e58db3b03317d87f90aaf72deda862a</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.0.4-Windows-x86_64.exe">Miniconda3-3.0.4-Windows-x86_64.exe</a></td>
       <td class="s">34.0M</td>
       <td>2014-02-14 11:41:54</td>
-      <td>51c2c0311c0a22fa3d45838a14d019fa</td>
+      <td>b52c0ed1595e9d6b1acc0d6fd98e855a1a14d2197e69e1fd26b70d51c55da0bf</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.0-Linux-x86.sh">Miniconda-3.0.0-Linux-x86.sh</a></td>
-      <td class="s">18.0M</td>
-      <td>2014-01-24 14:07:47</td>
-      <td>9d1473a904a39f44d6f8e0860424d16b</td>
+      <td><a href="Miniconda3-3.0.4-Windows-x86.exe">Miniconda3-3.0.4-Windows-x86.exe</a></td>
+      <td class="s">31.9M</td>
+      <td>2014-02-14 11:41:44</td>
+      <td>00320f96a9132df13331835df68518cffc0926e56471a3433473e7e2e4beb0c5</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-3.0.0-Linux-x86_64.sh">Miniconda-3.0.0-Linux-x86_64.sh</a></td>
-      <td class="s">18.9M</td>
-      <td>2014-01-24 14:07:41</td>
-      <td>acf150992cf8d5c332064b31ff885858</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.0-MacOSX-x86_64.sh">Miniconda-3.0.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">15.1M</td>
-      <td>2014-01-24 14:08:01</td>
-      <td>4dc63992aca6ddb3d10aba902ed00a56</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.0-Windows-x86.exe">Miniconda-3.0.0-Windows-x86.exe</a></td>
-      <td class="s">27.1M</td>
-      <td>2014-01-24 14:09:17</td>
-      <td>3d57c174a2f885f137f48f42bc21ad0f</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda-3.0.0-Windows-x86_64.exe">Miniconda-3.0.0-Windows-x86_64.exe</a></td>
+      <td><a href="Miniconda-3.0.4-Windows-x86_64.exe">Miniconda-3.0.4-Windows-x86_64.exe</a></td>
       <td class="s">29.0M</td>
-      <td>2014-01-24 14:09:27</td>
-      <td>d6ce8a747afc27f2a840f6d4b9ddb455</td>
+      <td>2014-02-14 11:41:33</td>
+      <td>f98be73d452a2ab84e15e0225389d4de42bc67f97ebeeef0a1c67b3bd2db7259</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.0-Linux-x86.sh">Miniconda3-3.0.0-Linux-x86.sh</a></td>
-      <td class="s">25.6M</td>
-      <td>2014-01-24 14:07:48</td>
-      <td>4abe8655f5c361338fb317b018ce7c98</td>
+      <td><a href="Miniconda-3.0.4-Windows-x86.exe">Miniconda-3.0.4-Windows-x86.exe</a></td>
+      <td class="s">27.1M</td>
+      <td>2014-02-14 11:41:24</td>
+      <td>94e57aef9b555688a38526ef58d615386e67380421a8093fdbc302d477b8f7ae</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.0-Linux-x86_64.sh">Miniconda3-3.0.0-Linux-x86_64.sh</a></td>
+      <td><a href="Miniconda3-3.0.4-MacOSX-x86_64.sh">Miniconda3-3.0.4-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.7M</td>
+      <td>2014-02-14 11:39:18</td>
+      <td>986525923231b4796c1eb13f2e4defae9aad5ed09b3e32c01b7ebb0aad4ad870</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.4-MacOSX-x86_64.sh">Miniconda-3.0.4-MacOSX-x86_64.sh</a></td>
+      <td class="s">15.1M</td>
+      <td>2014-02-14 11:39:17</td>
+      <td>a457695a2c1216ee91f23d6a1cf2a911178382ee25fd5166ad21d45d5e57de5b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.4-Linux-x86.sh">Miniconda3-3.0.4-Linux-x86.sh</a></td>
+      <td class="s">25.7M</td>
+      <td>2014-02-14 11:38:53</td>
+      <td>1046256accc3b752f4625658e7d845d65c14c7fbb7346579ee828adf7139471d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.4-Linux-x86.sh">Miniconda-3.0.4-Linux-x86.sh</a></td>
+      <td class="s">18.0M</td>
+      <td>2014-02-14 11:38:53</td>
+      <td>b3f392e042469a598e2cd74886d1e15c4708e190a4b188f50fa61c057d7a0ffe</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.4-Linux-x86_64.sh">Miniconda3-3.0.4-Linux-x86_64.sh</a></td>
       <td class="s">26.2M</td>
-      <td>2014-01-24 14:07:41</td>
-      <td>f74f8e9223492ef292a9b2d87e265de9</td>
+      <td>2014-02-14 11:38:36</td>
+      <td>afe03bbed5001a5352e81c018e0bb14e6ade2baa09ecf689febfd6edecb5e93a</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-3.0.0-MacOSX-x86_64.sh">Miniconda3-3.0.0-MacOSX-x86_64.sh</a></td>
-      <td class="s">21.6M</td>
-      <td>2014-01-24 14:08:02</td>
-      <td>2b356f05895a0694fc59f7cd809038f2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-3.0.0-Windows-x86.exe">Miniconda3-3.0.0-Windows-x86.exe</a></td>
-      <td class="s">31.8M</td>
-      <td>2014-01-24 14:09:37</td>
-      <td>c8c3832d1941c16c7c3c13b7d83eac3b</td>
+      <td><a href="Miniconda-3.0.4-Linux-x86_64.sh">Miniconda-3.0.4-Linux-x86_64.sh</a></td>
+      <td class="s">18.9M</td>
+      <td>2014-02-14 11:38:36</td>
+      <td>39f75a6d1619109b96756b4882d962ee12e40e07aa6d662eec10a88f19950eaa</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-3.0.0-Windows-x86_64.exe">Miniconda3-3.0.0-Windows-x86_64.exe</a></td>
       <td class="s">33.8M</td>
       <td>2014-01-24 14:09:48</td>
-      <td>04d8c6bf8fb73f433f5068d75ca9be15</td>
+      <td>4906e4471ae920863aa16795517b7e53de287557fc0bb6dfb417f3802c501cb3</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-2.2.8-Windows-x86.exe">Miniconda-2.2.8-Windows-x86.exe</a></td>
+      <td><a href="Miniconda3-3.0.0-Windows-x86.exe">Miniconda3-3.0.0-Windows-x86.exe</a></td>
+      <td class="s">31.8M</td>
+      <td>2014-01-24 14:09:37</td>
+      <td>eedd4d78d5c68cb28e40a176fb362bc665d15a579459abf15f0247fc91581cca</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.0-Windows-x86_64.exe">Miniconda-3.0.0-Windows-x86_64.exe</a></td>
+      <td class="s">29.0M</td>
+      <td>2014-01-24 14:09:27</td>
+      <td>4d659bb9033054b143a0483c2c7166b02d6125c77aed0e9af9b51b704b90f121</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.0-Windows-x86.exe">Miniconda-3.0.0-Windows-x86.exe</a></td>
       <td class="s">27.1M</td>
-      <td>2014-01-11 12:51:27</td>
-      <td>51afbc1b807643e7453bb0265e855739</td>
+      <td>2014-01-24 14:09:17</td>
+      <td>3922349c40eaf5972507fd642fcb3675762febc67877b8a4f0683a05beec190c</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-2.2.8-Windows-x86_64.exe">Miniconda-2.2.8-Windows-x86_64.exe</a></td>
-      <td class="s">29.1M</td>
-      <td>2014-01-11 12:51:36</td>
-      <td>5da464be16f0cdc67d87028229229243</td>
+      <td><a href="Miniconda3-3.0.0-MacOSX-x86_64.sh">Miniconda3-3.0.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">21.6M</td>
+      <td>2014-01-24 14:08:02</td>
+      <td>b693cfdd2c4b819cd2e977b7200277e7374bcc1578a3d1975255a28887896597</td>
     </tr>
     <tr>
-      <td><a href="Miniconda3-2.2.8-Windows-x86.exe">Miniconda3-2.2.8-Windows-x86.exe</a></td>
-      <td class="s">31.9M</td>
-      <td>2014-01-11 12:51:46</td>
-      <td>259e34e0e941f40cf7b43e71e6b159c3</td>
+      <td><a href="Miniconda-3.0.0-MacOSX-x86_64.sh">Miniconda-3.0.0-MacOSX-x86_64.sh</a></td>
+      <td class="s">15.1M</td>
+      <td>2014-01-24 14:08:01</td>
+      <td>8f825d04146a8229154c54cf07e9cafd9b1fe44dbcfe92c36020a502489e04da</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.0-Linux-x86.sh">Miniconda3-3.0.0-Linux-x86.sh</a></td>
+      <td class="s">25.6M</td>
+      <td>2014-01-24 14:07:48</td>
+      <td>1280ea8cbfcbd3f2a490b094657f2af7872752629b4895b88163f6d0d50dca83</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.0-Linux-x86.sh">Miniconda-3.0.0-Linux-x86.sh</a></td>
+      <td class="s">18.0M</td>
+      <td>2014-01-24 14:07:47</td>
+      <td>ffd2fb01d0c379d5e11a07f0712ebbddae73f24fe266d1af3c3fd93cc383ca8b</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-3.0.0-Linux-x86_64.sh">Miniconda3-3.0.0-Linux-x86_64.sh</a></td>
+      <td class="s">26.2M</td>
+      <td>2014-01-24 14:07:41</td>
+      <td>6bfa6dd73140f00b15e49a8092ec74dbbb96ad28d68a5e05dedd9b427539fcaf</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-3.0.0-Linux-x86_64.sh">Miniconda-3.0.0-Linux-x86_64.sh</a></td>
+      <td class="s">18.9M</td>
+      <td>2014-01-24 14:07:41</td>
+      <td>09b3a81ea0421260ae5f8a1ba8a6a21b1e9f0c745d43b997010f11ad1920dbe3</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-2.2.8-Windows-x86_64.exe">Miniconda3-2.2.8-Windows-x86_64.exe</a></td>
       <td class="s">33.9M</td>
       <td>2014-01-11 12:51:57</td>
-      <td>c3b1d72d83840e60b566abf301cde799</td>
+      <td>7515f37ed8fd9ab3b3a4cf1cb4c239237b42959343744d35f48d0e9fc9e44ef5</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-2.2.2-Linux-x86.sh">Miniconda-2.2.2-Linux-x86.sh</a></td>
-      <td class="s">18.0M</td>
-      <td>2013-11-27 13:12:30</td>
-      <td>26a4bdf7183aefa360f2aba8e9386a7f</td>
+      <td><a href="Miniconda3-2.2.8-Windows-x86.exe">Miniconda3-2.2.8-Windows-x86.exe</a></td>
+      <td class="s">31.9M</td>
+      <td>2014-01-11 12:51:46</td>
+      <td>036f0269d695619e933c8ef7bc5b95aeded21c2d770c62b02a2513cb972d7b44</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-2.2.2-Linux-x86_64.sh">Miniconda-2.2.2-Linux-x86_64.sh</a></td>
-      <td class="s">18.9M</td>
-      <td>2013-11-27 13:11:47</td>
-      <td>a24a8baa264dee7cfd9286ae3d4add60</td>
+      <td><a href="Miniconda-2.2.8-Windows-x86_64.exe">Miniconda-2.2.8-Windows-x86_64.exe</a></td>
+      <td class="s">29.1M</td>
+      <td>2014-01-11 12:51:36</td>
+      <td>91778dff882de8f25ddcdf6f31bec8f7167f4782e9dedcba765ed0c9de6aa49d</td>
     </tr>
     <tr>
-      <td><a href="Miniconda-2.2.2-MacOSX-x86_64.sh">Miniconda-2.2.2-MacOSX-x86_64.sh</a></td>
-      <td class="s">13.0M</td>
-      <td>2013-11-27 13:13:45</td>
-      <td>cd0c8059fd7040a25d015c67f85bbc44</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-2.2.2-Linux-x86.sh">Miniconda3-2.2.2-Linux-x86.sh</a></td>
-      <td class="s">25.6M</td>
-      <td>2013-11-27 13:12:31</td>
-      <td>2dac0e1abf6b0599b6c59ccf3a8cbcf2</td>
-    </tr>
-    <tr>
-      <td><a href="Miniconda3-2.2.2-Linux-x86_64.sh">Miniconda3-2.2.2-Linux-x86_64.sh</a></td>
-      <td class="s">26.2M</td>
-      <td>2013-11-27 13:11:47</td>
-      <td>486bd0f9fa6a6f51e4194ce2a91a4b8e</td>
+      <td><a href="Miniconda-2.2.8-Windows-x86.exe">Miniconda-2.2.8-Windows-x86.exe</a></td>
+      <td class="s">27.1M</td>
+      <td>2014-01-11 12:51:27</td>
+      <td>3abe168b0e2b42ab925d4f01178f11b184afa0851f17d3575631869995a524a4</td>
     </tr>
     <tr>
       <td><a href="Miniconda3-2.2.2-MacOSX-x86_64.sh">Miniconda3-2.2.2-MacOSX-x86_64.sh</a></td>
       <td class="s">19.5M</td>
       <td>2013-11-27 13:13:46</td>
-      <td>cc227b40bee9ea5f117114726f3b8a35</td>
+      <td>040065c06fdeaade1bec67418573608763f6c8c481e0e4e6a9f267598767ab33</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-2.2.2-MacOSX-x86_64.sh">Miniconda-2.2.2-MacOSX-x86_64.sh</a></td>
+      <td class="s">13.0M</td>
+      <td>2013-11-27 13:13:45</td>
+      <td>69139f6c3988b9dc7900e8e65a1f265745b185b6a60e577fe2fd4ff84646c94e</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-2.2.2-Linux-x86.sh">Miniconda3-2.2.2-Linux-x86.sh</a></td>
+      <td class="s">25.6M</td>
+      <td>2013-11-27 13:12:31</td>
+      <td>55a8d6fbd680a4959525c600f3d30475af54b338beee7cd1b44a10d8122e3ee4</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-2.2.2-Linux-x86.sh">Miniconda-2.2.2-Linux-x86.sh</a></td>
+      <td class="s">18.0M</td>
+      <td>2013-11-27 13:12:30</td>
+      <td>c6c7847066dbf459f3934f7fc870d2b0919cf2cbdad78601e85c2c720daadc9d</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda3-2.2.2-Linux-x86_64.sh">Miniconda3-2.2.2-Linux-x86_64.sh</a></td>
+      <td class="s">26.2M</td>
+      <td>2013-11-27 13:11:47</td>
+      <td>4fb79fd66c228e221e8e6627570c84efb785f90ede576d6697e91f906b515548</td>
+    </tr>
+    <tr>
+      <td><a href="Miniconda-2.2.2-Linux-x86_64.sh">Miniconda-2.2.2-Linux-x86_64.sh</a></td>
+      <td class="s">18.9M</td>
+      <td>2013-11-27 13:11:47</td>
+      <td>1cb05546029363279b0d6be5d66e7254b7e2b52637a02601483771f6248dde43</td>
     </tr>
     <tr>
       <td><a href="Miniconda-2.0.3-MacOSX-x86.sh">Miniconda-2.0.3-MacOSX-x86.sh</a></td>
       <td class="s">12.9M</td>
       <td>2013-11-01 23:36:15</td>
-      <td>b7d73e676631365ef64f7dbfa31c78a4</td>
+      <td>a660795eba01503057ed84ff348764c87820950cc1a6698c1cb0457ba6111fe6</td>
     </tr>
     <tr>
       <td><a href="Miniconda-2.0.0-Linux-x86_64.sh">Miniconda-2.0.0-Linux-x86_64.sh</a></td>
       <td class="s">18.9M</td>
       <td>2013-10-01 15:59:54</td>
-      <td>f7f0edd4d5476b24d4388d70638bc482</td>
+      <td>5eed434757f0d3612a27874bf2df8f95f69765b6053222a44aeb3ec824988af3</td>
     </tr>
     <tr>
       <td><a href="Miniconda-1.6.2-Linux-x86_64.sh">Miniconda-1.6.2-Linux-x86_64.sh</a></td>
       <td class="s">18.9M</td>
       <td>2013-09-10 10:25:11</td>
-      <td>37f25affea690c2a197eee5777f32210</td>
+      <td>531d339e1b5f087a1a0c86e14e792d139456c5cf85767f014f3aa573b9c30379</td>
     </tr>
     <tr>
       <td><a href="Miniconda-1.9.1-Linux-x86_64.sh">Miniconda-1.9.1-Linux-x86_64.sh</a></td>
       <td class="s">18.9M</td>
       <td>2013-09-06 15:52:09</td>
-      <td>7e446886360e48bf937c3b6eca610790</td>
+      <td>9900930071acd61c5b430115a805f68130d0146c6f9696234530770d9bf1ccad</td>
     </tr>
     <tr>
       <td><a href="Miniconda-1.6.0-Linux-x86_64.sh">Miniconda-1.6.0-Linux-x86_64.sh</a></td>
       <td class="s">18.7M</td>
       <td>2013-06-21 15:30:53</td>
-      <td>892d6abdfe274765036ff174f2b360b0</td>
+      <td>fc3786cdfac455382f86a3a6fb1f09a07f68218d929cb409c0207da21d90d7be</td>
     </tr>
   </table>
-  <address>Updated: 2020-03-11 10:47:39 CDT - Files: 463</address>
+  <address>Updated: 2023-07-13 14:00:25 CDT - Files: 799</address>
   <div>
   <p>
     These Miniconda installers contain the


### PR DESCRIPTION
- Miniconda changed their versioning from SemVer to CalVer (https://github.com/conda-incubator/ceps/blob/main/cep-8.md)
- Their version is `Year.Month.Patch`, but their upstream artifact is url-versioned `Year.Month.Path-BuildNumber` See example build script: https://github.com/conda/conda-docs/blob/e13a319bd24d9ce754d1f2e9091c7fc522922733/docs/source/create_miniconda_rst.py#L30
- They publish sha256 and not md5 like they used to.
- Publish sha from the upstream page and do not calculate (that's not depwatcher's job) - depwatcher resource simply passes upstream data down.

Fixes https://github.com/cloudfoundry/python-buildpack/issues/761