### PR TITLE
Update cflinuxfs3-dev dockefiles with the ESM packages to be removed

### DIFF
--- a/dockerfiles/cflinuxfs3-dev.Dockerfile
+++ b/dockerfiles/cflinuxfs3-dev.Dockerfile
@@ -2,12 +2,8 @@ FROM cloudfoundry/cflinuxfs3
 
 # Note: If this list starts to get long, we should consider using an external file to store the list of packages to remove.
 
+# Remove packages that are installed with an ESM version that is not compatible with some compilation processes for dependencies.
 RUN apt update && apt remove -y \
     libonig4 \
     libwebp6 \
-    libruby2.5 \
-    ruby \
-    ruby2.5 \
-    libldap2-dev \
-    libssl-dev \
-    libcurl4-openssl-dev \
+    libsnmp-dev


### PR DESCRIPTION
In #324, I initially made changes to include the removal of some additional ESM packages. However, after thorough debugging, it became evident that only `libsnmp-dev` is necessary to resolve the PHP Compilation errors.
