### PR TITLE
Update buildpacks ci dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,18 +54,13 @@ RUN apt-get -qqy update \
   && apt-get -qqy clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ARG RUBY_INSTALL_VERSION=0.8.1
-RUN wget -O ruby-install-$RUBY_INSTALL_VERSION.tar.gz https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz \
-  && tar -xzvf ruby-install-$RUBY_INSTALL_VERSION.tar.gz \
-  && cd ruby-install-$RUBY_INSTALL_VERSION/ \
-  && make install \
-  && rm -rf ruby-install-$RUBY_INSTALL_VERSION*
-
-RUN apt-get -qqy update \
-  && ruby-install ruby 2.7.0 \
-  && ln -s /opt/rubies/$(ls /opt/rubies | head -1) /opt/rubies/latest \
-  && apt-get -qqy clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt update \
+    && apt install -y software-properties-common \
+    &&  apt-add-repository -y ppa:brightbox/ruby-ng \
+    &&  apt update \
+    &&  apt install -y ruby2.7 ruby2.7-dev \
+    &&  apt-get -qqy clean \
+    &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV GEM_HOME $HOME/.gem
 ENV GEM_PATH $HOME/.gem
@@ -134,8 +129,8 @@ ENV BASH_ENV /etc/profile.d/filter.sh
 # install buildpacks-ci Gemfile
 COPY Gemfile /tmp/Gemfile
 COPY Gemfile.lock /tmp/Gemfile.lock
-RUN /bin/bash -l -c "gem update --no-document --system \
-  && gem install bundler -v 2.0.1 \
+RUN /bin/bash -l -c "gem update --system 3.4.22 --no-document \
+  && gem install bundler -v 2.4.22 \
   && cd /tmp && bundle install && bundle binstub bundler --force"
 
 #install fly-cli

--- a/scripts/check-latest-gem-support.sh
+++ b/scripts/check-latest-gem-support.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Check if Ruby is installed
+if ! command -v ruby &> /dev/null; then
+  echo "Ruby is required to run this script"
+  exit 1
+fi
+
+
+while getopts ":g:v:" opt; do
+  case ${opt} in
+    g )
+      GEM_TO_TEST=$OPTARG
+      ;;
+    v )
+      RUBY_VERSION_TO_MATCH=$OPTARG
+      ;;
+    \? )
+      echo "Usage: $0 -g <gem_name> -v <ruby_version>"
+      exit 1
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$GEM_TO_TEST" ] || [ -z "$RUBY_VERSION_TO_MATCH" ]; then
+  echo "Both -g <gem_name> and -v <ruby_version> are required"
+  exit 1
+fi
+
+# Ruby code to be executed
+ruby_code=$(cat <<EOF
+require 'open-uri'
+require 'json'
+
+GEM_TO_TEST           = "$GEM_TO_TEST"
+RUBY_VERSION_TO_MATCH = "$RUBY_VERSION_TO_MATCH"
+
+API_URL = "https://rubygems.org/api/v1/versions/#{GEM_TO_TEST}.json"
+
+# Load list of all available versions of GEM_TO_TEST
+gem_versions = JSON.parse(open(API_URL).read)
+
+# Process list to find matching Ruby version
+matching_gem = gem_versions.find { |gem|
+  Gem::Dependency.new('', gem['ruby_version']).
+    match?('', RUBY_VERSION_TO_MATCH)
+}
+
+puts "Latest version of #{GEM_TO_TEST} " +
+     "compatible with Ruby #{RUBY_VERSION_TO_MATCH} " +
+     "is #{matching_gem['number']}."
+EOF
+)
+
+# Execute Ruby code
+ruby -e "$ruby_code"


### PR DESCRIPTION
# Context

In previous builds, failures started to occur when building the Docker image. After attempting to debug the problem, I found that the steps to install Ruby in the Dockefile were complex to understand, using the `ruby-install` tool. This can be changed to a slightly more understandable version, using PPA repositories, specifically `ppa:brightbox/ruby-ng`, and installing Ruby 2.7.

Once the Ruby installation process was updated, I identified a problem when executing the `gem update` command as the `--system` flag is specified, which attempts to install the latest version of `rubygems-update`, which is not compatible with Ruby 2.7, only with Ruby 3.

# Solution

After searching for which version of `rubygems-update` to use that is compatible with Ruby 2.7, I found a small script that can be used to find the latest version of a Gem available for a specific Ruby version:

With [this](https://github.com/cloudfoundry/buildpacks-ci/blob/12bf051727cd91bbac5b727bcd14883d9742c12e/scripts/check-latest-gem-support.sh) script, we can define both the appropriate version for `rubygems-update` and for `bundler`.

### rubygems-update

```bash
$ ./scripts/check-latest-gem-support.sh -g rubygems-update -v 2.7.5
Latest version of rubygems-update compatible with Ruby 2.7.5 is 3.4.22.
```

### bundler

```bash
$ ./scripts/check-latest-gem-support.sh -g rubygems-update -v 2.7.5
Latest version of rubygems-update compatible with Ruby 2.7.5 is 2.4.22.
```
