### PR TITLE
Update php modules october (Little refactor to bump script included)

### DIFF
--- a/scripts/php-modules/bump-versions.rb
+++ b/scripts/php-modules/bump-versions.rb
@@ -1,40 +1,64 @@
-require_relative('update.rb')
-require_relative('../../tasks/check-for-latest-php-module-versions/common.rb')
+require_relative 'update.rb'
+require_relative '../../tasks/check-for-latest-php-module-versions/common.rb'
 
+# Define a method to calculate the cache key
 def cache_key(name, klass)
   [name, klass]
 end
 
-def get_latest(name, klass, url, cache)
+# Define a method to get the latest version based on various conditions
+def get_latest_version(name, klass, url, cache)
   key = cache_key(name, klass)
 
+  # Check if the version is not already cached
   if !cache[key]
-    latest = current_pecl_version(name) if klass =~ /PECL/i
-    latest = current_github_version(url, ENV['GITHUB_TOKEN']) if url =~ %r{^https://github.com}
+    # Determine the latest version based on different conditions
+    latest = case
+             when klass =~ /PECL/i
+               current_pecl_version(name)
+             when name =~ /ioncube/i
+               current_ioncube_version(url)
+             when name =~ /maxminddb/i
+               current_pecl_version(name)
+             when name =~ /phpiredis/i
+               current_github_version(url, 'tag', ENV['GITHUB_TOKEN'],)
+             when name =~ /lua/i
+               current_lua_version(url)
+             when url =~ %r{^https://github.com}
+               current_github_version(url, 'release', ENV['GITHUB_TOKEN'],)
+             else
+               raise "Unknown module type: #{name} (#{klass})"
+             end
+
+    # Cache the latest version
     cache[key] = latest
   end
 
   cache[key]
 end
 
-def bump_version(dependency, cache)
+# Define a method to bump the version of a dependency
+def bump_dependency_version(dependency, cache)
   name = dependency['name']
   version = dependency['version']
   klass = dependency['klass']
 
+  # Check if the version is missing or set to 'nil'
   if !version || version == 'nil'
     return
   end
 
-  puts "    > Getting latest version of #{name} (#{klass})..."
+  puts "    > Getting the latest version of #{name} (#{klass})..."
   url = url_for_type(name, klass)
-  latest = get_latest(name, klass, url, cache)
+  latest = get_latest_version(name, klass, url, cache)
 
+  # Check if the latest version could not be determined
   if !latest || latest == 'Unknown'
-    puts "      WARNING! Could not determine latest version of #{name}. Manual check required (URL: #{url || '<none>'})."
+    puts "      WARNING! Could not determine the latest version of #{name}. Manual check required (URL: #{url || '<none>'})."
     return
   end
 
+  # Check if a version bump is required
   if version != latest
     puts "      Bumped #{name}: #{version} -> #{latest}"
     dependency['version'] = latest
@@ -44,8 +68,10 @@ def bump_version(dependency, cache)
   end
 end
 
+# Main script
 puts 'Bumping module versions...'
 
-update_modules(&method(:bump_version))
+# Use the update_modules method to iterate and bump version for each module
+update_modules(&method(:bump_dependency_version))
 
 puts 'Done!'

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php8-base-extensions.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php8-base-extensions.yml
@@ -21,8 +21,8 @@ native_modules:
   md5: 02a54449e5ae1c7a7414fb09c2f94aaa
   klass: LibRdKafkaRecipe
 - name: libsodium
-  version: 1.0.18
-  md5: 3ca9ebc13b6b4735acae0a6a4c4f9a95
+  version: 1.0.19
+  md5: 0d8e2233fc41be6d4c7ee36d5dfe9416
   klass: LibSodiumRecipe
 extensions:
 - name: apcu
@@ -70,24 +70,24 @@ extensions:
   md5: nil
   klass: PdoOdbcRecipe
 - name: pdo_sqlsrv
-  version: 5.11.0
-  md5: b982cecb57852e83d4662c78aed7b0b5
+  version: 5.11.1
+  md5: 5bbc5b7918d50dae918410ded7cb2b4d
   klass: PeclRecipe
 - name: rdkafka
   version: 6.0.3
   md5: fd10faec0c599e34837a9482d3c6c801
   klass: PeclRecipe
 - name: redis
-  version: 5.3.7
-  md5: 1ed6793902214cc02467666ba69dd2be
+  version: 6.0.1
+  md5: 77380f030761b81499fbec8bdaf0cdf9
   klass: RedisPeclRecipe
 - name: ssh2
   version: '1.4'
   md5: d4ff155a741fcc33c4439a6e20323afd
   klass: PeclRecipe
 - name: sqlsrv
-  version: 5.11.0
-  md5: 9f7bfb088cc2ec2b2ff37e9edef63920
+  version: 5.11.1
+  md5: b1423068e9084200fb58d44505bfb4ac
   klass: PeclRecipe
 - name: stomp
   version: 2.0.3
@@ -134,8 +134,8 @@ extensions:
   md5: nil
   klass: FakePeclRecipe
 - name: amqp
-  version: 2.0.0
-  md5: ed2b08564cf50be44029c9e647448e54
+  version: 2.1.0
+  md5: 399a0ddef685157c7d4e3003f1ac531c
   klass: AmqpPeclRecipe
 - name: maxminddb
   version: 1.11.0
@@ -146,8 +146,8 @@ extensions:
   md5: '07695da8376002babbce528205decf07'
   klass: PeclRecipe
 - name: phalcon
-  version: 5.3.0
-  md5: ddb4445ae329c4143a815b3cc92c302f
+  version: 5.3.1
+  md5: 81dee3b82cbd3c99d0f9bb6e91407902
   klass: PeclRecipe
 - name: phpiredis
   version: 1.0.1

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php81-extensions-patch.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php81-extensions-patch.yml
@@ -7,6 +7,6 @@ extensions:
     md5: 309190ef3ede2779a617c9375d32ea7a
     klass: OraclePeclRecipe
   - name: ioncube
-    version: 13.0.1
-    md5: 97e5be83bb3d9608b6e3c2207dbea0b5
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
     klass: IonCubeRecipe

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php82-extensions-patch.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php82-extensions-patch.yml
@@ -11,6 +11,6 @@ extensions:
     md5: bbbbb26f1791d1f27ffc05289abee2f3
     klass: OraclePeclRecipe
   - name: ioncube
-    version: 13.0.1
-    md5: 97e5be83bb3d9608b6e3c2207dbea0b5
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
     klass: IonCubeRecipe

--- a/tasks/build-binary-new/php8-base-extensions.yml
+++ b/tasks/build-binary-new/php8-base-extensions.yml
@@ -21,8 +21,8 @@ native_modules:
   md5: 02a54449e5ae1c7a7414fb09c2f94aaa
   klass: LibRdKafkaRecipe
 - name: libsodium
-  version: 1.0.18
-  md5: 3ca9ebc13b6b4735acae0a6a4c4f9a95
+  version: 1.0.19
+  md5: 0d8e2233fc41be6d4c7ee36d5dfe9416
   klass: LibSodiumRecipe
 extensions:
 - name: apcu
@@ -70,24 +70,24 @@ extensions:
   md5: nil
   klass: PdoOdbcRecipe
 - name: pdo_sqlsrv
-  version: 5.11.0
-  md5: b982cecb57852e83d4662c78aed7b0b5
+  version: 5.11.1
+  md5: 5bbc5b7918d50dae918410ded7cb2b4d
   klass: PeclRecipe
 - name: rdkafka
   version: 6.0.3
   md5: fd10faec0c599e34837a9482d3c6c801
   klass: PeclRecipe
 - name: redis
-  version: 5.3.7
-  md5: 1ed6793902214cc02467666ba69dd2be
+  version: 6.0.1
+  md5: 77380f030761b81499fbec8bdaf0cdf9
   klass: RedisPeclRecipe
 - name: ssh2
   version: '1.4'
   md5: d4ff155a741fcc33c4439a6e20323afd
   klass: PeclRecipe
 - name: sqlsrv
-  version: 5.11.0
-  md5: 9f7bfb088cc2ec2b2ff37e9edef63920
+  version: 5.11.1
+  md5: b1423068e9084200fb58d44505bfb4ac
   klass: PeclRecipe
 - name: stomp
   version: 2.0.3
@@ -134,8 +134,8 @@ extensions:
   md5: nil
   klass: FakePeclRecipe
 - name: amqp
-  version: 2.0.0
-  md5: ed2b08564cf50be44029c9e647448e54
+  version: 2.1.0
+  md5: 399a0ddef685157c7d4e3003f1ac531c
   klass: AmqpPeclRecipe
 - name: maxminddb
   version: 1.11.0
@@ -146,8 +146,8 @@ extensions:
   md5: '07695da8376002babbce528205decf07'
   klass: PeclRecipe
 - name: phalcon
-  version: 5.3.0
-  md5: ddb4445ae329c4143a815b3cc92c302f
+  version: 5.3.1
+  md5: 81dee3b82cbd3c99d0f9bb6e91407902
   klass: PeclRecipe
 - name: phpiredis
   version: 1.0.1

--- a/tasks/build-binary-new/php81-extensions-patch.yml
+++ b/tasks/build-binary-new/php81-extensions-patch.yml
@@ -7,6 +7,6 @@ extensions:
     md5: 309190ef3ede2779a617c9375d32ea7a
     klass: OraclePeclRecipe
   - name: ioncube
-    version: 13.0.1
-    md5: 97e5be83bb3d9608b6e3c2207dbea0b5
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
     klass: IonCubeRecipe

--- a/tasks/build-binary-new/php82-extensions-patch.yml
+++ b/tasks/build-binary-new/php82-extensions-patch.yml
@@ -11,6 +11,6 @@ extensions:
     md5: bbbbb26f1791d1f27ffc05289abee2f3
     klass: OraclePeclRecipe
   - name: ioncube
-    version: 13.0.1
-    md5: 97e5be83bb3d9608b6e3c2207dbea0b5
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
     klass: IonCubeRecipe

--- a/tasks/check-for-latest-php-module-versions/common.rb
+++ b/tasks/check-for-latest-php-module-versions/common.rb
@@ -4,9 +4,12 @@
 require 'json'
 require 'nokogiri'
 require 'open-uri'
+require 'net/http'
+require 'rubygems/version'
 
+# Get the release URL for a module
 def url_for_type(name, type)
-  case type.gsub(/Recipe$/,'')
+  case type.gsub(/Recipe$/, '')
   when 'LibSodium'
     'https://github.com/jedisct1/libsodium/releases'
   when 'PHPProtobufPecl'
@@ -32,7 +35,7 @@ def url_for_type(name, type)
   when 'Phalcon'
     'https://github.com/phalcon/cphalcon/releases'
   when 'PHPIRedis'
-    'https://github.com/nrk/phpiredis/releases'
+    'https://github.com/nrk/phpiredis/tags'
   when 'RabbitMQ'
     'https://github.com/alanxz/rabbitmq-c/releases'
   when 'TidewaysXhprof'
@@ -44,29 +47,69 @@ def url_for_type(name, type)
   end
 end
 
+# Get the latest version of a PECL module
 def current_pecl_version(name)
-  doc = Nokogiri::XML(URI.open("https://pecl.php.net/feeds/pkg_#{name}.rss")) rescue nil
+  rss_url = "https://pecl.php.net/feeds/pkg_#{name}.rss"
+  doc = Nokogiri::XML(URI.open(rss_url)) rescue nil
   return 'Unknown' unless doc
+
   doc.remove_namespaces!
-  versions = doc.xpath('//item/title').map do |li|
-    li.text.gsub(/^#{name} /i, '')
-  end.reject do |v|
-    Gem::Version.new(v).prerelease? rescue false
-  end.sort_by do |v|
-    Gem::Version.new(v)
-  end
+  versions = doc.xpath('//item/title').map { |li| li.text.gsub(/^#{name} /i, '') }
+  versions.reject! { |v| Gem::Version.new(v).prerelease? rescue false }
+  versions.sort_by! { |v| Gem::Version.new(v) }
   versions.last
 end
 
-def current_github_version(url, token = nil)
-  repo = url.match(%r{^https://github.com/(.*)/releases$})[1]
-  opts = token ? {:http_basic_authentication => ['token', token]} : {}
-  data = JSON.parse(URI.open("https://api.github.com/repos/#{repo}/releases", **opts).read)
-  data.reject do |d|
-    d['prerelease'] || d['draft']
-  end.map do |d|
-    d['tag_name'].gsub(/^\D*[v\-]/,'').gsub(/^version\s*/i,'').gsub(/\s*stable$/i,'')
-  end.sort_by do |v|
-    Gem::Version.new(v)
-  end.last
+# Get the latest version of a module from GitHub releases or tags
+def current_github_version(url, type = 'release', token = nil)
+  repo = url.match(%r{^https://github.com/(.*)/(releases|tags)$})[1]
+  opts = token ? { http_basic_authentication: ['token', token] } : {}
+  releases_or_tags = JSON.parse(URI.open("https://api.github.com/repos/#{repo}/#{type}s", **opts).read)
+
+  if type == 'release'
+    items = releases_or_tags.reject { |d| d['prerelease'] || d['draft'] }
+    versions = items.map { |d| d['tag_name'].gsub(/^\D*[v\-]/, '').gsub(/^version\s*/i, '').gsub(/\s*stable$/i, '').gsub(/\s*-RELEASE$/i, '') }
+  elsif type == 'tag'
+    versions = releases_or_tags.map { |d| d['name'].gsub(/^\D*[v\-]/, '').gsub(/^version\s*/i, '').gsub(/\s*stable$/i, '').gsub(/\s*-RELEASE$/i, '') }
+  else
+    raise ArgumentError, "Invalid 'type' parameter. Supported values are 'release' and 'tag'."
+  end
+
+  latest_version = versions.map { |v| Gem::Version.new(v) }.max
+  latest_version.to_s
+end
+
+# Get the latest IonCube version
+def current_ioncube_version(url)
+  doc = Nokogiri::HTML(URI.open(url))
+  table = doc.at_css('.loaders-rc-table')
+  valid_versions = []
+
+  table.css('tr td:nth-child(2)').map(&:text).reject(&:empty?).each do |version|
+    cleaned_version = version.strip
+    valid_versions << cleaned_version if cleaned_version.match(/^\d+\.\d+\.\d+$/)
+  end
+
+  sorted_versions = valid_versions.map { |v| Gem::Version.new(v) }.sort
+  latest_version = sorted_versions.last
+  latest_version.to_s
+end
+
+# Get the latest Lua version
+def current_lua_version(url)
+  doc = Nokogiri::HTML(URI.open(url))
+  table = doc.at('table')
+
+  versions = []
+
+  table.css('tr').drop(1).each do |row|
+    filename = row.at('td.name a').text
+    match = filename.match(/lua-(\d+\.\d+\.\d+)/)
+
+    versions << match[1] if match
+  end
+
+  sorted_versions = versions.map { |v| Gem::Version.new(v) }.sort
+  latest_version = sorted_versions.last
+  latest_version.to_s
 end


### PR DESCRIPTION
Besides the normal `.yml` files updates, I decided to update/refactor a little bit the bumping scripts (before it did not support certain dependencies so when a bumping occurs, you have to search manually by visiting the URL to see if there were any bumps).

As you can see in the code, it parses the `HTML` of the page that lists the releases (I could not find any endpoint that gave me the releases in another format) so it may be prone to errors due to changes you may make to the pages, but normally it will not require a major change. For the moment, leaving it like this saves a lot of time by not having to manually visit and search for these dependencies.