### PR TITLE
Run PHP Brats on Jammy

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -746,7 +746,7 @@ jobs: ##########################################################################
                 echo -e "config.json modified to:\n $(cat config.json)"
 <% end %>
         - task: brats-<%= stack %>
-          file: buildpacks-ci/tasks/run-bp-brats/task.yml
+          file: buildpacks-ci/tasks/<%= language.to_s == 'php' ? 'run-bp-brats-jammy' : 'run-bp-brats' %>/task.yml
           input_mapping: {cf-space: space}
           params:
             CF_STACK: <%= stack %>
@@ -869,7 +869,7 @@ jobs: ##########################################################################
           params:
             ORG: pivotal
         - task: brats-cflinuxfs3
-          file: buildpacks-ci/tasks/run-bp-brats/task.yml
+          file: buildpacks-ci/tasks/<%= language.to_s == 'php' ? 'run-bp-brats-jammy' : 'run-bp-brats' %>/task.yml
           params:
             CF_STACK: cflinuxfs3
             GINKGO_ATTEMPTS: <%= language.to_s == 'php' ? 10 : 4 %>

--- a/tasks/run-bp-brats-jammy/run.sh
+++ b/tasks/run-bp-brats-jammy/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -l
+
+set -o errexit
+set -o pipefail
+
+pushd buildpack > /dev/null
+  if [ ! -f ./go.mod ]; then
+      export GOPATH=$PWD
+  fi
+  export GOBIN=$PWD/.bin
+  export PATH=$GOBIN:$PATH
+popd > /dev/null
+
+if [[ -e "${PWD}/buildpack/scripts/.util/tools.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${PWD}/buildpack/scripts/.util/tools.sh"
+  util::tools::cf::install --directory "${PWD}/buildpack/.bin"
+fi
+
+"./cf-space/login"
+
+pushd buildpack > /dev/null
+  ./scripts/brats.sh
+popd > /dev/null

--- a/tasks/run-bp-brats-jammy/task.yml
+++ b/tasks/run-bp-brats-jammy/task.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfbuildpacks/test-on-jammy
+inputs:
+  - name: buildpacks-ci
+  - name: buildpack
+  - name: cf-space
+
+run:
+  path: buildpacks-ci/tasks/run-bp-brats/run.sh
+params:
+  CF_STACK:
+  GINKGO_ATTEMPTS:
+  GINKGO_NODES:


### PR DESCRIPTION
During a cleanup process in the `buildpacks-ci` repository, I discovered that the `PHP Buildpack` was running `BRATS` tests using a custom Jammy image. Specifically, we were utilizing the `swigmore/jammy-test-image` with CI configuration specific to the PHP Buildpack on a custom branch. From a maintenance perspective, this approach is not reliable, as it requires anyone making updates to the pipeline to update and rebase the branch to keep the PHP tests working.

This custom image was initially created during a debugging and fixing process, which I collaborated on with @sophiewigmore, to ensure support for cflinuxfs4 integration in the buildpack tests. As a result, we introduced a new image called `cfbuildpacks/test-on-jammy`, built using the Dockerfile found at https://github.com/cloudfoundry/buildpacks-ci/blob/master/dockerfiles/test-on-jammy.Dockerfile. This new image is a lightweight CI solution designed for running tests on the Jammy platform.

This pull request aims to make this change permanent by introducing a new Task that can be reused in the future, utilizing the `cfbuildpacks/test-on-jammy` image.
