### PR TITLE
Update TAS version from 2.11 to 4 in the Buildpacks tests

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -69,8 +69,8 @@
     'non_lts_pivnet' => true,
   }
 } %>
-<% pas_version = '2.11' %>
-<% pas_pool_name = 'tas-2_11' %>
+<% tas_version =  '4.0' %>
+<% tas_pool_name = 'tas_four' %>
 <% low_nodes_lts = ['ruby', 'python', 'dotnet-core', 'php'] %>
 ---
 resource_types:
@@ -301,7 +301,7 @@ resources: #####################################################################
       compatibility-mode: environments-app
 
 <% unless buildpacks[language]['non_lts'] %>
-  - name: shepherd-pas-<%= pas_version %>-environment
+  - name: shepherd-tas-<%= tas_version %>-environment
     type: shepherd
     source:
       url: https://v2.shepherd.run
@@ -310,7 +310,7 @@ resources: #####################################################################
         namespace: buildpacks
         pool:
           namespace: official
-          name: <%= pas_pool_name %>
+          name: <%= tas_pool_name %>
       compatibility-mode: environments-app
 <% end %>
 
@@ -817,11 +817,11 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: shepherd-pas-<%= pas_version %>-environment
+          resource: shepherd-tas-<%= tas_version %>-environment
           params:
             action: create
             duration: 6h
-            resource: shepherd-pas-<%= pas_version %>-environment
+            resource: shepherd-tas-<%= tas_version %>-environment
             description: |
               Running <%= language %>-buildpack specs-lts-integration-develop job.
           timeout: 6h
@@ -864,7 +864,7 @@ jobs: ##########################################################################
           file: buildpacks-ci/tasks/delete-cf-space/task.yml
     ensure:
       put: environment
-      resource: shepherd-pas-<%= pas_version %>-environment
+      resource: shepherd-tas-<%= tas_version %>-environment
       params:
         action: release
         resource: environment
@@ -875,11 +875,11 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - put: environment
-          resource: shepherd-pas-<%= pas_version %>-environment
+          resource: shepherd-tas-<%= tas_version %>-environment
           params:
             action: create
             duration: 6h
-            resource: shepherd-pas-<%= pas_version %>-environment
+            resource: shepherd-tas-<%= tas_version %>-environment
             description: |
               Running <%= language %>-buildpack specs-lts-brats-develop job.
           timeout: 6h
@@ -911,7 +911,7 @@ jobs: ##########################################################################
           file: buildpacks-ci/tasks/delete-cf-space/task.yml
     ensure:
       put: environment
-      resource: shepherd-pas-<%= pas_version %>-environment
+      resource: shepherd-tas-<%= tas_version %>-environment
       params:
         action: release
         resource: environment


### PR DESCRIPTION
## Context

In issue #313, it was identified that TAS version 2.11 will no longer be supported in April. Although that date has not yet arrived, after some struggles with the Python Buildpack, it discovered that the LTS tests running on 2.11 present several flakes (likely related to the Shepherd environment), as seen in builds [#1301](https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-lts-integration-develop/builds/1301) to [#1310](https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-lts-integration-develop/builds/1310). After making a test change to run them in a TAS 4 environment, they ran [smoothly](https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-lts-integration-develop/builds/1312).

This issue also manifests in Node.js ([CI](https://buildpacks.ci.cf-app.com/teams/main/pipelines/nodejs-buildpack/jobs/specs-lts-integration-develop/builds/1064)), so updating now doesn't cause any problems and helps address potential flakes in 2.11 environments.
