### PR TITLE
Combine release notes

### DIFF
--- a/tasks/get-buildpack-github-release-notes/run.sh
+++ b/tasks/get-buildpack-github-release-notes/run.sh
@@ -19,39 +19,42 @@ if [ -z "${GITHUB_ACCESS_TOKEN}" ]; then
   exit 1
 fi
 
-version=$(cat version/version)
-if [ -z "${version}" ]; then
-  echo "task error: can't read version from version/version" >&2
-  exit 1
-fi
-
 pushd buildpack
+
+release_body=''
 
 while IFS= read -r line
 do
-   offline_release=$(
-     curl "https://api.github.com/repos/${OFFLINE_RELEASE}/releases/tags/v${line}" \
-     --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
-     | jq -r .
+  version="${line/v/}"
+
+  offline_release_body=$(
+     curl "https://api.github.com/repos/${OFFLINE_RELEASE}/releases/tags/${version}" \
+       --silent \
+       --location \
+       --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
+     | jq -r '.body'
    )
 
-  if [[ "${offline_release}" == "null" ]]; then
+  if [[ "${offline_release_body}" == "null" ]]; then
     release_body+=$(
-      curl "https://api.github.com/repos/${BUILDPACK_REPO}/releases/tags/v${line}" \
+      curl "https://api.github.com/repos/${BUILDPACK_REPO}/releases/tags/v${version}" \
         --silent \
         --location \
-      | jq -r '.body'
+        --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
+      | jq -r '.body' | sed '/^Packaged binaries:$/,$d'
     )
+
+    if [[ "${release_body}" == "null" ]]; then
+      echo "task error: Error retrieving release notes from github.com/${BUILDPACK_REPO}" >&2
+      exit 1
+    fi
+
   else
      break
   fi
+
 done < <(git tag -l --sort=-version:refname "v*")
 
 popd
-
-if [[ "${release_body}" == "null" ]]; then
-  echo "task error: Error retrieving release notes from github.com/${BUILDPACK_REPO}" >&2
-  exit 1
-fi
 
 echo -e "${release_body}" > release-body/body

--- a/tasks/get-buildpack-github-release-notes/run.sh
+++ b/tasks/get-buildpack-github-release-notes/run.sh
@@ -8,6 +8,17 @@ if [ -z "${BUILDPACK_REPO}" ]; then
   exit 1
 fi
 
+if [ -z "${OFFLINE_RELEASE}" ]; then
+  # e.g. "pivotal-cf/go-offline-buildpack-release"
+  echo "task error: OFFLINE_RELEASE not set" >&2
+  exit 1
+fi
+
+if [ -z "${GITHUB_ACCESS_TOKEN}" ]; then
+  echo "task error: GITHUB_ACCESS_TOKEN not set" >&2
+  exit 1
+fi
+
 version=$(cat version/version)
 if [ -z "${version}" ]; then
   echo "task error: can't read version from version/version" >&2
@@ -19,8 +30,8 @@ pushd buildpack
 while IFS= read -r line
 do
    offline_release=$(
-     curl "https://api.github.com/repos/${BUILDPACK_REPO}/releases/tags/v${line}" \
-     --header "Authorization: Bearer GITHUB_ACCESS_TOKEN" \
+     curl "https://api.github.com/repos/${OFFLINE_RELEASE}/releases/tags/v${line}" \
+     --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
      | jq -r .
    )
 

--- a/tasks/get-buildpack-github-release-notes/task.yml
+++ b/tasks/get-buildpack-github-release-notes/task.yml
@@ -13,3 +13,4 @@ run:
   path: buildpacks-ci/tasks/get-buildpack-github-release-notes/run.sh
 params:
   BUILDPACK_REPO:
+  GITHUB_ACCESS_TOKEN:

--- a/tasks/get-buildpack-github-release-notes/task.yml
+++ b/tasks/get-buildpack-github-release-notes/task.yml
@@ -6,6 +6,7 @@ image_resource:
     repository: cfbuildpacks/ci
 inputs:
   - name: buildpacks-ci
+  - name: buildpack
   - name: version
 outputs:
   - name: release-body
@@ -13,4 +14,5 @@ run:
   path: buildpacks-ci/tasks/get-buildpack-github-release-notes/run.sh
 params:
   BUILDPACK_REPO:
+  OFFLINE_RELEASE:
   GITHUB_ACCESS_TOKEN:


### PR DESCRIPTION
Modifies the logic of the get-buildpack-github-release-notes task to roll up any missed release notes into the most recent release.

- Git tag is used to generate the list of versions to check
- Release notes are obtained for OSS buildpack release (tag) without a corresponding offline buildpack release 