### PR TITLE
Remove cflinuxfs3 notification pipeline

### DIFF
--- a/pipelines/notifications.yml
+++ b/pipelines/notifications.yml
@@ -15,15 +15,6 @@ resource_types:
       repository: cfbuildpacks/cron-resource
 
 resources:
-  - name: davos-cve-stories-cflinuxfs3
-    type: cf-tracker-resource
-    source:
-      project_id: 2537714
-      token: ((pivotal-tracker-api-token))
-      labels:
-        - cflinuxfs3
-        - security-notice
-
   - name: davos-cve-stories-cflinuxfs4
     type: cf-tracker-resource
     source:
@@ -67,18 +58,6 @@ resources:
       paths: [ new-cve-notifications/* ]
       private_key: ((public-buildpacks-ci-robots-deploy-key.private_key))
 
-  - name: cflinuxfs3
-    type: git
-    source:
-      uri: https://github.com/cloudfoundry/cflinuxfs3
-
-  - name: cflinuxfs3-release
-    type: github-release
-    source:
-      owner: cloudfoundry
-      repository: cflinuxfs3
-      access_token: ((buildpacks-github-token))
-
   - name: cflinuxfs4
     type: git
     source:
@@ -92,49 +71,6 @@ resources:
       access_token: ((buildpacks-github-token))
 
 jobs:
-  - name: categorize-security-notices-cflinuxfs3
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-          - get: davos-cve-stories
-            resource: davos-cve-stories-cflinuxfs3
-            trigger: true
-          - get: buildpacks-ci
-          - get: cflinuxfs3-release
-            params:
-              include_source_tarball: true
-      - in_parallel:
-          - task: categorize-security-notices-cflinuxfs3
-            file: buildpacks-ci/tasks/categorize-security-notices/task.yml
-            params:
-              TRACKER_PROJECT_ID: 2537714
-              TRACKER_PROJECT_REQUESTER: 1431988
-              TRACKER_API_TOKEN: ((pivotal-tracker-api-token))
-              STACK: cflinuxfs3
-
-  - name: new-rootfs-cves-cflinuxfs3
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-          - get: buildpacks-ci
-          - get: new-cves
-          - get: cflinuxfs3
-          - get: check-interval
-            trigger: true
-      - in_parallel:
-          - do:
-              - task: check-for-new-cflinuxfs3-cves
-                file: buildpacks-ci/tasks/check-for-new-rootfs-cves/task.yml
-                output_mapping:
-                  output-new-cves: output-new-cves-cflinuxfs3
-              - put: new-cves-cflinuxfs3
-                resource: new-cves
-                params:
-                  repository: output-new-cves-cflinuxfs3
-                  rebase: true
-
   - name: categorize-security-notices-cflinuxfs4
     serial: true
     public: true


### PR DESCRIPTION
cflinuxfs3 is no longer EOL in the project, so we no longer need to collect CVE information for it in the pipeline.

I will fly the pipeline changes when this is merged in