### PR TITLE
Move from toolsmith to Shepherd

### DIFF
--- a/pipelines/brats.yml.erb
+++ b/pipelines/brats.yml.erb
@@ -29,10 +29,11 @@ resource_types:
     source:
       repository: cfbuildpacks/cf-space-resource
 
-  - name: cf-pool
-    type: docker-image
+  - name: shepherd
+    type: registry-image
     source:
-      repository: cftoolsmiths/toolsmiths-envs-resource
+      repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
+      tag: v1
 
 resources:
   - name: nightly-trigger
@@ -54,19 +55,29 @@ resources:
       branch: master
       private_key: {{buildpacks-envs-private-key}}
 
-  - name: smith-environments-<%= tas_version %>
-    type: cf-pool
+  - name: shepherd-tas-<%= tas_version %>-environment
+    type: shepherd
     source:
-      api_token: ((toolsmiths-api-token))
-      hostname: environments.toolsmiths.cf-app.com
-      pool_name: us_<%= tas_version.gsub('.', '_') %>
+      url: https://v2.shepherd.run
+      service-account-key: ((shepherd-buildpacks-service-account-key))
+      lease:
+        namespace: buildpacks
+        pool:
+          namespace: official
+          name: airgap-tas-<%= tas_version.gsub('.', '_') %>
+      compatibility-mode: environments-app
 
-  - name: cf-toolsmiths-environment
-    type: cf-pool
+  - name: shepherd-cf-environment
+    type: shepherd
     source:
-      api_token: ((toolsmiths-api-token))
-      hostname: environments.toolsmiths.cf-app.com
-      pool_name: cf-deployment
+      url: https://v2.shepherd.run
+      service-account-key: ((shepherd-buildpacks-service-account-key))
+      lease:
+        namespace: buildpacks
+        pool:
+          namespace: official
+          name: cfd
+      compatibility-mode: environments-app
 
   - name: cf-deployment
     type: git
@@ -96,19 +107,21 @@ jobs:
         - get: nightly-trigger
           trigger: true
       - do:
-        - put: smith-environments-<%= tas_version %>
+        - put: shepherd-tas-<%= tas_version %>-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-tas-<%= tas_version %>-environment
         - task: create-cf-space
           attempts: 5
           file: buildpacks-ci/tasks/create-cf-space-toolsmiths/task.yml
           input_mapping:
-            environment: smith-environments-<%= tas_version %>
+            environment: shepherd-tas-<%= tas_version %>-environment
           params:
             ORG: pivotal
 
         - task: run-brats-cflinuxfs4
-          file: buildpacks-ci/tasks/run-bp-brats/task.yml
+          file: buildpacks-ci/tasks/<%= language.to_s == 'php' ? 'run-bp-brats-jammy' : 'run-bp-brats' %>/task.yml
           attempts: <%= if language == "ruby" then 3 else 1 end %>
           params:
             CF_STACK: cflinuxfs4
@@ -116,18 +129,21 @@ jobs:
             GINKGO_NODES: 6
         ensure:
           in_parallel:
-          - put: smith-environments-<%= tas_version %>
+          - put: shepherd-tas-<%= tas_version %>-environment
             params:
-              action: unclaim
-              env_file: smith-environments-<%= tas_version %>/metadata
+              action: release
+              resource: shepherd-tas-<%= tas_version %>-environment
   - name: brats-<%= language %>-edge
     serial: true
     public: true
     plan:
       - do:
-        - put: cf-toolsmiths-environment
+        - put: shepherd-cf-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-cf-environment
+          timeout: 6h
         - in_parallel:
           - get: buildpacks-ci
           - get: env-repo
@@ -141,7 +157,7 @@ jobs:
           file: buildpacks-ci/tasks/cf/redeploy/task.yml
           input_mapping:
             ci: buildpacks-ci
-            lock: cf-toolsmiths-environment
+            lock: shepherd-cf-environment
           params:
             DEPLOY_WINDOWS_CELL: true
 <% end %>
@@ -156,9 +172,9 @@ jobs:
                 ORG: pivotal
               input_mapping:
                 ci: buildpacks-ci
-                lock: cf-toolsmiths-environment
+                lock: shepherd-cf-environment
             - task: run-brats-<%= stack %>
-              file: buildpacks-ci/tasks/run-bp-brats/task.yml
+              file: buildpacks-ci/tasks/<%= language.to_s == 'php' ? 'run-bp-brats-jammy' : 'run-bp-brats' %>/task.yml
               input_mapping: {cf-space: space}
               params:
                 CF_STACK: <%= stack %>
@@ -166,8 +182,8 @@ jobs:
                 GINKGO_NODES: 6
 <% end %>
         ensure:
-          put: cf-toolsmiths-environment
+          put: shepherd-cf-environment
           params:
-            action: unclaim
-            env_file: cf-toolsmiths-environment/metadata
+            action: release
+            resource: shepherd-cf-environment
 <% end %>

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -9,11 +9,11 @@ resource_types:
     repository: pivotalcf/pivnet-resource
     tag: latest-final
 
-- name: toolsmiths-envs
-  type: docker-image
+- name: shepherd
+  type: registry-image
   source:
-    repository: cftoolsmiths/toolsmiths-envs-resource
-
+    repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
+    tag: v1
 
 resources:
 - name: buildpacks-ci
@@ -41,11 +41,16 @@ resources:
     branch: main
 
 - name: cf-deployment-env
-  type: toolsmiths-envs
+  type: shepherd
   source:
-    api_token: ((toolsmiths-api-token))
-    hostname: environments.toolsmiths.cf-app.com
-    pool_name: cf-deployment
+    url: https://v2.shepherd.run
+    service-account-key: ((shepherd-buildpacks-service-account-key))
+    lease:
+      namespace: buildpacks
+      pool:
+        namespace: official
+        name: cfd
+    compatibility-mode: environments-app
 
 - name: java-pivnet-production
   type: pivnet
@@ -136,7 +141,10 @@ jobs:
     trigger: true
   - put: cf-deployment-env
     params:
-      action: claim
+      action: create
+      duration: 1h
+      resource: cf-deployment-env
+    timeout: 2h
 
 #@ for language in data.values.supported_languages:
 - name: #@ "create-" + language.name + "-buildpack-dev-release"
@@ -146,6 +154,8 @@ jobs:
   - in_parallel:
     - get: buildpacks-ci
     - get: cf-deployment-env
+      params:
+        resource: cf-deployment-env
       trigger: true
       passed: [claim-cf-deployment-env]
     - get: release
@@ -186,6 +196,8 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-deployment
     - get: cf-deployment-env
+      params:
+        resource: cf-deployment-env
       trigger: true
       passed:
 #@ for language in data.values.supported_languages:
@@ -302,6 +314,8 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment-env
+      params:
+        resource: cf-deployment-env
       passed: [deploy]
       trigger: true
 #@ for language in data.values.supported_languages:
@@ -326,12 +340,14 @@ jobs:
   serial: true
   plan:
   - get: cf-deployment-env
+    params:
+      resource: cf-deployment-env
     passed: [cats]
     trigger: true
   - put: cf-deployment-env
     params:
-      action: unclaim
-      env_file: cf-deployment-env/metadata
+      action: release
+      resource: cf-deployment-env
 
 - name: ship-it
   public: true

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -87,10 +87,11 @@ resource_types:
     source:
       repository: cfbuildpacks/cron-resource
 
-  - name: cf-pool
-    type: docker-image
+  - name: shepherd
+    type: registry-image
     source:
-      repository: cftoolsmiths/toolsmiths-envs-resource
+      repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
+      tag: v1
 
   - name: pool
     type: registry-image
@@ -286,20 +287,30 @@ resources: #####################################################################
 
   ## Resource Pools ##
 
-  - name: cf-toolsmiths-environment
-    type: cf-pool
+  - name: shepherd-cf-environment
+    type: shepherd
     source:
-      api_token: ((toolsmiths-api-token))
-      hostname: environments.toolsmiths.cf-app.com
-      pool_name: cf-deployment
+      url: https://v2.shepherd.run
+      service-account-key: ((shepherd-buildpacks-service-account-key))
+      lease:
+        namespace: buildpacks
+        pool:
+          namespace: official
+          name: cfd
+      compatibility-mode: environments-app
 
 <% unless buildpacks[language]['non_lts'] %>
-  - name: smith-environments-<%= pas_version %>
-    type: cf-pool
+  - name: shepherd-pas-<%= pas_version %>-environment
+    type: shepherd
     source:
-      api_token: ((toolsmiths-api-token))
-      hostname: environments.toolsmiths.cf-app.com
-      pool_name: us_<%= pas_version.gsub('.', '_') + "_lts2" %>
+      url: https://v2.shepherd.run
+      service-account-key: ((shepherd-buildpacks-service-account-key))
+      lease:
+        namespace: buildpacks
+        pool:
+          namespace: official
+          name: tas-<%= pas_version.gsub('.', '_') %>
+      compatibility-mode: environments-app
 <% end %>
 
   ## Alerts ##
@@ -619,9 +630,14 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: cf-toolsmiths-environment
+          resource: shepherd-cf-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-cf-environment
+            description: |
+              Running <%= language %>-buildpack specs-edge-integration-develop-<%= stack %> job.
+          timeout: 6h
         - get: buildpacks-ci
         - get: env-repo
         - get: buildpack
@@ -672,10 +688,10 @@ jobs: ##########################################################################
             <% end %>
     on_success:
       put: environment
-      resource: cf-toolsmiths-environment
+      resource: shepherd-cf-environment
       params:
-        action: unclaim
-        env_file: environment/metadata
+        action: release
+        resource: environment
 <% end %>
 
 <% unless buildpacks[language]['skip_brats'] %>
@@ -685,9 +701,14 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: cf-toolsmiths-environment
+          resource: shepherd-cf-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-cf-environment
+            description: |
+              Running <%= language %>-buildpack specs-edge-brats-develop job.
+          timeout: 6h
         - get: buildpacks-ci
         - get: env-repo
         - get: buildpack
@@ -755,10 +776,10 @@ jobs: ##########################################################################
 <% end %>
     on_success:
       put: environment
-      resource: cf-toolsmiths-environment
+      resource: shepherd-cf-environment
       params:
-        action: unclaim
-        env_file: environment/metadata
+        action: release
+        resource: environment
 <% end %>
 
   - name: specs-edge-shared-develop
@@ -795,9 +816,14 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: smith-environments-<%= pas_version %>
+          resource: shepherd-pas-<%= pas_version %>-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-pas-<%= pas_version %>-environment
+            description: |
+              Running <%= language %>-buildpack specs-lts-integration-develop job.
+          timeout: 6h
         - get: buildpacks-ci
         - get: buildpack
           resource: buildpack-develop
@@ -837,10 +863,10 @@ jobs: ##########################################################################
           file: buildpacks-ci/tasks/delete-cf-space/task.yml
     ensure:
       put: environment
-      resource: smith-environments-<%= pas_version %>
+      resource: shepherd-pas-<%= pas_version %>-environment
       params:
-        action: unclaim
-        env_file: environment/metadata
+        action: release
+        resource: environment
 <% unless buildpacks[language]['skip_brats'] %>
   - name: specs-lts-brats-develop
     serial: true
@@ -848,9 +874,14 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: smith-environments-<%= pas_version %>
+          resource: shepherd-pas-<%= pas_version %>-environment
           params:
-            action: claim
+            action: create
+            duration: 6h
+            resource: shepherd-pas-<%= pas_version %>-environment
+            description: |
+              Running <%= language %>-buildpack specs-lts-brats-develop job.
+          timeout: 6h
         - get: buildpacks-ci
         - get: buildpack
           resource: buildpack-develop
@@ -879,10 +910,10 @@ jobs: ##########################################################################
           file: buildpacks-ci/tasks/delete-cf-space/task.yml
     ensure:
       put: environment
-      resource: smith-environments-<%= pas_version %>
+      resource: shepherd-pas-<%= pas_version %>-environment
       params:
-        action: unclaim
-        env_file: environment/metadata
+        action: release
+        resource: environment
 <% end %>
   - name: specs-lts-gcp-develop
     serial: true

--- a/scripts/cf-target
+++ b/scripts/cf-target
@@ -1,76 +1,103 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-env_name=
-gcp=
 
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+lease_id=
 
-function main() {
-  local token
+main() {
+  configure_shepherd
+
   parse_arguments "$@"
 
-  source ~/workspace/bp-envs/scripts/login_credhub_public
-
-  local token
-  token="$(credhub get -n /concourse/main/toolsmiths-api-token -q)"
-
-  if [[ -z "${env_name}" && -z "${gcp}" ]]; then
-    environment_available=$(curl -sS -XPOST "https://environments.toolsmiths.cf-app.com/pooled_gcp_engineering_environments/claim?api_token=$token&pool_name=cf-deployment")
-    if [[ $(echo "$environment_available" | sed 's/[][]//g' | sed 's/\"//g') == "No unclaimed environments available" ]]; then
-      echo "No unclaimed environments available, please try again later or contact #cf-toolsmiths on Slack"
-      exit 1
-    fi
-    env_name=$(echo $environment_available | jq -r .name)
-    get_metadata_file "${token}" "${env_name}"
-    echo "claimed: ${env_name}"
-
-  elif [[ -n "${env_name}" && -z "${gcp}" ]]; then
-    echo "using: ${env_name}"
-
-  elif [[ "${gcp}" -eq 1 ]]; then
-    get_metadata_file_gcp "${token}" "${env_name}"
-    env_name=$(cat /tmp/output/name)
-    rm -rf /tmp/output
-    echo "claimed: ${env_name}"
+  if [[ -z "${lease_id}" ]]; then
+    util::print::title "No lease provided. Claiming a new environment"
+    claim_environment
+  elif [[ -n "${lease_id}" ]]; then
+    util::print::title "Using lease ${lease_id}"
+    get_metadata_file "${lease_id}"
   fi
 
-  login_to_existing_env "${env_name}"
+  login_to_existing_env "${lease_id}"
 }
 
-parse_arguments() {
+function configure_shepherd() {
+  if ! command -v shepherd &> /dev/null; then
+    util::print::error "shepherd CLI is not installed. Please install it from https://gitlab.eng.vmware.com/shepherd/shepherd2/-/blob/main/USERGUIDE.md#1-install-the-shepherd2-cli"
+  fi
+
+  util::print::info "Configuring shepherd CLI"
+
+  shepherd config location https://v2.shepherd.run > /dev/null
+
+  source "${HOME}/workspace/bp-envs/scripts/login_credhub_public"
+
+  local token
+
+  token="$(credhub get -n /concourse/main/shepherd-buildpacks-service-account-key -q)"
+  shepherd login service-account "${token}" > /dev/null
+  if [[ $? -ne 0 ]]; then
+    util::print::error "Failed to login to shepherd, please check your credentials"
+  fi
+
+  shepherd config namespace buildpacks > /dev/null
+  if [[ $? -ne 0 ]]; then
+    util::print::error "Failed to set namespace to buildpacks, please check your credentials"
+  fi
+}
+
+function parse_arguments() {
   local OPTIND
-  while getopts "e:g" opt; do
+  while getopts "l:" opt; do
     case "${opt}" in
-    e)
-      env_name="${OPTARG}"
-      ;;
-    g)
-      gcp=1
+    l)
+      lease_id="${OPTARG}"
       ;;
     *)
-      echo "Usage: $0 [-e <name of environment to log into> || -g <use if running off of the vpn>]"
+      util::print::error "Usage: $0 [-l <lease id from Shepherd>]"
       exit 1
       ;;
     esac
   done
 }
 
-function get_metadata_file() {
-  token=$1
-  env_name=$2
+function claim_environment() {
 
-  echo "getting metadata file for ${env_name}...."
-  curl -s -XGET \
-    "https://environments.toolsmiths.cf-app.com/pooled_gcp_engineering_environments/claim?api_token=$token&environment_name=$env_name" \
-    >"/tmp/$env_name.json"
+  local claimer output env_name lease_id
+  claimer="$(whoami)"
+
+  output=$(shepherd create lease --pool cfd --pool-namespace official --duration 4h --description "Claimed by ${claimer} from Buildpacks team" --json)
+  if [[ $? -ne 0 ]]; then
+    util::print::error "Failed to claim an environment ${output}"
+  fi
+
+  lease_id=$(echo "${output}" | jq -r .id)
+  util::print::success "Claimed: ${lease_id} for 4 hours. If you need more time, please run 'shepherd set-duration lease ${lease_id} --extend-by <duration in seconds>'"
+
+  get_metadata_file "${lease_id}"
+}
+
+function get_metadata_file() {
+  local lease_id="$1"
+
+  util::print::info "Getting metadata file for lease ${lease_id}...."
+
+  output=$(shepherd get lease "${lease_id}" --json)
+  if [[ $? -ne 0 ]]; then
+    util::print::error "Failed to get metadata file for lease ${lease_id} from Shepherd: ${output}"
+  fi
+
+  echo "${output}" | jq -r .output > "/tmp/${lease_id}.json"
 }
 
 function login_to_existing_env() {
-  env_name=$1
-  echo "loggining into ${env_name}...."
+  local lease_id="$1"
+  local env_name
 
-  eval "$(bbl print-env --metadata-file "/tmp/$env_name.json")"
+  env_name="$(jq -r .name "/tmp/${lease_id}.json")"
+  util::print::info "Logging into environment ${env_name} from lease ${lease_id}...."
+
+  eval "$(bbl print-env --metadata-file "/tmp/${lease_id}.json")"
 
   export CF_USERNAME=admin
   export CF_PASSWORD=$(credhub get -n "/bosh-${env_name}/cf/cf_admin_password" -q)
@@ -81,24 +108,42 @@ function login_to_existing_env() {
   cf create-space my-space
   cf target -s my-space
 
-  echo "logged into ${env_name}"
+  util::print::success "Logged into ${env_name}"
 }
 
-function get_metadata_file_gcp() {
-  local token name
-  token=$1
-  name=$2
+function util::print::title() {
+  local blue reset message
+  blue="\033[0;34m"
+  reset="\033[0;39m"
+  message="${1}"
 
-  fly -t buildpacks status || fly -t buildpacks login
+  echo -e "\n${blue}${message}${reset}" >&2
+}
 
-  mkdir -p /tmp/output
+function util::print::info() {
+  local message
+  message="${1}"
 
-  TOOLSMITHS_API_TOKEN="${token}" ENV_NAME="${name}" \
-    fly -t buildpacks execute -c "${PROGDIR}/get-env-gcp/task.yml" \
-    -i script="${PROGDIR}/get-env-gcp" \
-    -o metadata=/tmp/output
+  echo -e "${message}" >&2
+}
 
-  mv /tmp/output/*.json /tmp/
+function util::print::error() {
+  local message red reset
+  message="${1}"
+  red="\033[0;31m"
+  reset="\033[0;39m"
+
+  echo -e "${red}${message}${reset}" >&2
+  exit 1
+}
+
+function util::print::success() {
+  local message green reset
+  message="${1}"
+  green="\033[0;32m"
+  reset="\033[0;39m"
+
+  echo -e "${green}${message}${reset}" >&2
 }
 
 main "$@"

--- a/tasks/cf/create-space/task.sh
+++ b/tasks/cf/create-space/task.sh
@@ -30,9 +30,8 @@ LOGIN
 function cf::authenticate() {
   util::print::info "[task] * authenticating with CF environment"
 
-  local lock name target
-  lock="$(cat "${LOCK_DIR}/name")"
-  name="${lock//[[:digit:]]/}"
+  local name target
+  name="$(jq -r .name "${LOCK_DIR}/metadata")"
   target="api.${name}.${DOMAIN}"
 
   cf api "${target}" --skip-ssl-validation

--- a/tasks/create-cf-space-toolsmiths/run.sh
+++ b/tasks/create-cf-space-toolsmiths/run.sh
@@ -7,11 +7,11 @@ set -x
 OUTPUT=cf-space
 
 set +x
-env_name="$(cat environment/name)"
 
-ops_manager_username="pivotalcf"
-ops_manager_password="$(jq -r .ops_manager.password environment/metadata )"
-ops_manager_url="https://pcf.$env_name.cf-app.com"
+env_name="$(jq -r .name environment/metadata)"
+ops_manager_username="$(jq -r .ops_manager.username environment/metadata)"
+ops_manager_password="$(jq -r .ops_manager.password environment/metadata)"
+ops_manager_url="$(jq -r .ops_manager.url environment/metadata)"
 
 TARGET="api.sys.$env_name.cf-app.com"
 USERNAME="admin"


### PR DESCRIPTION
# Context

This PR is part of the transition from Environments Apps (Toolsmith) to Shepherd. It encompasses necessary changes to support the migration. Additionally, the `cf-target` script, employed for claiming environments during testing, has been modified to align with this new behavior.

Changes already fly-ed.