### PR TITLE
Update cflinuxfs3-dev.Dockerfile

### DIFF
--- a/dockerfiles/cflinuxfs3-dev.Dockerfile
+++ b/dockerfiles/cflinuxfs3-dev.Dockerfile
@@ -5,4 +5,4 @@ RUN apt update
 # Remove ESM packages required for dependenciees
 
 ## PHP
-RUN apt remove libonig4 -y
+RUN apt remove libonig4 libwebp6 -y


### PR DESCRIPTION
# Context
As expected, some ESM packages are affecting the PHP Build process. In this case `libwebp-dev` that depends on `libwebp6` and `libwebpmux3`.

```bash
The following packages have unmet dependencies:
 libwebp-dev : Depends: libwebp6 (= 0.6.1-2ubuntu0.18.04.2) but 0.6.1-2ubuntu0.18.04.2+esm1 is to be installed
               Depends: libwebpmux3 (= 0.6.1-2ubuntu0.18.04.2) but 0.6.1-2ubuntu0.18.04.2+esm1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-php-8.0.x/builds/83#L64706947:615

# Solution

I added the `libwebp6`package to the "ESM Packages list" intended to be removed (and later installed with the correct non-ESM version in the PHP Build process).