### PR TITLE
Update Python version used in Nodejs Buildpack

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -288,9 +288,9 @@ dependencies:
             link: https://www.python.org/dev/peps/pep-0664/
       nodejs:
         lines:
-          - line: 3.10.X
-            deprecation_date: 2026-10-04
-            link: https://www.python.org/dev/peps/pep-0619/
+          - line: 3.11.X
+            deprecation_date: 2027-10-24
+            link: https://www.python.org/dev/peps/pep-0664/
         removal_strategy: remove_all
     versions_to_keep: 1
   r:


### PR DESCRIPTION
Updated to latest 3.11.x version due to CVEs