### PR TITLE
s3 buildpacks-team user: move to access via cloudgate

### DIFF
--- a/pipelines/buildpacks-site.yml.erb
+++ b/pipelines/buildpacks-site.yml.erb
@@ -40,6 +40,8 @@ jobs:
         file: buildpacks-ci/tasks/build-and-publish/task.yml
         attempts: 2
         params:
+          #!# Intentionally not migrated to cloudgate service-user based access because this
+          #!# buildpacks-site is most probably not used anymore and a candidate for deletion
           AWS_ACCESS_KEY_ID: {{pivotal-buildpacks-s3-access-key}}
           AWS_SECRET_ACCESS_KEY: {{pivotal-buildpacks-s3-secret-key}}
           AWS_BUCKET: pivotal-buildpacks

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -165,9 +165,9 @@ jobs:
   - task: create-buildpack-dev-release
     file: buildpacks-ci/tasks/cf-release/create-buildpack-dev-release/task.yml
     params:
-      #!# TODO pass in the role ARN when this AWS account access is moved to cloudgate-based service user
-      AWS_ACCESS_KEY_ID: ((pivotal-buildpacks-s3-access-key))
-      AWS_SECRET_ACCESS_KEY: ((pivotal-buildpacks-s3-secret-key))
+      AWS_ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
+      AWS_SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
+      AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
   - put: #@ language.name + "-buildpack-release"
     params:
       repository: release
@@ -400,8 +400,9 @@ jobs:
   - task: finalize-release
     file: buildpacks-ci/tasks/cf-release/finalize-buildpack-release/task.yml
     params:
-      AWS_ACCESS_KEY_ID: ((pivotal-buildpacks-s3-access-key))
-      AWS_SECRET_ACCESS_KEY: ((pivotal-buildpacks-s3-secret-key))
+      AWS_ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
+      AWS_SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
+      AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
   - put: #@ language.name + "-buildpack-release"
     params:
       repository: release

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -139,16 +139,18 @@ resources:
   source:
     bucket: pivotal-buildpacks
     regexp: rootfs/cflinuxfs4-(.*).tar.gz
-    access_key_id: ((pivotal-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-team-access-key))
+    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
 
 - name: receipt-s3
   type: s3
   source:
     bucket: pivotal-buildpacks
     regexp: rootfs/receipt.cflinuxfs4.x86_64-(.*)
-    access_key_id: ((pivotal-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-team-access-key))
+    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
 
 - name: cflinuxfs4-cf-deployment
   type: bosh-deployment
@@ -196,8 +198,9 @@ resources:
   source:
     bucket: pivotal-buildpacks
     key: versions/stack-cflinuxfs4
-    access_key_id: ((pivotal-buildpacks-s3-access-key))
-    secret_access_key: ((pivotal-buildpacks-s3-secret-key))
+    access_key_id: ((svc-buildpacks-aws-team-access-key))
+    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
 
 - name: failure-alert
   type: slack-notification

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -211,8 +211,9 @@ private_key = '((cf-buildpacks-eng-github-ssh-key.private_key))'
   type: s3
   source:
     bucket: {{buildpacks-binaries-s3-bucket}}
-    access_key_id: {{pivotal-buildpacks-s3-access-key}}
-    secret_access_key: {{pivotal-buildpacks-s3-secret-key}}
+    access_key_id: ((svc-buildpacks-aws-team-access-key))
+    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
+    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
     # pip, go and libgdiplus have some versions of the form 'v1.2'; everyone else uses 'v1.2.3'
     regexp: dependencies/<%=dep_name%>/<%=dep_name == 'nginx-static' ? 'nginx' : dep_name %>.*?<%= (dep_name == 'pip' || dep_name == 'go' || dep_name == 'libgdiplus') ? '(\d+\.\d+(?:\.\d+)?)' : '(\d+\.\d+\.\d+)' %>(.*)
 <% end %>

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -1011,8 +1011,9 @@ jobs: ##########################################################################
         - task: create-bosh-release
           file: buildpacks-ci/tasks/create-bosh-release/task.yml
           params:
-            ACCESS_KEY_ID: {{pivotal-buildpacks-s3-access-key}}
-            SECRET_ACCESS_KEY: {{pivotal-buildpacks-s3-secret-key}}
+            ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
+            SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
+            AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
             LANGUAGE: "hwc"
             RELEASE_NAME: hwc-buildpack
             RELEASE_DIR: release

--- a/tasks/cf-release/finalize-buildpack-release/run
+++ b/tasks/cf-release/finalize-buildpack-release/run
@@ -30,6 +30,12 @@ blobstore:
     access_key_id: ${AWS_ACCESS_KEY_ID}
     secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 EOF
+
+if [ -n "${AWS_ASSUME_ROLE_ARN:-}" ]; then
+  cat >>release/config/private.yml <<-EOF
+    assume_role_arn: ${AWS_ASSUME_ROLE_ARN}
+EOF
+fi
 }
 
 

--- a/tasks/cf-release/finalize-buildpack-release/task.yml
+++ b/tasks/cf-release/finalize-buildpack-release/task.yml
@@ -15,5 +15,6 @@ outputs:
 params:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  AWS_ASSUME_ROLE_ARN:
 run:
   path: buildpacks-ci/tasks/cf-release/finalize-buildpack-release/run

--- a/tasks/create-bosh-release/buildpack-bosh-release-updater.rb
+++ b/tasks/create-bosh-release/buildpack-bosh-release-updater.rb
@@ -5,10 +5,11 @@ require_relative '../../lib/git-client'
 
 
 class BuildpackBOSHReleaseUpdater
-  def initialize(version, access_key_id, secret_access_key, language, release_name, release_tarball_dir)
+  def initialize(version, access_key_id, secret_access_key, assume_role_arn, language, release_name, release_tarball_dir)
     @version = version
     @access_key_id = access_key_id
     @secret_access_key = secret_access_key
+    @assume_role_arn = assume_role_arn
     @language = language
     @release_name = release_name
     @release_tarball_dir = release_tarball_dir
@@ -25,6 +26,16 @@ class BuildpackBOSHReleaseUpdater
   def write_private_yml
     puts "creating private.yml"
 
+    if @assume_role_arn && !@assume_role_arn.empty?
+    private_yml = <<~YAML
+                     ---
+                     blobstore:
+                       options:
+                         access_key_id: #{@access_key_id}
+                         secret_access_key: #{@secret_access_key}
+                         assume_role_arn: #{@assume_role_arn}
+                     YAML
+    else
     private_yml = <<~YAML
                      ---
                      blobstore:
@@ -32,6 +43,7 @@ class BuildpackBOSHReleaseUpdater
                          access_key_id: #{@access_key_id}
                          secret_access_key: #{@secret_access_key}
                      YAML
+    end
 
     File.write('config/private.yml', private_yml)
   end

--- a/tasks/create-bosh-release/run.rb
+++ b/tasks/create-bosh-release/run.rb
@@ -14,6 +14,7 @@ end
 version = versions.first
 access_key_id = ENV.fetch('ACCESS_KEY_ID', false)
 secret_access_key = ENV.fetch('SECRET_ACCESS_KEY', false)
+assume_role_arn = ENV.fetch('AWS_ASSUME_ROLE_ARN', false)
 language = ENV.fetch('LANGUAGE')
 release_name = ENV.fetch('RELEASE_NAME')
 release_tarball_dir = File.join(Dir.pwd, 'release-tarball')
@@ -31,6 +32,7 @@ Dir.chdir(ENV.fetch('RELEASE_DIR')) do
     version,
     access_key_id,
     secret_access_key,
+    assume_role_arn,
     language,
     release_name,
     release_tarball_dir)

--- a/tasks/create-bosh-release/task.yml
+++ b/tasks/create-bosh-release/task.yml
@@ -27,5 +27,6 @@ params:
   RELEASE_DIR:
   ACCESS_KEY_ID:
   SECRET_ACCESS_KEY:
+  AWS_ASSUME_ROLE_ARN:
 run:
   path: buildpacks-ci/tasks/create-bosh-release/run.rb


### PR DESCRIPTION
This is the user that owns the s3 bucket "pivotal-buildpacks" used for both dependency storage, and online buildpack bosh release blob storage.

See [issue](https://github.com/pivotal-cf/tanzu-buildpacks/issues/292) for more details.