### PR TITLE
Add Go 1.21.x

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -90,13 +90,10 @@ dependencies:
         lines:
           #! go version lines lose support the day that the version line 2 minor bumps ahead is released
           #! for example, 1.17.X reaches EOS whenever 1.19 releases. This gap is roughly 12 months.
-          - line: 1.18.X
-            deprecation_date: ""
-            link: https://golang.org/doc/devel/release.html
-          - line: 1.19.X
-            deprecation_date: ""
-            link: https://golang.org/doc/devel/release.html
           - line: 1.20.X
+            deprecation_date: ""
+            link: https://golang.org/doc/devel/release.html
+          - line: 1.21.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html
         removal_strategy: remove_all


### PR DESCRIPTION
Add Go `1.21.x`, remove `1.18.x` (old, not used in the Buildpack but present in the pipeline) and `1.19.x` (Now that `1.21.x` is released `1.19.x` is deprecated)