### PR TITLE
Update cflinuxfs3-dev dockefiles with new ESM packages to be removed

### DIFF
--- a/dockerfiles/cflinuxfs3-dev.Dockerfile
+++ b/dockerfiles/cflinuxfs3-dev.Dockerfile
@@ -1,8 +1,13 @@
 FROM cloudfoundry/cflinuxfs3
 
-RUN apt update
+# Note: If this list starts to get long, we should consider using an external file to store the list of packages to remove.
 
-# Remove ESM packages required for dependenciees
-
-## PHP
-RUN apt remove libonig4 libwebp6 -y
+RUN apt update && apt remove -y \
+    libonig4 \
+    libwebp6 \
+    libruby2.5 \
+    ruby \
+    ruby2.5 \
+    libldap2-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \


### PR DESCRIPTION
As expected, some ESM packages are affecting the PHP Build process. In this case, these packages should be removed since in the base `cflinuxfs3` image are installed with an ESM version.

- libruby2.5
- ruby
- ruby2.5
- libldap2-dev
- libssl-dev
- libcurl4-openssl-dev
