### PR TITLE
task: make sure legacy tags don't affect task

### DIFF
--- a/tasks/get-buildpack-github-release-notes/run.sh
+++ b/tasks/get-buildpack-github-release-notes/run.sh
@@ -71,7 +71,7 @@ do
   else
      break
   fi
-done < <(git tag -l --sort=-version:refname "v*")
+done < <(git tag -l --sort=-version:refname 'v[0-9]*.[0-9]*.[0-9]*')
 
 release_body="$changelog$release_body_suffix"
 popd


### PR DESCRIPTION
It looks like certain buildpacks like python has legacy tags like [v95](https://github.com/cloudfoundry/python-buildpack/releases/tag/v95) that do not have an associated release. Filter them out.

Hopefully should fix [this job](https://buildpacks-private.ci.cf-app.com/teams/core-deps/pipelines/tas/jobs/publish-python-offline-buildpack-release/builds/63)