### PR TITLE
create-buildpack-dev-release task: support aws assume roles

### DIFF
--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -165,6 +165,7 @@ jobs:
   - task: create-buildpack-dev-release
     file: buildpacks-ci/tasks/cf-release/create-buildpack-dev-release/task.yml
     params:
+      #!# TODO pass in the role ARN when this AWS account access is moved to cloudgate-based service user
       AWS_ACCESS_KEY_ID: ((pivotal-buildpacks-s3-access-key))
       AWS_SECRET_ACCESS_KEY: ((pivotal-buildpacks-s3-secret-key))
   - put: #@ language.name + "-buildpack-release"

--- a/tasks/cf-release/create-buildpack-dev-release/run
+++ b/tasks/cf-release/create-buildpack-dev-release/run
@@ -68,6 +68,12 @@ blobstore:
     access_key_id: ${AWS_ACCESS_KEY_ID}
     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 EOF
+
+if [ -n "${AWS_ASSUME_ROLE_ARN:-}" ]; then
+  cat >>release/config/private.yml <<-EOF
+    assume_role_arn: ${AWS_ASSUME_ROLE_ARN}
+EOF
+fi
 }
 
 upload_blobs() {

--- a/tasks/cf-release/create-buildpack-dev-release/task.yml
+++ b/tasks/cf-release/create-buildpack-dev-release/task.yml
@@ -23,5 +23,6 @@ outputs:
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  AWS_ASSUME_ROLE_ARN:
 run:
   path: buildpacks-ci/tasks/cf-release/create-buildpack-dev-release/run


### PR DESCRIPTION
This is done for the pipeline in private ci calling this task. Bosh cli version is already updated in the previous commit.

https://bosh.io/docs/s3-release-blobstore/#assume-role