### PR TITLE
php: yaf module still not building on 8.2 and 8.3

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php82-extensions-patch.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php82-extensions-patch.yml
@@ -1,4 +1,8 @@
 ---
 extensions:
   exclusions:
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
   additions:

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php83-extensions-patch.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php83-extensions-patch.yml
@@ -1,4 +1,8 @@
 ---
 extensions:
   exclusions:
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
   additions:

--- a/tasks/build-binary-new/php82-extensions-patch.yml
+++ b/tasks/build-binary-new/php82-extensions-patch.yml
@@ -1,4 +1,8 @@
 ---
 extensions:
   exclusions:
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
   additions:

--- a/tasks/build-binary-new/php83-extensions-patch.yml
+++ b/tasks/build-binary-new/php83-extensions-patch.yml
@@ -1,4 +1,8 @@
 ---
 extensions:
   exclusions:
+    - name: yaf
+      version: 3.3.5
+      md5: 128ecf6c84dd71d59c12d826cc51f0c4
+      klass: PeclRecipe
   additions:


### PR DESCRIPTION
continutation of #364

See
https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-php-8.2.x/builds/75 and
https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-php-8.3.x/builds/17