### PR TITLE
Add setuptools/pip upgrade step when doing the pip setup

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -822,6 +822,7 @@ class DependencyBuild
     def self.setup_python_and_pip
       Runner.run('apt', 'update')
       Runner.run('apt', 'install', '-y', 'python3', 'python3-pip')
+      Runner.run('pip3', 'install', '--upgrade', 'pip', 'setuptools')
     end
 
     def self.prune_dotnet_files(source_input, files_to_exclude, write_runtime = false)


### PR DESCRIPTION
# Context

The `pipenv` build process started to fail for the `cflinuxfs4` stack. After some investigation, I found that there are some issues with the default version of `setuptools` that comes by default when you install `python3` and `python3-pip`, which is causing problems with the download of dependencies.

Build failure: [132](https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-pipenv-latest/builds/132)

# Solution

I have added an upgrade command of `setuptools` to the `setup_python_and_pip` function used to build `pipenv`. This will install the latest available version.

Build succeded with the proposed changes: [133](https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-pipenv-latest/builds/133)
