### PR TITLE
Fix error in PHP Update dependency logic (related to cflinuxfs3-dev)

### DIFF
--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -54,6 +54,9 @@ builds = {}
 version = ''
 
 Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each do |stack_dependency_build|
+  # See github.com/cloudfoundry/buildpacks-ci/pull/300 - we don't want to process the *cflinuxfs3.json files (they are replaced by *cflinuxfs3-dev.json files)
+  next if source_name == 'php' && stack_dependency_build.include?('cflinuxfs3.json')
+
   if !is_null(deprecation_date) && !is_null(deprecation_link) && version_line != 'latest'
     dependency_deprecation_date = {
       'version_line' => version_line.downcase,


### PR DESCRIPTION
When we introduced the `cflinuxfs3-dev` stack in #300, the `tasks/update-buildpack-dependency` task began encountering failures, despite the updates introduced in #303. To address this issue, I made a change to ignore the `cflinuxfs3.json` file in PHP binary-builds, ensuring that older versions are not selected over those specified in `cflinuxfs3-dev.json`.
