### PR TITLE
move depwatcher back to coredeps repo

### DIFF
--- a/dockerfiles/depwatcher/README.md
+++ b/dockerfiles/depwatcher/README.md
@@ -17,9 +17,12 @@ The various depwatchers in this resource (in `src`) are written in Crystal, as a
 
 ## Building/Pushing
 
-`docker build -t cfbuildpacks/depwatcher .`
+To build locally:
+`docker build -t mydepwatcherresource .`
 
-`docker push cfbuildpacks/depwatcher`
+The
+[resources/build-and-push-depwatcher](https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/resources)
+is responsible for building and pushing the production-level image to `index.docker.io/coredeps/depwatcher`
 
 ## Example run
 

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -114,7 +114,7 @@ resource_types:
 - name: depwatcher
   type: docker-image
   source:
-    repository: cfbuildpacks/depwatcher
+    repository: coredeps/depwatcher
 - name: slack-notification
   type: docker-image
   source:


### PR DESCRIPTION
Revert the change at https://github.com/cloudfoundry/buildpacks-ci/pull/130/files#diff-70b7a4c21fcded21b75fa15467102293dc8fd901af7c0234954642e10b4d8930R140

The pipeline pushes changes to "coredeps/depwatcher"

More details in [this conversation](https://vmware.slack.com/archives/GPFFKPBQ8/p1689626047298799)