### PR TITLE
Add PHP 8.3 / Remove PHP 8.1

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -234,10 +234,6 @@ dependencies:
     buildpacks:
       php:
         lines:
-          - line: 8.0.X
-            match: 8.0.\d+
-            deprecation_date: 2023-11-26
-            link: http://php.net/supported-versions.php
           - line: 8.1.X
             match: 8.1.\d+
             deprecation_date: 2024-11-25
@@ -246,10 +242,13 @@ dependencies:
             match: 8.2.\d+
             deprecation_date: 2025-12-08
             link: http://php.net/supported-versions.php
+          - line: 8.3.X
+            match: 8.3.\d+
+            deprecation_date: 2026-11-23
+            link: http://php.net/supported-versions.php
         removal_strategy: keep_latest_released
     source_type: php
     versions_to_keep: 2
-    skip_lines_cflinuxfs4: [ '8.0.X' ]
     mixins:
       'io.buildpacks.stacks.bionic':
         - libargon2-0

--- a/scripts/php-modules/update.rb
+++ b/scripts/php-modules/update.rb
@@ -10,7 +10,7 @@ end
 
 def update_modules(&f)
   cache = {}
-  %w[php8-base-extensions.yml php81-extensions-patch.yml php82-extensions-patch.yml].each do |ext_file|
+  %w[php8-base-extensions.yml php81-extensions-patch.yml php82-extensions-patch.yml php83-extensions-patch.yml].each do |ext_file|
     path = File.expand_path("../../tasks/build-binary-new/#{ext_file}")
 
     puts "==> Processing: #{path}"

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php83-extensions-patch.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php83-extensions-patch.yml
@@ -1,0 +1,16 @@
+---
+extensions:
+  exclusions:
+  - name: yaf
+    version: 3.3.5
+    md5: 128ecf6c84dd71d59c12d826cc51f0c4
+    klass: PeclRecipe
+  additions:
+  - name: oci8
+    version: 3.3.0
+    md5: bbbbb26f1791d1f27ffc05289abee2f3
+    klass: OraclePeclRecipe
+  - name: ioncube
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
+    klass: IonCubeRecipe

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -902,6 +902,8 @@ class Builder
         patch_file = File.join(php_extensions_dir, 'php81-extensions-patch.yml')
       elsif source_input.version.start_with?('8.2.')
         patch_file = File.join(php_extensions_dir, 'php82-extensions-patch.yml')
+      elsif source_input.version.start_with?('8.3.')
+        patch_file = File.join(php_extensions_dir, 'php83-extensions-patch.yml')
       end
 
       php_extensions.patch!(patch_file) if patch_file

--- a/tasks/build-binary-new/php83-extensions-patch.yml
+++ b/tasks/build-binary-new/php83-extensions-patch.yml
@@ -1,0 +1,16 @@
+---
+extensions:
+  exclusions:
+  - name: yaf
+    version: 3.3.5
+    md5: 128ecf6c84dd71d59c12d826cc51f0c4
+    klass: PeclRecipe
+  additions:
+  - name: oci8
+    version: 3.3.0
+    md5: bbbbb26f1791d1f27ffc05289abee2f3
+    klass: OraclePeclRecipe
+  - name: ioncube
+    version: 13.0.2
+    md5: 0526cd3702ef25de119e4724d603d773
+    klass: IonCubeRecipe

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -201,12 +201,12 @@ end
 php_defaults = nil
 if !rebuilt && manifest_name == 'php' && buildpack_name == 'php'
   case resource_version
-  when /^8.0/
-    varname = 'PHP_80_LATEST'
   when /^8.1/
     varname = 'PHP_81_LATEST'
   when /^8.2/
     varname = 'PHP_82_LATEST'
+  when /^8.3/
+    varname = 'PHP_83_LATEST'
   else
     puts "Unexpected version #{resource_version} is not in known version lines."
     exit 1


### PR DESCRIPTION
https://github.com/cloudfoundry/buildpacks-github-config/issues/64
@brayanhenao let me know if these changes look OK. It removes 8.0 and adds 8.3. Since PHP 8.3 extensions are not fully available, for now I have copied 8.2 extensions