### PR TITLE
Tag CI image on push with the date

### DIFF
--- a/.github/workflows/build-buildpacks-ci-image.yml
+++ b/.github/workflows/build-buildpacks-ci-image.yml
@@ -26,8 +26,12 @@ jobs:
           username: ${{ secrets.CF_BUILDPACKS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CF_BUILDPACKS_DOCKERHUB_TOKEN }}
 
+      - name: Get current date
+        id: get-date
+        run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: cfbuildpacks/ci
+          tags: cfbuildpacks/ci:latest, cfbuildpacks/ci:${{ steps.get-date.outputs.date }}

--- a/.github/workflows/build-test-on-jammy-image.yml
+++ b/.github/workflows/build-test-on-jammy-image.yml
@@ -26,10 +26,14 @@ jobs:
           username: ${{ secrets.CF_BUILDPACKS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CF_BUILDPACKS_DOCKERHUB_TOKEN }}
 
+      - name: Get current date
+        id: get-date
+        run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: cfbuildpacks/test-on-jammy
           file: dockerfiles/test-on-jammy.Dockerfile
+          tags: cfbuildpacks/test-on-jammy:latest, cfbuildpacks/test-on-jammy:${{ steps.get-date.outputs.date }}

--- a/dockerfiles/test-on-jammy.Dockerfile
+++ b/dockerfiles/test-on-jammy.Dockerfile
@@ -72,11 +72,9 @@ COPY build/*.sh /etc/profile.d/
 # Ensure that Concourse filtering is on for non-interactive shells
 ENV BASH_ENV /etc/profile.d/filter.sh
 
-RUN cd /usr/local \
-  && curl -L https://go.dev/dl/go1.20.8.linux-amd64.tar.gz -o go.tar.gz \
-  && [ cc97c28d9c252fbf28f91950d830201aa403836cbed702a05932e63f7f0c7bc4 = $(shasum -a 256 go.tar.gz | cut -d' ' -f1) ] \
-  && tar xf go.tar.gz \
-  && rm go.tar.gz
+RUN export GO_VERSION=$(wget -qO- https://golang.org/dl/\?mode\=json | jq -r '.[0].version' | sed 's/go//') && \
+    wget -q https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz
 
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go


### PR DESCRIPTION
# Context

To facilitate the debugging and to have a track of the versions used to build, I added a new tag in `%Y.%m.%d` format so in the future when you need to verify the versions of certain libraries used or installed (For example Go) at a point in time it will be easy to access it because previously the latest tag was overwritten and the history was lost.

Also, I updated the Go version used in the `test-on-jammy.Dockerfile` so it aligns with the normal CI image one.