### PR TITLE
update-dep task: fix bug with temp -dev stack

### DIFF
--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -75,6 +75,9 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
   end
 
   stack = %r{#{resource_version}-(.*)\.json$}.match(stack_dependency_build)[1]
+
+  # See github.com/cloudfoundry/buildpacks-ci/pull/300 - the build process may create temp stacks like cflinuxfs3-dev
+  stack = stack.end_with?("-dev") ? stack.chomp("-dev") : stack
   next unless all_stacks.include?(stack) # make sure we not pulling something that's not a stack eg 'preview
 
   ## TODO: This should be removed when all the buildpacks are built using cflinuxfs4. Right now it only uses the buildpacks included in buildpacks-ci/pipelines/config/dependency-builds.yml --> cflinuxfs4_buildpacks:

--- a/tasks/update-buildpack-dependency/task.yml
+++ b/tasks/update-buildpack-dependency/task.yml
@@ -13,9 +13,8 @@ inputs:
 outputs:
   - name: artifacts
 run:
-  path: bash
+  path: ruby
   args:
-    - -cl
     - buildpacks-ci/tasks/update-buildpack-dependency/run.rb
 params:
   GPG_SIGNING_KEY_ID:


### PR DESCRIPTION
- See #300 The build process may create temp stacks like cflinuxfs3-dev. This task needs to account for that.

- Not sure why but running the ruby via bash was resulting in task ending up in the red for a while now.

Runs with this branch:
- https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/update-php-8.1.x-php/builds/73
- https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/update-php-8.0.x-php/builds/85