### PR TITLE
Deprecate JRuby 9.3.x

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -131,7 +131,6 @@ dependencies:
     buildpacks:
       ruby:
         lines:
-          - line: 9.3.X
           - line: 9.4.X
     source_type: jruby
     versions_to_keep: 2


### PR DESCRIPTION
Cleanup work. Context: https://github.com/cloudfoundry/ruby-buildpack/pull/889