### PR TITLE
s3 buildpacks-ci user: move to access via cloudgate

### DIFF
--- a/lib/aws_assume_role.sh
+++ b/lib/aws_assume_role.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+shopt -s inherit_errexit
+
+function main {
+  if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "Script is not sourced. Please source this script."
+    exit 1
+  fi
+  if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+    echo 'Please set the $AWS_ACCES_KEY_ID of the Principal before calling this script'
+    exit 1
+  fi
+  if [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    echo 'Please set the $AWS_SECRET_ACCES_KEY of the Principal before calling this script'
+    exit 1
+  fi
+  if [ -z "${AWS_ASSUME_ROLE_ARN:-}" ]; then
+    echo 'Please set the $AWS_ASSUME_ROLE_ARN of the role to be assumed before calling this script'
+    exit 1
+  fi
+
+  uuid=$(cat /proc/sys/kernel/random/uuid)
+  RESULT="$(aws sts assume-role --role-arn "${AWS_ASSUME_ROLE_ARN}" --role-session-name "buildpacks-ci-${uuid}")"
+
+  export AWS_ACCESS_KEY_ID="$(echo "${RESULT}" |jq -r .Credentials.AccessKeyId)"
+  export AWS_SECRET_ACCESS_KEY="$(echo "${RESULT}" |jq -r .Credentials.SecretAccessKey)"
+  export AWS_SESSION_TOKEN="$(echo "${RESULT}" |jq -r .Credentials.SessionToken)"
+}
+
+function usage() {
+  cat <<-USAGE
+aws_assume_role.sh
+
+Assumes the given role ARN by generating a set of temporary security credentials
+Must be called with the Principal's creds provided via the following env vars set:
+AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ASSUME_ROLE_ARN.
+You must already set up the AWS trust policy for the Principal to assume the role.
+Script to be sourced.
+
+USAGE
+}
+
+main "${@:-}"

--- a/pipelines/buildpacks-site.yml.erb
+++ b/pipelines/buildpacks-site.yml.erb
@@ -15,8 +15,9 @@ resources:
     type: s3
     source:
       bucket: buildpacks-site
-      access_key_id: {{pivotal-offline-buildpacks-s3-access-key}}
-      secret_access_key: {{pivotal-offline-buildpacks-s3-secret-key}}
+      access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+      secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+      aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
       versioned_file: buildpacks.json
 <% buildpacks.each do |language| %>
   - name: <%= language %>_buildpack

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -55,13 +55,14 @@ resources:
 
 #@ for language in data.values.supported_languages_without_java:
   #@ for stack in language.stacks:
-- name: #@ language.name + "-buildpack-"+ stack
+- name: #@ language.name + "-buildpack-" + stack
   type: s3
   source:
     bucket: buildpack-release-candidates
     regexp: #@  "{}/{}_buildpack-{}-v(.*).zip".format(language.name, language.name, stack)
-    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+    secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
   #@ end
 #@ end
 
@@ -85,16 +86,18 @@ resources:
   source:
     bucket: buildpack-release-rcs
     regexp: #@  "{}/{}-buildpack-release-(.*).tgz".format(language.name, language.name)
-    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+    secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 
 - name: #@ language.name + "-buildpack-release-trigger"
   type: s3
   source:
     bucket: buildpack-release-triggers
     versioned_file: #@ language.name + "-buildpack"
-    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+    secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 #@ end
 
 - name: weekday-mornings
@@ -110,16 +113,18 @@ resources:
   source:
     bucket: shared-buildpack-release-triggers
     versioned_file: non-java
-    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+    secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 
 - name: shared-java-buildpack-release-trigger
   type: s3
   source:
     bucket: shared-buildpack-release-triggers
     versioned_file: java
-    access_key_id: ((pivotal-offline-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-offline-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+    secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 
 
 jobs:
@@ -371,8 +376,9 @@ jobs:
   - task: update-buildpack-release-trigger
     file: buildpacks-ci/tasks/cf-release/update-buildpack-release-trigger/task.yml
     params:
-      AWS_ACCESS_KEY_ID: ((pivotal-offline-buildpacks-s3-access-key))
-      AWS_SECRET_ACCESS_KEY: ((pivotal-offline-buildpacks-s3-secret-key))
+      AWS_ACCESS_KEY_ID: ((svc-buildpacks-aws-bp-ci-access-key))
+      AWS_SECRET_ACCESS_KEY: ((svc-buildpacks-aws-bp-ci-secret-key))
+      AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
       BUCKET: buildpack-release-triggers
 
 - name: #@ "publish-" + language.name + "-buildpack-release"

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -352,9 +352,6 @@ jobs:
           STACK: cflinuxfs4
       - task: use-new-buildpack-bosh-releases
         file: buildpacks-ci/tasks/use-new-buildpack-bosh-releases/task.yml
-        params:
-          ACCESS_KEY_ID: ((pivotal-offline-buildpacks-s3-access-key))
-          SECRET_ACCESS_KEY: ((pivotal-offline-buildpacks-s3-secret-key))
     - put: cflinuxfs4-rootfs-smoke-test-deployment
       params:
         source_file: deployment-source-config/source_file.yml

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -250,16 +250,18 @@ resources: #####################################################################
     source:
       bucket: {{buildpack-release-candidates-bucket}}
       regexp: <%= language%>/<%= language %>_buildpack-<%= stack %>-v(.*).zip
-      access_key_id: {{pivotal-offline-buildpacks-s3-access-key}}
-      secret_access_key: {{pivotal-offline-buildpacks-s3-secret-key}}
+      access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+      secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+      aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 
   - name: pivotal-buildpack-cached-<%= stack %>
     type: s3
     source:
       bucket: {{buildpack-release-candidates-bucket}}
       regexp: <%= language%>/<%= language %>_buildpack-cached-<%= stack %>-v(.*).zip
-      access_key_id: {{pivotal-offline-buildpacks-s3-access-key}}
-      secret_access_key: {{pivotal-offline-buildpacks-s3-secret-key}}
+      access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+      secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+      aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 <% end %>
 
 <% if language.to_s == 'hwc' || language.to_s == 'binary' %>
@@ -268,16 +270,18 @@ resources: #####################################################################
     source:
       bucket: {{buildpack-release-candidates-bucket}}
       regexp: <%= language%>/<%= language %>_buildpack-cached-v(.*).zip
-      access_key_id: {{pivotal-offline-buildpacks-s3-access-key}}
-      secret_access_key: {{pivotal-offline-buildpacks-s3-secret-key}}
+      access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+      secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+      aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 
   - name: pivotal-buildpack-any
     type: s3
     source:
       bucket: {{buildpack-release-candidates-bucket}}
       regexp: <%= language%>/<%= language %>_buildpack-v(.*).zip
-      access_key_id: {{pivotal-offline-buildpacks-s3-access-key}}
-      secret_access_key: {{pivotal-offline-buildpacks-s3-secret-key}}
+      access_key_id: ((svc-buildpacks-aws-bp-ci-access-key))
+      secret_access_key: ((svc-buildpacks-aws-bp-ci-secret-key))
+      aws_role_arn: ((svc-buildpacks-aws-bp-ci-assume-role-arn))
 <% end %>
 
   ## Resource Pools ##

--- a/tasks/cf-release/update-buildpack-release-trigger/run
+++ b/tasks/cf-release/update-buildpack-release-trigger/run
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source buildpacks-ci/lib/aws_assume_role.sh
+
 buildpack_name="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .name)"
 old_version="$(cat "buildpack-release-trigger/${buildpack_name}")"
 new_version="$(tar -xf buildpack-release-tarball/*.tgz -O release.MF | yj -yj | jq -r .version | cut -d'-' -f1)"

--- a/tasks/cf-release/update-buildpack-release-trigger/task.yml
+++ b/tasks/cf-release/update-buildpack-release-trigger/task.yml
@@ -11,6 +11,7 @@ inputs:
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  AWS_ASSUME_ROLE_ARN:
   BUCKET:
 run:
   path: buildpacks-ci/tasks/cf-release/update-buildpack-release-trigger/run

--- a/tasks/use-new-buildpack-bosh-releases/task.yml
+++ b/tasks/use-new-buildpack-bosh-releases/task.yml
@@ -18,8 +18,6 @@ inputs:
 outputs:
   - name: buildpacks-opsfile
   - name: built-buildpacks-artifacts
-params:
-  ACCESS_KEY_ID:
-  SECRET_ACCESS_KEY:
 run:
   path: buildpacks-ci/tasks/use-new-buildpack-bosh-releases/run.sh
+params:


### PR DESCRIPTION
Move from direct AWS s3 access to cloudgate service-user based access.

<details>
<summary>The permissions policy for the corresponding IAMRole at the time of the commit:</summary>

```json
{
	"Version": "2012-10-17",
	"Statement": [
		{
			"Sid": "VisualEditor0",
			"Effect": "Allow",
			"Action": [
				"s3:ListBucketMultipartUploads",
				"s3:GetObjectRetention",
				"s3:GetObjectVersionTagging",
				"s3:ListBucketVersions",
				"s3:GetObjectAttributes",
				"s3:ListBucket",
				"s3:GetObjectVersionAttributes",
				"s3:ListMultipartUploadParts",
				"s3:PutObject",
				"s3:GetObjectAcl",
				"s3:GetObject",
				"s3:PutObjectVersionAcl",
				"s3:GetObjectVersionAcl",
				"s3:GetObjectTagging",
				"s3:PutBucketVersioning",
				"s3:PutObjectAcl",
				"s3:GetObjectVersion"
			],
			"Resource": [
				"arn:aws:s3:::buildpack-release-candidates/*",
				"arn:aws:s3:::buildpack-release-rcs/*",
				"arn:aws:s3:::buildpack-release-triggers/*",
				"arn:aws:s3:::shared-buildpack-release-triggers/*",
				"arn:aws:s3:::buildpacks-site/*",
				"arn:aws:s3:::buildpack-release-candidates",
				"arn:aws:s3:::buildpack-release-rcs",
				"arn:aws:s3:::buildpack-release-triggers",
				"arn:aws:s3:::shared-buildpack-release-triggers",
				"arn:aws:s3:::buildpacks-site"
			]
		}
	]
}
```
</details>

* task update-buildpack-release-trigger:
use service-user creds to temporarily assume the role.

* task use-new-buildpack-bosh-releases:
remove dangling params that was removed here
(https://github.com/cloudfoundry/buildpacks-ci/commit/693826bfa12974bb090aa98841fd5d3df16a9e4b) but never removed from caller pipeline job.

* The source-of-truth for service-creds is lastpass. The creds have been copied to concourse under the core-deps/main teams and used here.

Fixes https://github.com/pivotal-cf/tanzu-buildpacks/issues/293