### PR TITLE
Update deps ruby and openresty

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -321,9 +321,6 @@ dependencies:
     buildpacks:
       ruby:
         lines:
-          - line: 2.7.X
-            deprecation_date: 2023-03-31
-            link: https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/
           - line: 3.0.X
             deprecation_date: 2024-03-31
             link: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
@@ -333,6 +330,9 @@ dependencies:
           - line: 3.2.X
             deprecation_date: 2026-03-31
             link: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
+          - line: 3.3.X
+            deprecation_date: 2027-03-31
+            link: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
         removal_strategy: keep_latest_released
     versions_to_keep: 2
     #! Older ruby versions aren't compatible with openssl 3 of jammy

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -182,8 +182,8 @@ dependencies:
     buildpacks:
       nginx:
         lines:
-          - line: 1.19.X
           - line: 1.21.X
+          - line: 1.25.X
     versions_to_keep: 2
   nginx-static:
     buildpacks:


### PR DESCRIPTION
- ruby add 3.3.X
also remove useless 2.7.X from the pipeline. It was deprecated from the buildpacks https://github.com/cloudfoundry/ruby-buildpack/pull/773

Fixes https://github.com/cloudfoundry/buildpacks-github-config/issues/66

---

- openresty: s/1.19/1.25

Fixes https://github.com/cloudfoundry/buildpacks-github-config/issues/67