### PR TITLE
Update go version

### DIFF
--- a/.github/workflows/build-buildpacks-ci-image.yml
+++ b/.github/workflows/build-buildpacks-ci-image.yml
@@ -3,7 +3,7 @@ name: Build buildpacks-ci docker image
 on:
   workflow_dispatch: { }
   schedule:
-    - cron: "0 1 * * 1"
+    - cron: "0 1 * * 4"
   push:
     branches: [ master ]
     paths: [ Dockerfile, config/**, build/** , Gemfile, Gemfile.lock ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,10 @@ RUN cd /usr/local \
   && tar xf go.tar.gz \
   && rm go.tar.gz
 
+RUN export GO_VERSION=$(wget -qO- https://golang.org/dl/?mode=json | grep -oP '"version": "\K([^"]+)' | head -n 1) && \
+    wget -q https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz
+
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH


### PR DESCRIPTION
In response to issue #309 and inspired by @arjun024's suggestion, I've implemented a solution to ensure that the Dockerfile installs the most up-to-date version of Go available.

Additionally, recognizing that Go typically releases minor or patch updates on Tuesdays or Wednesdays, we've adjusted our weekly image building schedule from 1 AM Mondays to Thursdays. This change ensures that our builds coincide with potential Go updates, maximizing the likelihood of capturing the latest version during our weekly builds.

In the event that prompt action is needed to patch the Golang version within a week or as soon as possible in the future, we'll establish a trigger and an additional workflow dedicated to continuously monitoring and updating versions.

Release dates to get context on the day:

```
go1.21.1 (released 2023-09-06) - Tuesday
go1.21.2 (released 2023-10-05) - Thursday
go1.21.3 (released 2023-10-10) - Tuesday
go1.21.4 (released 2023-11-07) - Tuesday
go1.21.5 (released 2023-12-05) - Tuesday
go1.21.6 (released 2024-01-09) - Tuesday
go1.21.7 (released 2024-02-06) - Monday
----
go1.20.1 (released 2023-02-14) - Tuesday
go1.20.2 (released 2023-03-07) - Tuesday
go1.20.3 (released 2023-04-04) - Tuesday
go1.20.4 (released 2023-05-02) - Tuesday
go1.20.5 (released 2023-06-06) - Tuesday
go1.20.6 (released 2023-07-11) - Tuesday
go1.20.7 (released 2023-08-01) - Monday
go1.20.8 (released 2023-09-06) - Wednesday
go1.20.9 (released 2023-10-05) - Thursday
go1.20.10 (released 2023-10-10) - Tuesday
go1.20.11 (released 2023-11-07) - Tuesday
go1.20.12 (released 2023-12-05) - Tuesday
go1.20.13 (released 2024-01-09) - Monday
go1.20.14 (released 2024-02-06) - Monday
```