### PR TITLE
Fix error with release notes

### DIFF
--- a/scripts/generate-release-notes-cf-stacks.rb
+++ b/scripts/generate-release-notes-cf-stacks.rb
@@ -1,0 +1,57 @@
+require 'octokit'
+require 'open-uri'
+require './lib/release-notes-creator'
+
+def generate_release_notes
+  stack_repo = ARGV[0]
+  current_version = ARGV[1]
+  stack = ARGV[3]
+  gh_token = ARGV[2]
+
+  temp_dir = Dir.mktmpdir
+
+  release_notes = File.open('release-notes', 'w')
+
+  Dir.chdir(temp_dir) do
+    if current_version.split('.')[1] == '0'
+      puts "This is the first minor version, no previous version to compare"
+      exit
+    end
+
+    previous_version = current_version.sub(/(\d+)\.(\d+)\.(\d+)/) do |match|
+      major, minor, patch = $1.to_i, $2.to_i, $3.to_i
+      "#{major}.#{minor - 1}.#{patch}"
+    end
+
+    puts "Genreating release notes for repo: #{stack_repo}"
+
+    receipt_file_name = "receipt.#{stack}.x86_64"
+
+    client = Octokit::Client.new(access_token: gh_token)
+
+    old_receipt_encoded_contents = client.contents("#{stack_repo}", path: "#{receipt_file_name}", query: { ref: "#{previous_version}" })
+    old_receipt_contents = Base64.decode64(old_receipt_encoded_contents.content)
+    old_receipt = File.open('old-receipt', 'w')
+    File.write(old_receipt.path, old_receipt_contents)
+
+    new_receipt_encoded_contents = client.contents("#{stack_repo}", path: "#{receipt_file_name}", query: { ref: "#{current_version}" })
+    new_receipt_contents = Base64.decode64(new_receipt_encoded_contents.content)
+    new_receipt = File.open('new-receipt', 'w')
+    File.write(new_receipt.path, new_receipt_contents)
+
+    dummy_cves_yaml_file = File.open('dummy-cves.yaml', 'w')
+    File.write(dummy_cves_yaml_file.path, "---
+- title: 'Test'
+  stack_release: 0.0.0")
+
+    notes = RootfsReleaseNotesCreator.new(dummy_cves_yaml_file.path, old_receipt.path, new_receipt.path).release_notes
+    output = "Release notes #{previous_version} -> #{current_version}: \n\n#{notes}"
+
+    release_notes.write(output)
+    release_notes.close
+  end
+
+  FileUtils.rm_rf(temp_dir)
+end
+
+generate_release_notes

--- a/scripts/generate-release-notes-cf-stacks.sh
+++ b/scripts/generate-release-notes-cf-stacks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+  echo "Docker is required to run this script"
+  exit 1
+fi
+
+while getopts ":r:v:g:" opt; do
+  case ${opt} in
+    r )
+      repo=$OPTARG
+      ;;
+    v )
+      version=$OPTARG
+      ;;
+    g )
+      github_token=$OPTARG
+      ;;
+    \? )
+      echo "Usage: $0 -r <Stack repo in the format org/repo> -v <version of the stack, eg 1.75.0> -g <GitHub token>"
+      exit 1
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$repo" ] || [ -z "$version" ] || [ -z "$github_token" ]; then
+  echo "All -r <Stack repo in the format org/repo> -v <version of the stack, eg 1.75.0> -g <GitHub token> are required"
+  exit 1
+fi
+
+stack=$(echo "$repo" | cut -d'/' -f2 | sed 's/tanzu-//')
+
+# Run the script in a Docker container using the cfbuildpacks/ci image
+docker run --rm -v "$(pwd)":/usr/src/app -w /usr/src/app cfbuildpacks/ci bash -c "bundle exec ruby ./scripts/generate-release-notes-cf-stacks.rb '$repo' '$version' '$github_token' '$stack'"
+
+cat release-notes
+rm release-notes

--- a/tasks/generate-rootfs-release-notes/run.rb
+++ b/tasks/generate-rootfs-release-notes/run.rb
@@ -29,7 +29,7 @@ else
   puts "Using GitHub token to fetch receipt..."
   begin
     client = Octokit::Client.new(access_token: gh_token)
-    encoded_contents = client.contents("#{stack_repo}", path: "#{receipt_file_name}", tag: "#{previous_version}")
+    encoded_contents = client.contents("#{stack_repo}", path: "#{receipt_file_name}", query: { ref: "#{previous_version}" })
     old_receipt_contents = Base64.decode64(encoded_contents.content)
   rescue Octokit::Error => e
     puts "Error fetching receipt: #{e.message}"


### PR DESCRIPTION
Few changes

## Octokit query

After some failures with the Stacks `release-generator` I found that the Octokit query was not getting the correct tags. The parameter `query` must be used to get the corresponding `ref`.


## Release notes generator - Helper script

I added a new Script to generate release notes for Tanzu/CF stacks. This works for released/tagged releases that could have empty receipt notes and someone asks/requires them.

Example usage:

If I want the release notes for the release/tag `1.74.0` in the `cloudfoundry/cflinuxfs4` repo, the script will compute the receipt diffs for `1.73.0 --> 1.74.0` with the command:

```bash
./scripts/generate-release-notes-cf-stacks.sh -r "cloudfoundry/cflinuxfs4" -g "<YOUR-GITHUB-TOKEN" -v "1.75.0"
```
**Note** : This script requires docker, since it will run the code using the `cfbuildpacks/ci` image (same as how CI compute the diffs, without the `cves.yml` from robots)


