### PR TITLE
task/stack-release-notes: enable gh token & custom repo

### DIFF
--- a/tasks/generate-rootfs-release-notes/task.yml
+++ b/tasks/generate-rootfs-release-notes/task.yml
@@ -20,5 +20,5 @@ run:
     - "buildpacks-ci/tasks/generate-rootfs-release-notes/run.rb"
 params:
   STACK:
-  GITHUB_USERNAME:
-  GITHUB_PASSWORD:
+  STACK_REPO:
+  GITHUB_ACCESS_TOKEN:


### PR DESCRIPTION
To fix builds like [this](https://buildpacks-private.ci.cf-app.com/teams/core-deps/pipelines/tanzu-cflinuxfs3/jobs/upload-to-github/builds/18)