### PR TITLE
Moved the repo from brayanhenao/php-releases-information to ci repo

### DIFF
--- a/.github/workflows/get-all-php-releases.yml
+++ b/.github/workflows/get-all-php-releases.yml
@@ -1,0 +1,31 @@
+name: Get PHP Releases
+on:
+  workflow_dispatch: { }
+  schedule:
+    - cron: 0 * * * *
+
+jobs:
+  get-new-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get PHP Versions
+        run: |
+          curl --silent --show-error --fail https://www.php.net/releases/index.php?json --http2 | jq . > "php-releases/releases.json"
+
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Update PHP releases"
+          pathspec: "php-releases/releases.json"
+          committer_name: "Cloud Foundry Buildpacks Team Robot"
+          committer_email: "tanzu-buildpacks.pdl@broadcom.com"
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: master

--- a/.github/workflows/get-specific-php-version-releases.yml
+++ b/.github/workflows/get-specific-php-version-releases.yml
@@ -1,0 +1,41 @@
+name: Get PHP Releases for each version
+on:
+  workflow_dispatch: { }
+  schedule:
+    - cron: 0 * * * *
+  push:
+    branches:
+      - main
+    paths:
+      - releases.json
+
+jobs:
+  get-new-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get PHP Versions
+        run: |
+          versions=($(jq -r 'keys | .[]' releases.json))
+          echo "versions: ${versions[*]}"
+          for version in "${versions[@]}"; do
+            curl --silent --show-error --fail --http2 "https://www.php.net/releases/index.php?json&version=$version&max=1000" |
+              jq . > "php-releases/php-$version.json"
+          done
+
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "PHP Releases for each version"
+          pathspec: "php-releases/php-*.json"
+          committer_name: "Cloud Foundry Buildpacks Team Robot"
+          committer_email: "tanzu-buildpacks.pdl@broadcom.com"
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: master

--- a/php-releases/php-3.json
+++ b/php-releases/php-3.json
@@ -1,0 +1,20 @@
+{
+  "3.0.x (latest)": {
+    "date": "20 Oct 2000",
+    "source": [
+      {
+        "filename": "php-3.0.18.tar.gz",
+        "name": "PHP 3.0.18 Source Code",
+        "md5": "b4b8f7f1151ce66d5f3910a066651133"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-3.0.17-win32.zip",
+        "name": "PHP 3.0.17 Windows binary",
+        "md5": "29029ac1c3c2075dce38bbd804c42f72"
+      }
+    ],
+    "museum": true
+  }
+}

--- a/php-releases/php-4.json
+++ b/php-releases/php-4.json
@@ -1,0 +1,893 @@
+{
+  "4.4.9": {
+    "announcement": {
+      "English": "/releases/4_4_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-4.4.9.tar.bz2",
+        "name": "PHP 4.4.9 (tar.bz2)",
+        "md5": "2e3b2a0e27f10cb84fd00e5ecd7a1880",
+        "date": "07 August 2008"
+      },
+      {
+        "filename": "php-4.4.9.tar.gz",
+        "name": "PHP 4.4.9 (tar.gz)",
+        "md5": "9bcc1aba50be0dfeeea551d018375548",
+        "date": "07 August 2008"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.9-Win32.zip",
+        "name": "PHP 4.4.9 zip package",
+        "md5": "7395068d5489a9f8abf50c6e4b48622f",
+        "date": "07 August 2008"
+      }
+    ],
+    "date": "07 August 2008",
+    "museum": true
+  },
+  "4.4.8": {
+    "announcement": {
+      "English": "/releases/4_4_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-4.4.8.tar.bz2",
+        "name": "PHP 4.4.8 (tar.bz2)",
+        "md5": "ed31e77414e0331e787487b53732dbca",
+        "date": "03 January 2008"
+      },
+      {
+        "filename": "php-4.4.8.tar.gz",
+        "name": "PHP 4.4.8 (tar.gz)",
+        "md5": "8ad5d1ca793d55b24cd82e591248c04e",
+        "date": "03 January 2008"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.8-Win32.zip",
+        "name": "PHP 4.4.8 zip package",
+        "md5": "09ffff4b1a54bbadb8fee6acd85a2c1f",
+        "date": "12 Feb 2008"
+      }
+    ],
+    "date": "03 January 2008",
+    "museum": true
+  },
+  "4.4.7": {
+    "announcement": {
+      "English": "/releases/4_4_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-4.4.7.tar.bz2",
+        "name": "PHP 4.4.7 (tar.bz2)",
+        "md5": "3f21b44d37a57ca3876d3aea713c700d",
+        "date": "03 May 2007"
+      },
+      {
+        "filename": "php-4.4.7.tar.gz",
+        "name": "PHP 4.4.7 (tar.gz)",
+        "md5": "2669d2049822ac14abb263703d24f643",
+        "date": "03 May 2007"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.7-Win32.zip",
+        "name": "PHP 4.4.7 zip package",
+        "md5": "065e867fa3cfa75cba8271dde9b10cee",
+        "date": "04 May 2007",
+        "note": "This package was updated due to faulty Apache2 module shipped with the orginal.<br> (CGI binary plus server API versions for Apache, Apache2 (experimental), ISAPI, NSAPI, Servlet and Pi3Web. MySQL support built-in, many extensions included, packaged as zip)<br>"
+      }
+    ],
+    "date": "03 May 2007",
+    "museum": true
+  },
+  "4.4.6": {
+    "date": "01 Mar 2007",
+    "source": [
+      {
+        "filename": "php-4.4.6.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "5db283824310c87efb18c76b4735c4bd"
+      },
+      {
+        "filename": "php-4.4.6.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "07c607fcf12435f0078d72fe0de4e3c0"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.6-Win32.zip",
+        "name": "Windows binary",
+        "md5": "486764cefb5f7bde39e95c49b2e38635"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_6.php"
+    },
+    "museum": true
+  },
+  "4.4.5": {
+    "date": "14 Feb 2007",
+    "source": [
+      {
+        "filename": "php-4.4.5.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-4.4.5.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.5-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_5.php"
+    },
+    "museum": true
+  },
+  "4.4.4": {
+    "date": "17 Aug 2006",
+    "source": [
+      {
+        "filename": "php-4.4.4.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-4.4.4.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.4-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.4.4-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_4.php"
+    },
+    "museum": true
+  },
+  "4.4.3": {
+    "date": "03 Aug 2006",
+    "source": [
+      {
+        "filename": "php-4.4.3.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-4.4.3.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.3-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.4.3-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_3.php"
+    },
+    "museum": true
+  },
+  "4.4.2": {
+    "date": "13 Jan 2006",
+    "source": [
+      {
+        "filename": "php-4.4.2.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.4.2.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.4.2-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_2.php"
+    },
+    "museum": true
+  },
+  "4.4.1": {
+    "date": "31 Oct 2005",
+    "source": [
+      {
+        "filename": "php-4.4.1.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.4.1.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.4.1-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_1.php"
+    },
+    "museum": true
+  },
+  "4.4.0": {
+    "date": "11 Jul 2005",
+    "source": [
+      {
+        "filename": "php-4.4.0.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.4.0.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.0-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.4.0-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_4_0.php"
+    },
+    "museum": true
+  },
+  "4.3.11": {
+    "date": "31 Mar 2005",
+    "source": [
+      {
+        "filename": "php-4.3.11.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.3.11.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.11-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.11-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_11.php",
+      "French": "/releases/4_3_11_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.10": {
+    "date": "15 Dec 2004",
+    "source": [
+      {
+        "filename": "php-4.3.10.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.3.10.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.10-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.10-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_10.php",
+      "French": "/releases/4_3_10_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.9": {
+    "date": "22 Sep 2004",
+    "source": [
+      {
+        "filename": "php-4.3.9.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.3.9.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.9-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.9-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_9.php",
+      "French": "/releases/4_3_9_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.8": {
+    "date": "13 July 2004",
+    "source": [
+      {
+        "filename": "php-4.3.8.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.8-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.8-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_8.php"
+    },
+    "museum": true
+  },
+  "4.3.7": {
+    "date": "03 June 2004",
+    "source": [
+      {
+        "filename": "php-4.3.7.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.7-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.7-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_7.php",
+      "French": "/releases/4_3_7_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.6": {
+    "date": "15 April 2004",
+    "source": [
+      {
+        "filename": "php-4.3.6.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.6-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.6-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_6.php",
+      "French": "/releases/4_3_6_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.5": {
+    "date": "26 March 2004",
+    "source": [
+      {
+        "filename": "php-4.3.5.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.5-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.5-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_5.php",
+      "French": "/releases/4_3_5_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.4": {
+    "date": "03 November 2003",
+    "source": [
+      {
+        "filename": "php-4.3.4.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.4-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.4-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_4.php",
+      "French": "/releases/4_3_4_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.3": {
+    "date": "25 August 2003",
+    "source": [
+      {
+        "filename": "php-4.3.3.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.3.3.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.3-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_3.php",
+      "French": "/releases/4_3_3_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.2": {
+    "date": "29 May 2003",
+    "source": [
+      {
+        "filename": "php-4.3.2.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.3.2.tar.bz2",
+        "name": "Source (tar.bz2)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.2-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_2.php",
+      "French": "/releases/4_3_2_fr.php"
+    },
+    "museum": true
+  },
+  "4.3.1": {
+    "date": "17 February 2003",
+    "source": [
+      {
+        "filename": "php-4.3.1.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.1-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_1.php"
+    },
+    "museum": true
+  },
+  "4.3.0": {
+    "date": "27 December 2002",
+    "source": [
+      {
+        "filename": "php-4.3.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.3.0-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.3.0-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_3_0.php",
+      "French": "/releases/4_3_0_fr.php"
+    },
+    "museum": true
+  },
+  "4.2.3": {
+    "date": "6 September 2002",
+    "source": [
+      {
+        "filename": "php-4.2.3.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.2.3-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.2.3-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/37"
+    },
+    "museum": true
+  },
+  "4.2.2": {
+    "date": "22 July 2002",
+    "source": [
+      {
+        "filename": "php-4.2.2.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.2.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.2.2-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_2_2.php",
+      "French": "/releases/4_2_2_fr.php"
+    },
+    "museum": true
+  },
+  "4.2.1": {
+    "date": "13 May 2002",
+    "source": [
+      {
+        "filename": "php-4.2.1.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.2.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.2.1-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_2_1.php",
+      "French": "/releases/4_2_1_fr.php"
+    },
+    "museum": true
+  },
+  "4.2.0": {
+    "date": "22 April 2002",
+    "source": [
+      {
+        "filename": "php-4.2.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.2.0-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.2.0-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_2_0.php",
+      "French": "/releases/4_2_0_fr.php"
+    },
+    "museum": true
+  },
+  "4.1.2": {
+    "date": "12 March 2002",
+    "source": [
+      {
+        "filename": "php-4.1.2.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.1.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.1.2-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_1_2_win32.php"
+    },
+    "museum": true
+  },
+  "4.1.1": {
+    "date": "26 Dec 2001",
+    "source": [
+      {
+        "filename": "php-4.1.1.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.1.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.1.1-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_1_1.php"
+    },
+    "museum": true
+  },
+  "4.1.0": {
+    "date": "10 Dec 2001",
+    "source": [
+      {
+        "filename": "php-4.1.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.1.0-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/4_1_0.php",
+      "French": "/releases/4_1_0_fr.php"
+    },
+    "museum": true
+  },
+  "4.0.6": {
+    "date": "23 June 2001",
+    "source": [
+      {
+        "filename": "php-4.0.6.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.6-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "museum": true
+  },
+  "4.0.5": {
+    "date": "30 April 2001",
+    "source": [
+      {
+        "filename": "php-4.0.5.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.5-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "museum": true
+  },
+  "4.0.4": {
+    "date": "19 December 2000",
+    "source": [
+      {
+        "filename": "php-4.0.4.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.0.4pl1.tar.gz",
+        "name": "4.0.4pl1 Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.4-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.0.4-installer.zip",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "php-4.0.4pl1-Win32.zip",
+        "name": "4.0.4pl1 Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/28"
+    },
+    "museum": true
+  },
+  "4.0.3": {
+    "date": "11 October 2000",
+    "source": [
+      {
+        "filename": "php-4.0.3.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.0.3pl1.tar.gz",
+        "name": "4.0.3pl1 Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.3-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.0.3pl1-installer.exe",
+        "name": "4.0.3pl1 Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/26",
+      "English (pl1)": "http://news.php.net/php.announce/27"
+    },
+    "museum": true
+  },
+  "4.0.2": {
+    "date": "29 August 2000",
+    "source": [
+      {
+        "filename": "php-4.0.2.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.2-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/24"
+    },
+    "museum": true
+  },
+  "4.0.1": {
+    "date": "28 June 2000",
+    "source": [
+      {
+        "filename": "php-4.0.1.tar.gz",
+        "name": "Source (tar.gz)"
+      },
+      {
+        "filename": "php-4.0.1pl2.tar.gz",
+        "name": "4.0.1pl2 Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-4.0.1pl1-Win32.zip",
+        "name": "4.0.1pl1 Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/23"
+    },
+    "museum": true
+  },
+  "4.0.0": {
+    "date": "22 May 2000",
+    "source": [
+      {
+        "filename": "php-4.0.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.0.0-Win32.zip",
+        "name": "Windows binary"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/22"
+    },
+    "museum": true
+  }
+}

--- a/php-releases/php-5.json
+++ b/php-releases/php-5.json
@@ -1,0 +1,5054 @@
+{
+  "5.6.40": {
+    "announcement": {
+      "English": "/releases/5_6_40.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.40.tar.bz2",
+        "name": "PHP 5.6.40 (tar.bz2)",
+        "sha256": "ffd025d34623553ab2f7fd8fb21d0c9e6f9fa30dc565ca03a1d7b763023fba00",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-5.6.40.tar.gz",
+        "name": "PHP 5.6.40 (tar.gz)",
+        "sha256": "56fb9878d12fdd921f6a0897e919f4e980d930160e154cbde2cc6d9206a27cac",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-5.6.40.tar.xz",
+        "name": "PHP 5.6.40 (tar.xz)",
+        "sha256": "1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c",
+        "date": "10 Jan 2019"
+      }
+    ],
+    "date": "10 Jan 2019",
+    "museum": false
+  },
+  "5.6.39": {
+    "announcement": {
+      "English": "/releases/5_6_39.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.39.tar.bz2",
+        "name": "PHP 5.6.39 (tar.bz2)",
+        "sha256": "b3db2345f50c010b01fe041b4e0f66c5aa28eb325135136f153e18da01583ad5",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-5.6.39.tar.gz",
+        "name": "PHP 5.6.39 (tar.gz)",
+        "sha256": "127b122b7d6c7f3c211c0ffa554979370c3131196137404a51a391d8e2e9c7bb",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-5.6.39.tar.xz",
+        "name": "PHP 5.6.39 (tar.xz)",
+        "sha256": "8147576001a832ff3d03cb2980caa2d6b584a10624f87ac459fcd3948c6e4a10",
+        "date": "06 Dec 2018"
+      }
+    ],
+    "date": "06 Dec 2018",
+    "museum": false
+  },
+  "5.6.38": {
+    "announcement": {
+      "English": "/releases/5_6_38.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.38.tar.bz2",
+        "name": "PHP 5.6.38 (tar.bz2)",
+        "sha256": "d65b231bbdd63be4439ef5ced965cfd63e62983429dbd4dfcfb49981593ebc03",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-5.6.38.tar.gz",
+        "name": "PHP 5.6.38 (tar.gz)",
+        "sha256": "3b74d46cd79a45cce90c8059e09d8bd0beeb5de562cbb0cb42f96ff8fa665fd4",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-5.6.38.tar.xz",
+        "name": "PHP 5.6.38 (tar.xz)",
+        "sha256": "c2fac47dc6316bd230f0ea91d8a5498af122fb6a3eb43f796c9ea5f59b04aa1e",
+        "date": "13 Sep 2018"
+      }
+    ],
+    "date": "13 Sep 2018",
+    "museum": false
+  },
+  "5.6.37": {
+    "announcement": {
+      "English": "/releases/5_6_37.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.37.tar.bz2",
+        "name": "PHP 5.6.37 (tar.bz2)",
+        "sha256": "886ad63d05d94ea3e54322691aadea0cf1d4bcdb4450b02fe300e5b570788b23",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-5.6.37.tar.gz",
+        "name": "PHP 5.6.37 (tar.gz)",
+        "sha256": "b7ec077f35ef3a8cdd33c29124140b1761111a1429878b4c463bb20d2a31b184",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-5.6.37.tar.xz",
+        "name": "PHP 5.6.37 (tar.xz)",
+        "sha256": "5000d82610f9134aaedef28854ec3591f68dedf26a17b8935727dac2843bd256",
+        "date": "19 Jul 2018"
+      }
+    ],
+    "date": "19 Jul 2018",
+    "museum": false
+  },
+  "5.6.36": {
+    "announcement": {
+      "English": "/releases/5_6_36.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.36.tar.bz2",
+        "name": "PHP 5.6.36 (tar.bz2)",
+        "sha256": "626a0e3f5d8a0e686a2b930f0dd3a0601fe3dcb5e43dd0e8c3fab631e64e172a",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-5.6.36.tar.gz",
+        "name": "PHP 5.6.36 (tar.gz)",
+        "sha256": "06086a8b6a9964ef8009c4d9176b4eeb0c564ea39c1213f015e24f3466d2d69f",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-5.6.36.tar.xz",
+        "name": "PHP 5.6.36 (tar.xz)",
+        "sha256": "18f536bf548e909b4e980379d0c4e56d024b2b1eb1c9768fd169360491f1d6dd",
+        "date": "26 Apr 2018"
+      }
+    ],
+    "date": "26 Apr 2018",
+    "museum": false
+  },
+  "5.6.35": {
+    "announcement": {
+      "English": "/releases/5_6_35.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.35.tar.bz2",
+        "name": "PHP 5.6.35 (tar.bz2)",
+        "sha256": "ee78a7e9ca21d8ea394d037c55effff477a49dbae31c7753c547036f5bd73b92",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-5.6.35.tar.gz",
+        "name": "PHP 5.6.35 (tar.gz)",
+        "sha256": "dd0242304f510d48a5216dd2f5796bcf59e8e18366658259aaf205e1d63abf71",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-5.6.35.tar.xz",
+        "name": "PHP 5.6.35 (tar.xz)",
+        "sha256": "9985cb64cb8224c289effff5b34f670d14f838175f76daea0507d643eec650d2",
+        "date": "29 Mar 2018"
+      }
+    ],
+    "date": "29 Mar 2018",
+    "museum": false
+  },
+  "5.6.34": {
+    "announcement": {
+      "English": "/releases/5_6_34.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.34.tar.bz2",
+        "name": "PHP 5.6.34 (tar.bz2)",
+        "sha256": "e19f499d8cee4b0b0780361ecb6a00c41654772a754803ab9ea866b8d47cf2cd",
+        "date": "01 Mar 2018"
+      },
+      {
+        "filename": "php-5.6.34.tar.gz",
+        "name": "PHP 5.6.34 (tar.gz)",
+        "sha256": "de28251ef6d7eb945eb7b770ff668b9f978d9adad52a8c763f6ee409a96732ea",
+        "date": "01 Mar 2018"
+      },
+      {
+        "filename": "php-5.6.34.tar.xz",
+        "name": "PHP 5.6.34 (tar.xz)",
+        "sha256": "21453be3a045204cd2717543ef42771324f411f40962ecda4fe841930a933128",
+        "date": "01 Mar 2018"
+      }
+    ],
+    "date": "01 Mar 2018",
+    "museum": false
+  },
+  "5.6.33": {
+    "announcement": {
+      "English": "/releases/5_6_33.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.33.tar.bz2",
+        "name": "PHP 5.6.33 (tar.bz2)",
+        "sha256": "07f696a9761dcd839e2045c95c3a4d2ffb52c54417477cca9d30a14975b831cc",
+        "date": "04 Jan 2018"
+      },
+      {
+        "filename": "php-5.6.33.tar.gz",
+        "name": "PHP 5.6.33 (tar.gz)",
+        "sha256": "bedfac81cfaa25961812a1aec458c4109411a14991b43a416343ffb830b8da6a",
+        "date": "04 Jan 2018"
+      },
+      {
+        "filename": "php-5.6.33.tar.xz",
+        "name": "PHP 5.6.33 (tar.xz)",
+        "sha256": "9004995fdf55f111cd9020e8b8aff975df3d8d4191776c601a46988c375f3553",
+        "date": "04 Jan 2018"
+      }
+    ],
+    "date": "04 Jan 2018",
+    "museum": false
+  },
+  "5.6.32": {
+    "announcement": {
+      "English": "/releases/5_6_32.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.32.tar.bz2",
+        "name": "PHP 5.6.32 (tar.bz2)",
+        "sha256": "3ee44e7a5fa42b563652b3ea0d3487bc236fcc9e5ea74b583775cab867abcb51",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-5.6.32.tar.gz",
+        "name": "PHP 5.6.32 (tar.gz)",
+        "sha256": "7bef1ae8cd633df5b9c5964262d276d2dc21acbfcd94022d1e2084d199315df4",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-5.6.32.tar.xz",
+        "name": "PHP 5.6.32 (tar.xz)",
+        "sha256": "8c2b4f721c7475fb9eabda2495209e91ea933082e6f34299d11cba88cd76e64b",
+        "date": "26 Oct 2017"
+      }
+    ],
+    "date": "26 Oct 2017",
+    "museum": false
+  },
+  "5.6.31": {
+    "announcement": {
+      "English": "/releases/5_6_31.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.31.tar.bz2",
+        "name": "PHP 5.6.31 (tar.bz2)",
+        "sha256": "8f397169cb65f0539f3bcb04060f97770d73e19074a37bd2c58b98ebf6ecb10f",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-5.6.31.tar.gz",
+        "name": "PHP 5.6.31 (tar.gz)",
+        "sha256": "6687ed2f09150b2ad6b3780ff89715891f83a9c331e69c90241ef699dec4c43f",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-5.6.31.tar.xz",
+        "name": "PHP 5.6.31 (tar.xz)",
+        "sha256": "c464af61240a9b7729fabe0314cdbdd5a000a4f0c9bd201f89f8628732fe4ae4",
+        "date": "06 Jul 2017"
+      }
+    ],
+    "date": "06 Jul 2017",
+    "museum": false
+  },
+  "5.6.30": {
+    "announcement": {
+      "English": "/releases/5_6_30.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.30.tar.bz2",
+        "name": "PHP 5.6.30 (tar.bz2)",
+        "sha256": "a105c293fa1dbff118b5b0ca74029e6c461f8c78f49b337a2a98be9e32c27906",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-5.6.30.tar.gz",
+        "name": "PHP 5.6.30 (tar.gz)",
+        "sha256": "8bc7d93e4c840df11e3d9855dcad15c1b7134e8acf0cf3b90b932baea2d0bde2",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-5.6.30.tar.xz",
+        "name": "PHP 5.6.30 (tar.xz)",
+        "sha256": "a363185c786432f75e3c7ff956b49c3369c3f6906a6b10459f8d1ddc22f70805",
+        "date": "19 Jan 2017"
+      }
+    ],
+    "date": "19 Jan 2017",
+    "museum": false
+  },
+  "5.6.29": {
+    "announcement": {
+      "English": "/releases/5_6_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.29.tar.bz2",
+        "name": "PHP 5.6.29 (tar.bz2)",
+        "sha256": "499b844c8aa7be064c111692e51a093ba94e54d2d9abb01e70ea76183a1825bb",
+        "date": "08 Dec 2016"
+      },
+      {
+        "filename": "php-5.6.29.tar.gz",
+        "name": "PHP 5.6.29 (tar.gz)",
+        "sha256": "0b1b939129a7286c5a474ac2cf845b979477f26dff36639e04022def9e252574",
+        "date": "08 Dec 2016"
+      },
+      {
+        "filename": "php-5.6.29.tar.xz",
+        "name": "PHP 5.6.29 (tar.xz)",
+        "sha256": "0ff352a433f73e2c82b0d5b283b600402518569bf72a74e247f356dacbf322a7",
+        "date": "08 Dec 2016"
+      }
+    ],
+    "date": "08 Dec 2016",
+    "museum": false
+  },
+  "5.6.28": {
+    "announcement": {
+      "English": "/releases/5_6_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.28.tar.bz2",
+        "name": "PHP 5.6.28 (tar.bz2)",
+        "sha256": "c55ea3f4aad5a0b65631d01c4468930fd981ad208ffcd242acdf731bcb47548f",
+        "date": "10 Nov 2016"
+      },
+      {
+        "filename": "php-5.6.28.tar.gz",
+        "name": "PHP 5.6.28 (tar.gz)",
+        "sha256": "27a47ac15e0868d51181d3909cfe3c63ae9b643a3ab40dc30a75b5b500bce500",
+        "date": "10 Nov 2016"
+      },
+      {
+        "filename": "php-5.6.28.tar.xz",
+        "name": "PHP 5.6.28 (tar.xz)",
+        "sha256": "07187ba2870f89cef334cd2ad6cb801aeec5eaf283da0293a9a6be75d6786d11",
+        "date": "10 Nov 2016"
+      }
+    ],
+    "date": "10 Nov 2016",
+    "museum": false
+  },
+  "5.6.27": {
+    "announcement": {
+      "English": "/releases/5_6_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.27.tar.bz2",
+        "name": "PHP 5.6.27 (tar.bz2)",
+        "sha256": "3b77d3a067b6e9cc7bb282d4d5b0e6eeb0623a828bb0479241e3b030446f2a3c",
+        "date": "13 Oct 2016"
+      },
+      {
+        "filename": "php-5.6.27.tar.gz",
+        "name": "PHP 5.6.27 (tar.gz)",
+        "sha256": "3e6cecec615907587a2b35fa8e7f915f038034dc57530734c2b94d381e664a1a",
+        "date": "13 Oct 2016"
+      },
+      {
+        "filename": "php-5.6.27.tar.xz",
+        "name": "PHP 5.6.27 (tar.xz)",
+        "sha256": "16eb544498339d1d855292826e2e547ab01a31600141094959073e5e10e93ab5",
+        "date": "13 Oct 2016"
+      }
+    ],
+    "date": "13 Oct 2016",
+    "museum": false
+  },
+  "5.6.26": {
+    "announcement": {
+      "English": "/releases/5_6_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.26.tar.bz2",
+        "name": "PHP 5.6.26 (tar.bz2)",
+        "sha256": "d47aab8083a4284b905777e1b45dd7735adc53be827b29f896684750ac8b6236",
+        "date": "15 Sep 2016"
+      },
+      {
+        "filename": "php-5.6.26.tar.gz",
+        "name": "PHP 5.6.26 (tar.gz)",
+        "sha256": "f76b6cc23739d9dabf875aee57d91ae73f15e88ddf78803369b8b4728b19b924",
+        "date": "15 Sep 2016"
+      },
+      {
+        "filename": "php-5.6.26.tar.xz",
+        "name": "PHP 5.6.26 (tar.xz)",
+        "sha256": "203a854f0f243cb2810d1c832bc871ff133eccdf1ff69d32846f93bc1bef58a8",
+        "date": "15 Sep 2016"
+      }
+    ],
+    "date": "15 Sep 2016",
+    "museum": false
+  },
+  "5.6.25": {
+    "announcement": {
+      "English": "/releases/5_6_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.25.tar.bz2",
+        "name": "PHP 5.6.25 (tar.bz2)",
+        "sha256": "58ce6032aced7f3e42ced492bd9820e5b3f2a3cd3ef71429aa92fd7b3eb18dde",
+        "date": "18 Aug 2016"
+      },
+      {
+        "filename": "php-5.6.25.tar.gz",
+        "name": "PHP 5.6.25 (tar.gz)",
+        "sha256": "733f1c811d51c2d4031a0c058dc94d09d03858d781ca2eb2cce78853bc76db58",
+        "date": "18 Aug 2016"
+      },
+      {
+        "filename": "php-5.6.25.tar.xz",
+        "name": "PHP 5.6.25 (tar.xz)",
+        "sha256": "7535cd6e20040ccec4594cc386c6f15c3f2c88f24163294a31068cf7dfe7f644",
+        "date": "18 Aug 2016"
+      }
+    ],
+    "date": "18 Aug 2016",
+    "museum": false
+  },
+  "5.6.24": {
+    "announcement": {
+      "English": "/releases/5_6_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.24.tar.bz2",
+        "name": "PHP 5.6.24 (tar.bz2)",
+        "sha256": "bf23617ec3ed0a125ec8bde2b7bca9d3804b2ff4df8de192890c84dc9fac38c6",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-5.6.24.tar.gz",
+        "name": "PHP 5.6.24 (tar.gz)",
+        "sha256": "5f8b2e4e00360fee6eb1b89447266ae45993265955bd1ea9866270d75cdb6ec1",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-5.6.24.tar.xz",
+        "name": "PHP 5.6.24 (tar.xz)",
+        "sha256": "ed7c38c6dac539ade62e08118258f4dac0c49beca04d8603bee4e0ea6ca8250b",
+        "date": "21 Jul 2016"
+      }
+    ],
+    "date": "21 Jul 2016",
+    "museum": false
+  },
+  "5.5.38": {
+    "announcement": {
+      "English": "/releases/5_5_38.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.38.tar.bz2",
+        "name": "PHP 5.5.38 (tar.bz2)",
+        "sha256": "473c81ebb2e48ca468caee031762266651843d7227c18a824add9b07b9393e38",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-5.5.38.tar.gz",
+        "name": "PHP 5.5.38 (tar.gz)",
+        "sha256": "4f458c9b504269615715a62f182b7c2f89bb8284f484befc221b56a1571b506e",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-5.5.38.tar.xz",
+        "name": "PHP 5.5.38 (tar.xz)",
+        "sha256": "cb527c44b48343c8557fe2446464ff1d4695155a95601083e5d1f175df95580f",
+        "date": "21 Jul 2016"
+      }
+    ],
+    "date": "21 Jul 2016",
+    "museum": false
+  },
+  "5.6.23": {
+    "announcement": {
+      "English": "/releases/5_6_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.23.tar.bz2",
+        "name": "PHP 5.6.23 (tar.bz2)",
+        "sha256": "facd280896d277e6f7084b60839e693d4db68318bfc92085d3dc0251fd3558c7",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-5.6.23.tar.gz",
+        "name": "PHP 5.6.23 (tar.gz)",
+        "sha256": "5f2274a13970887e8c81500c2afe292d51c3524d1a06554b0a87c74ce0a24ffe",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-5.6.23.tar.xz",
+        "name": "PHP 5.6.23 (tar.xz)",
+        "sha256": "39141e9a617af172aedbbacee7a63eb15502850f7cea20d759a9cffa7cfb0a1a",
+        "date": "23 Jun 2016"
+      }
+    ],
+    "date": "23 Jun 2016",
+    "museum": false
+  },
+  "5.5.37": {
+    "announcement": {
+      "English": "/releases/5_5_37.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.37.tar.bz2",
+        "name": "PHP 5.5.37 (tar.bz2)",
+        "sha256": "d2380ebe46caf17f2c4cd055867d00a82e6702dc5f62dc29ce864a5742905d88",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-5.5.37.tar.gz",
+        "name": "PHP 5.5.37 (tar.gz)",
+        "sha256": "7cef04b549fdbe00c26dc785b6ba10439672a1596db518fc46632ecba45f44b9",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-5.5.37.tar.xz",
+        "name": "PHP 5.5.37 (tar.xz)",
+        "sha256": "c322444fdf6d3ba26aa67d67ee32d1e815a877f35831351c83763431a80e3612",
+        "date": "23 Jun 2016"
+      }
+    ],
+    "date": "23 Jun 2016",
+    "museum": false
+  },
+  "5.5.36": {
+    "announcement": {
+      "English": "/releases/5_5_36.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.36.tar.bz2",
+        "name": "PHP 5.5.36 (tar.bz2)",
+        "sha256": "2484edfaa3de606d74f927b55c5206f51b1ae24ea8e428aa9fc15474c7bb71bb",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-5.5.36.tar.gz",
+        "name": "PHP 5.5.36 (tar.gz)",
+        "sha256": "ef829f9a9600a858e2363533b80c4e4773505bdc8ea3692d703fc893f267728a",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-5.5.36.tar.xz",
+        "name": "PHP 5.5.36 (tar.xz)",
+        "sha256": "e1bbe33d6b4da66b15c483131520a9fc505eeb6629fa70c5cfba79590a1d0801",
+        "date": "26 May 2016"
+      }
+    ],
+    "date": "26 May 2016",
+    "museum": false
+  },
+  "5.6.22": {
+    "announcement": {
+      "English": "/releases/5_6_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.22.tar.bz2",
+        "name": "PHP 5.6.22 (tar.bz2)",
+        "sha256": "90da8a80cc52fa699cf2bfa4c6fa737c772df7c92b81ef483460aa3b1e9f88c6",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-5.6.22.tar.gz",
+        "name": "PHP 5.6.22 (tar.gz)",
+        "sha256": "4ce0f58c3842332c4e3bb2ec1c936c6817294273abaa37ea0ef7ca2a68cf9b21",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-5.6.22.tar.xz",
+        "name": "PHP 5.6.22 (tar.xz)",
+        "sha256": "c96980d7de1d66c821a4ee5809df0076f925b2fe0b8c362d234d92f2f0a178e2",
+        "date": "26 May 2016"
+      }
+    ],
+    "date": "26 May 2016",
+    "museum": false
+  },
+  "5.6.21": {
+    "announcement": {
+      "English": "/releases/5_6_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.21.tar.bz2",
+        "name": "PHP 5.6.21 (tar.bz2)",
+        "sha256": "b4ed7ab574b689fd6d6494fde954826c06efc85c505e017b8d776c7c7f479590",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-5.6.21.tar.gz",
+        "name": "PHP 5.6.21 (tar.gz)",
+        "sha256": "5997668c1f6f2d86a59cf75cc86b4a94687884614dec481fad7e13a76b70fcd5",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-5.6.21.tar.xz",
+        "name": "PHP 5.6.21 (tar.xz)",
+        "sha256": "566ff1a486cb0485ed477a91ea292423f77a58671270ff73b74e67e3ce7084f9",
+        "date": "28 Apr 2016"
+      }
+    ],
+    "date": "28 Apr 2016",
+    "museum": false
+  },
+  "5.5.35": {
+    "announcement": {
+      "English": "/releases/5_5_35.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.35.tar.bz2",
+        "name": "PHP 5.5.35 (tar.bz2)",
+        "sha256": "2d648dd648e820fd64693ce72f9bf07064d147220e594e39fb9f6310238258d7",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-5.5.35.tar.gz",
+        "name": "PHP 5.5.35 (tar.gz)",
+        "sha256": "21e10a49c62ab34a7edc976af686a952e70142f19135ca8da67758e1c8c3df30",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-5.5.35.tar.xz",
+        "name": "PHP 5.5.35 (tar.xz)",
+        "sha256": "9bef96634af853960be085690b2f4cea5850b749ea950942769b22b1a9f24873",
+        "date": "28 Apr 2016"
+      }
+    ],
+    "date": "31 Mar 2016",
+    "museum": false
+  },
+  "5.6.20": {
+    "announcement": {
+      "English": "/releases/5_6_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.20.tar.bz2",
+        "name": "PHP 5.6.20 (tar.bz2)",
+        "sha256": "5ac7bf7caec7a79b18cf458e786fd1609ad2da771224b80bc15cc6f01b22bf1f",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-5.6.20.tar.gz",
+        "name": "PHP 5.6.20 (tar.gz)",
+        "sha256": "9a7ec6e1080ee93dcbe7df3e49ea1c3c3da5fc2258aff763f39ab3786baf8d56",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-5.6.20.tar.xz",
+        "name": "PHP 5.6.20 (tar.xz)",
+        "sha256": "2b87d40213361112af49157a435e0d4cdfd334c9b7c731c8b844932b1f444e7a",
+        "date": "31 Mar 2016"
+      }
+    ],
+    "date": "31 Mar 2016",
+    "museum": false
+  },
+  "5.5.34": {
+    "announcement": {
+      "English": "/releases/5_5_34.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.34.tar.bz2",
+        "name": "PHP 5.5.34 (tar.bz2)",
+        "sha256": "af88884416a92619de842ad0fd23f7f7e8140efb0b9194f98a38a78781e5851c",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-5.5.34.tar.gz",
+        "name": "PHP 5.5.34 (tar.gz)",
+        "sha256": "0e573b406441294b233e35e1f2e12d7896d68457e3e10bf6e1f4825e75271cca",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-5.5.34.tar.xz",
+        "name": "PHP 5.5.34 (tar.xz)",
+        "sha256": "6989a4f9900e6ddec7248790449bbb4aa55728730bff4973acb49d236c9e9e2a",
+        "date": "31 Mar 2016"
+      }
+    ],
+    "date": "31 Mar 2016",
+    "museum": false
+  },
+  "5.6.19": {
+    "announcement": {
+      "English": "/releases/5_6_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.19.tar.bz2",
+        "name": "PHP 5.6.19 (tar.bz2)",
+        "sha256": "2a24a3f84971680ac0a4c71050067de4f76ee235aa4a041fae21bfa69975c168",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-5.6.19.tar.gz",
+        "name": "PHP 5.6.19 (tar.gz)",
+        "sha256": "fce49cddac9337f0c83afbafac5acfb82ba9f876a5a880c88240feac8c9b7a22",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-5.6.19.tar.xz",
+        "name": "PHP 5.6.19 (tar.xz)",
+        "sha256": "bb32337f93a00b71789f116bddafa8848139120e7fb6f4f98a84f52dbcb8329f",
+        "date": "03 Mar 2016"
+      }
+    ],
+    "date": "03 Mar 2016",
+    "museum": false
+  },
+  "5.5.33": {
+    "announcement": {
+      "English": "/releases/5_5_33.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.33.tar.bz2",
+        "name": "PHP 5.5.33 (tar.bz2)",
+        "sha256": "c490b1ed4df596b48eb68f630d89ca512945e2650840e7dace1119cc7e600aa9",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-5.5.33.tar.gz",
+        "name": "PHP 5.5.33 (tar.gz)",
+        "sha256": "d2747bcf2cc94f652ac216f522904863a22042c66fabcf82ad7449d261d7a45b",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-5.5.33.tar.xz",
+        "name": "PHP 5.5.33 (tar.xz)",
+        "sha256": "b91dbd3c53f9895e8f7b29e5fed25a64dd3a76b454f6ef7265e73c96b4303f30",
+        "date": "03 Mar 2016"
+      }
+    ],
+    "date": "03 Mar 2016",
+    "museum": false
+  },
+  "5.6.18": {
+    "announcement": {
+      "English": "/releases/5_6_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.18.tar.bz2",
+        "name": "PHP 5.6.18 (tar.bz2)",
+        "sha256": "c3cd4a29a9562309d36e2b128407d6eaa5c7dde590d2b1a464457383e517f4ed",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-5.6.18.tar.gz",
+        "name": "PHP 5.6.18 (tar.gz)",
+        "sha256": "76da4150dc2da86b7b63b1aad3c20d1d11964796251ac0dd4d26d0a3f5045015",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-5.6.18.tar.xz",
+        "name": "PHP 5.6.18 (tar.xz)",
+        "sha256": "54dd9106c3469bc7028644d72ac140af00655420bbaaf4a742a64e9ed02ec1b0",
+        "date": "04 Feb 2016"
+      }
+    ],
+    "date": "04 Feb 2016",
+    "museum": false
+  },
+  "5.5.32": {
+    "announcement": {
+      "English": "/releases/5_5_32.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.32.tar.bz2",
+        "name": "PHP 5.5.32 (tar.bz2)",
+        "sha256": "b0f2c108db8e05db9f6366aaba9a754fd0ee31f3f86ee889561b608dfd6e92ee",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-5.5.32.tar.gz",
+        "name": "PHP 5.5.32 (tar.gz)",
+        "sha256": "419aa62a68a640192799928a29e5cd4cd5b965458223bea2b3209a68c3e95989",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-5.5.32.tar.xz",
+        "name": "PHP 5.5.32 (tar.xz)",
+        "sha256": "02f569dcf5bd57dd5e390ddcab8609e3957a698e2db0b793cf2c11a7e33743c9",
+        "date": "04 Feb 2016"
+      }
+    ],
+    "date": "04 Feb 2016",
+    "museum": false
+  },
+  "5.6.17": {
+    "announcement": {
+      "English": "/releases/5_6_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.17.tar.bz2",
+        "name": "PHP 5.6.17 (tar.bz2)",
+        "sha256": "77b45f56a1e63e75bb22b42cfb8b438ec4083c59ce774b4d7c1685544b7add3b",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-5.6.17.tar.gz",
+        "name": "PHP 5.6.17 (tar.gz)",
+        "sha256": "f5036535651e919415f4b6589391c95e4ff48f2d391818251c45da216791aac8",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-5.6.17.tar.xz",
+        "name": "PHP 5.6.17 (tar.xz)",
+        "sha256": "ea9d5749380c7c7171e131616466deacd7cb124b5010eafc34e551b0a7b0fb2c",
+        "date": "07 Jan 2016"
+      }
+    ],
+    "date": "07 Jan 2016",
+    "museum": false
+  },
+  "5.5.31": {
+    "announcement": {
+      "English": "/releases/5_5_31.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.31.tar.bz2",
+        "name": "PHP 5.5.31 (tar.bz2)",
+        "sha256": "fb4a382b9a9dceb749b7ef047d8251320bc8d371c843714e5b4f4b70d61ba277",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-5.5.31.tar.gz",
+        "name": "PHP 5.5.31 (tar.gz)",
+        "sha256": "59a4417029ba5497d17ee02b65f419129ecf9ca8a1d864e0bccd5a3d4407a597",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-5.5.31.tar.xz",
+        "name": "PHP 5.5.31 (tar.xz)",
+        "sha256": "a9ac5b94fcc3811b661a090dddd716f81e43947240b35e6a0123e609a135ac54",
+        "date": "07 Jan 2016"
+      }
+    ],
+    "date": "07 Jan 2016",
+    "museum": false
+  },
+  "5.6.16": {
+    "announcement": {
+      "English": "/releases/5_6_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.16.tar.bz2",
+        "name": "PHP 5.6.16 (tar.bz2)",
+        "sha256": "4fe6f40964c1bfaba05fc144ba20a2cdad33e11685f4f101ea5a48b98bbcd2ae",
+        "date": "26 Nov 2015"
+      },
+      {
+        "filename": "php-5.6.16.tar.gz",
+        "name": "PHP 5.6.16 (tar.gz)",
+        "sha256": "b6618df6b11a275fa28596f1775727679f8492e100f3bd488d8a8bfbfc19349f",
+        "date": "26 Nov 2015"
+      },
+      {
+        "filename": "php-5.6.16.tar.xz",
+        "name": "PHP 5.6.16 (tar.xz)",
+        "sha256": "8ef43271d9bd8cc8f8d407d3ba569de9fa14a28985ae97c76085bb50d597de98",
+        "date": "26 Nov 2015"
+      }
+    ],
+    "date": "26 Nov 2015",
+    "museum": false
+  },
+  "5.5.30": {
+    "announcement": {
+      "English": "/releases/5_5_30.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.30.tar.bz2",
+        "name": "PHP 5.5.30 (tar.bz2)",
+        "sha256": "e7332a713cecdd1cb44a1b1336739885c9789f633f0f51236b25e48ab03c3b29",
+        "date": "01 Oct 2015"
+      },
+      {
+        "filename": "php-5.5.30.tar.gz",
+        "name": "PHP 5.5.30 (tar.gz)",
+        "sha256": "8ad57f4317391354e66c83d26752f67515b2e923277eb97b2b420dfeff3c1007",
+        "date": "01 Oct 2015"
+      },
+      {
+        "filename": "php-5.5.30.tar.xz",
+        "name": "PHP 5.5.30 (tar.xz)",
+        "sha256": "d00dc06fa5e0f3de048fb0cf940b3cc59b43b3f8cad825d4fffb35503cf2e8f2",
+        "date": "01 Oct 2015"
+      }
+    ],
+    "date": "01 Oct 2015",
+    "museum": false
+  },
+  "5.6.15": {
+    "announcement": {
+      "English": "/releases/5_6_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.15.tar.bz2",
+        "name": "PHP 5.6.15 (tar.bz2)",
+        "sha256": "11a0645c4d4b749e256da1e0d6df89dd886b5b06b83c914d942653661dbd1c38",
+        "date": "29 Oct 2015"
+      },
+      {
+        "filename": "php-5.6.15.tar.gz",
+        "name": "PHP 5.6.15 (tar.gz)",
+        "sha256": "bb2d4c226a4897b7c3659c2538a87aef7ec104f58f5ae930a263dd77fb8ebc40",
+        "date": "29 Oct 2015"
+      },
+      {
+        "filename": "php-5.6.15.tar.xz",
+        "name": "PHP 5.6.15 (tar.xz)",
+        "sha256": "cf52e2e621e60997269663fa4bc06253191fa2a41dc9b08c8c911435b3ebcca9",
+        "date": "29 Oct 2015"
+      }
+    ],
+    "date": "29 Oct 2015",
+    "museum": false
+  },
+  "5.6.14": {
+    "announcement": {
+      "English": "/releases/5_6_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.14.tar.bz2",
+        "name": "PHP 5.6.14 (tar.bz2)",
+        "sha256": "36f295f11641c1839a5df00e693f685fd134c65e8a1d46e8ee0abae8662b2eb0",
+        "date": "01 Oct 2015"
+      },
+      {
+        "filename": "php-5.6.14.tar.gz",
+        "name": "PHP 5.6.14 (tar.gz)",
+        "sha256": "29baf7ffca644f7f8e86028c40275b9e460342bdf9562d45f8f0498899cb738d",
+        "date": "01 Oct 2015"
+      },
+      {
+        "filename": "php-5.6.14.tar.xz",
+        "name": "PHP 5.6.14 (tar.xz)",
+        "sha256": "c8edf6b05fd8a69ebd88d90c5c0975ee168502204622ad5cfcd550bc222632d9",
+        "date": "01 Oct 2015"
+      }
+    ],
+    "date": "01 Oct 2015",
+    "museum": false
+  },
+  "5.6.13": {
+    "announcement": {
+      "English": "/releases/5_6_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.13.tar.bz2",
+        "name": "PHP 5.6.13 (tar.bz2)",
+        "sha256": "6358837c9cbab41b91ede59dbf0670ae0fb925a1369ecbc1a44a27212420f893",
+        "date": "03 Sep 2015"
+      },
+      {
+        "filename": "php-5.6.13.tar.gz",
+        "name": "PHP 5.6.13 (tar.gz)",
+        "sha256": "92acc6c067f5e015a6881b4119eafec10eca11722e810f2c2083f72e17119bcf",
+        "date": "03 Sep 2015"
+      },
+      {
+        "filename": "php-5.6.13.tar.xz",
+        "name": "PHP 5.6.13 (tar.xz)",
+        "sha256": "c1f0837df20cd3bed149033924770deca3e7e2d18e2e7e81395096576f153fdc",
+        "date": "03 Sep 2015"
+      }
+    ],
+    "date": "03 Sep 2015",
+    "museum": false
+  },
+  "5.5.29": {
+    "announcement": {
+      "English": "/releases/5_5_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.29.tar.bz2",
+        "name": "PHP 5.5.29 (tar.bz2)",
+        "sha256": "fbcee579ecc77cad6960a541116aee669cf145c2cd9a54bf60503a870843b946",
+        "date": "03 Sep 2015"
+      },
+      {
+        "filename": "php-5.5.29.tar.gz",
+        "name": "PHP 5.5.29 (tar.gz)",
+        "sha256": "c25a4c4eae558cc9899d2994813dd272eafff9466926f30821a83edaafe620a9",
+        "date": "03 Sep 2015"
+      },
+      {
+        "filename": "php-5.5.29.tar.xz",
+        "name": "PHP 5.5.29 (tar.xz)",
+        "sha256": "22c72d1b88c8d9a8ab9ca565e9ca5844287c006134098805d9a373a862bbbcad",
+        "date": "03 Sep 2015"
+      }
+    ],
+    "date": "03 Sep 2015",
+    "museum": false
+  },
+  "5.5.28": {
+    "announcement": {
+      "English": "/releases/5_5_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.28.tar.bz2",
+        "name": "PHP 5.5.28 (tar.bz2)",
+        "sha256": "197d2c572e030c177e53d3763d59ac6d363d7c78dc22e6cc1e2ac65573d9c2f3",
+        "date": "06 Aug 2015"
+      },
+      {
+        "filename": "php-5.5.28.tar.gz",
+        "name": "PHP 5.5.28 (tar.gz)",
+        "sha256": "6084f25a39ab2f79ade46bf0258a1cd6c9bbb09a106b40dd996dbdf8cd3b08f2",
+        "date": "06 Aug 2015"
+      },
+      {
+        "filename": "php-5.5.28.tar.xz",
+        "name": "PHP 5.5.28 (tar.xz)",
+        "sha256": "d060455c804c622cda9f3f5f084b10c6ceba73ee76c1720897e17137a0f75ecd",
+        "date": "06 Aug 2015"
+      }
+    ],
+    "date": "06 Aug 2015",
+    "museum": false
+  },
+  "5.6.12": {
+    "announcement": {
+      "English": "/releases/5_6_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.12.tar.bz2",
+        "name": "PHP 5.6.12 (tar.bz2)",
+        "sha256": "6f27104272af7b2a996f85e4100fac627630fbdaf39d7bd263f16cf529c8853a",
+        "date": "06 Aug 2015"
+      },
+      {
+        "filename": "php-5.6.12.tar.gz",
+        "name": "PHP 5.6.12 (tar.gz)",
+        "sha256": "7799b42606c1770d1ad90bfc7521d2b6c294c4c27dcf1a206dee562533b4f984",
+        "date": "06 Aug 2015"
+      },
+      {
+        "filename": "php-5.6.12.tar.xz",
+        "name": "PHP 5.6.12 (tar.xz)",
+        "sha256": "f8a8446866c0dc3f33319aa196ce87b64d71cab3dd96e39c8816adccc7e8ef33",
+        "date": "06 Aug 2015"
+      }
+    ],
+    "date": "06 Aug 2015",
+    "museum": false
+  },
+  "5.6.11": {
+    "announcement": {
+      "English": "/releases/5_6_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.11.tar.bz2",
+        "name": "PHP 5.6.11 (tar.bz2)",
+        "sha256": "bd6b260816764c267244749ead07482120dbf8d1920ebbbb0dcb2aa411033866",
+        "date": "10 Jul 2015"
+      },
+      {
+        "filename": "php-5.6.11.tar.gz",
+        "name": "PHP 5.6.11 (tar.gz)",
+        "sha256": "85916b46c0d1f2a5315c84fb2773293f4084c3676ba4ed420d0432cbb60ff9d8",
+        "date": "10 Jul 2015"
+      },
+      {
+        "filename": "php-5.6.11.tar.xz",
+        "name": "PHP 5.6.11 (tar.xz)",
+        "sha256": "3f97dbb1c646b90e1ef638defabe429ef036f903b5baa1c34769d3de4fe62bd4",
+        "date": "10 Jul 2015"
+      }
+    ],
+    "date": "10 Jul 2015",
+    "museum": false
+  },
+  "5.5.27": {
+    "announcement": {
+      "English": "/releases/5_5_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.27.tar.bz2",
+        "name": "PHP 5.5.27 (tar.bz2)",
+        "sha256": "c4b4c6a534c0ca67a9ae39bec4f51e52d13e820135dd016eae230e15337e1f70",
+        "date": "09 Jul 2015"
+      },
+      {
+        "filename": "php-5.5.27.tar.gz",
+        "name": "PHP 5.5.27 (tar.gz)",
+        "sha256": "57cc716ebb37a62654c154582e48a282055b08ce91995c79b0be41b9940237f0",
+        "date": "09 Jul 2015"
+      },
+      {
+        "filename": "php-5.5.27.tar.xz",
+        "name": "PHP 5.5.27 (tar.xz)",
+        "sha256": "7ee398058067a7d8184e402fcdccb25003852cb8dc94eefa3cda051a3e47fdd8",
+        "date": "09 Jul 2015"
+      }
+    ],
+    "date": "09 Jul 2015",
+    "museum": false
+  },
+  "5.6.10": {
+    "announcement": {
+      "English": "/releases/5_6_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.10.tar.bz2",
+        "name": "PHP 5.6.10 (tar.bz2)",
+        "sha256": "0a579c81c724ea41815eee0caa8ea7d8eeb302458519d8cc4fc5b055577c8c45",
+        "date": "11 Jun 2015"
+      },
+      {
+        "filename": "php-5.6.10.tar.gz",
+        "name": "PHP 5.6.10 (tar.gz)",
+        "sha256": "7759d6e178be524085e1482921748c14d11cbd0a133ba8aabb96c391ce7ed3fc",
+        "date": "11 Jun 2015"
+      },
+      {
+        "filename": "php-5.6.10.tar.xz",
+        "name": "PHP 5.6.10 (tar.xz)",
+        "sha256": "1af720c955b0a57aa47606e928616e84c78868aff2a5f269c70601a77d6da8c1",
+        "date": "11 Jun 2015"
+      }
+    ],
+    "date": "11 Jun 2015",
+    "museum": false
+  },
+  "5.5.26": {
+    "announcement": {
+      "English": "/releases/5_5_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.26.tar.bz2",
+        "name": "PHP 5.5.26 (tar.bz2)",
+        "sha256": "816afffdb03ff4c542bc172a2f77f9c69b817df82d60cce05c1b4f578c2c926e",
+        "date": "11 Jun 2015"
+      },
+      {
+        "filename": "php-5.5.26.tar.gz",
+        "name": "PHP 5.5.26 (tar.gz)",
+        "sha256": "bee980d433bab99d07ee2bf6f2dcb87d746e49d57adec7d0ce7edb39306695ec",
+        "date": "11 Jun 2015"
+      },
+      {
+        "filename": "php-5.5.26.tar.xz",
+        "name": "PHP 5.5.26 (tar.xz)",
+        "sha256": "97672c41cf2f95628dbffb63648147b43b23ea41b99ad22ccf5f4fe9b6e91b51",
+        "date": "11 Jun 2015"
+      }
+    ],
+    "date": "11 Jun 2015",
+    "museum": false
+  },
+  "5.6.9": {
+    "announcement": {
+      "English": "/releases/5_6_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.9.tar.bz2",
+        "name": "PHP 5.6.9 (tar.bz2)",
+        "sha256": "19d3b87b7b8bba3be24cf6d757d16b723a98881c3af8d15469fd25501e9abcb9",
+        "date": "14 May 2015"
+      },
+      {
+        "filename": "php-5.6.9.tar.gz",
+        "name": "PHP 5.6.9 (tar.gz)",
+        "sha256": "49527ba66357fe65bcd463dfb8dcff1b8879419f88b3c334f50696a2aceacb87",
+        "date": "14 May 2015"
+      },
+      {
+        "filename": "php-5.6.9.tar.xz",
+        "name": "PHP 5.6.9 (tar.xz)",
+        "sha256": "1fac497b596f5e4e87d87a7ca90f8725e39a8ca3f9d7adb500fa83c4bb70a73f",
+        "date": "14 May 2015"
+      }
+    ],
+    "date": "14 May 2015",
+    "museum": false
+  },
+  "5.5.25": {
+    "announcement": {
+      "English": "/releases/5_5_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.25.tar.bz2",
+        "name": "PHP 5.5.25 (tar.bz2)",
+        "sha256": "68df37e725ddd05675c0df906041038127938ecc52113a54d10e1e4029262c63",
+        "date": "14 May 2015"
+      },
+      {
+        "filename": "php-5.5.25.tar.gz",
+        "name": "PHP 5.5.25 (tar.gz)",
+        "sha256": "c9397f60bff139e0df441c5e2766108c5bc7ad690de136eb9f5b2f9bbf771240",
+        "date": "14 May 2015"
+      },
+      {
+        "filename": "php-5.5.25.tar.xz",
+        "name": "PHP 5.5.25 (tar.xz)",
+        "sha256": "ac10015dddfc103b58ccc949504bd50f0d79d0abe74a0cc7842251af06ce8b07",
+        "date": "14 May 2015"
+      }
+    ],
+    "date": "14 May 2015",
+    "museum": false
+  },
+  "5.6.8": {
+    "announcement": {
+      "English": "/releases/5_6_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.8.tar.bz2",
+        "name": "PHP 5.6.8 (tar.bz2)",
+        "sha256": "0af0045745d61eeb74a3ea744529a2481b27cb689da720e6c0250675043724e4",
+        "date": "16 Apr 2015"
+      },
+      {
+        "filename": "php-5.6.8.tar.gz",
+        "name": "PHP 5.6.8 (tar.gz)",
+        "sha256": "c5b1c75c5671c239473eb611129f33ac432a55a1c341990b70009a2aa3b8dbc3",
+        "date": "16 Apr 2015"
+      },
+      {
+        "filename": "php-5.6.8.tar.xz",
+        "name": "PHP 5.6.8 (tar.xz)",
+        "sha256": "4c417387b88e100ca306adeda8051eb9fad93dae8da983f962dabf91a14b2b7b",
+        "date": "16 Apr 2015"
+      }
+    ],
+    "date": "16 Apr 2015",
+    "museum": false
+  },
+  "5.5.24": {
+    "announcement": {
+      "English": "/releases/5_5_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.24.tar.bz2",
+        "name": "PHP 5.5.24 (tar.bz2)",
+        "sha256": "801b5cf2e0c01b07314d4ac3c8a7c28d524bdd8263ebdd0e33a99008251316a2",
+        "date": "16 Apr 2015"
+      },
+      {
+        "filename": "php-5.5.24.tar.gz",
+        "name": "PHP 5.5.24 (tar.gz)",
+        "sha256": "43e6b83fe8151f8d2062ca4da915312fc92e47789801049231c705a8b29b05bc",
+        "date": "16 Apr 2015"
+      },
+      {
+        "filename": "php-5.5.24.tar.xz",
+        "name": "PHP 5.5.24 (tar.xz)",
+        "sha256": "ffb6235a25043cab71e6445cfc9e8bf16ae80a2835f0373cdd948fcc31eafe57",
+        "date": "16 Apr 2015"
+      }
+    ],
+    "date": "16 Apr 2015",
+    "museum": false
+  },
+  "5.6.7": {
+    "announcement": {
+      "English": "/releases/5_6_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.7.tar.bz2",
+        "name": "PHP 5.6.7 (tar.bz2)",
+        "date": "19 Mar 2015",
+        "sha256": "02954fb74c61a7879d48ebdcd4ecb78aa0056f4215ca9b096232de28eb8f17bc"
+      },
+      {
+        "filename": "php-5.6.7.tar.gz",
+        "name": "PHP 5.6.7 (tar.gz)",
+        "date": "19 Mar 2015",
+        "sha256": "11398540a582c876f5e070207231afde975eb49bb2eeae20b052e8ca325c0f47"
+      },
+      {
+        "filename": "php-5.6.7.tar.xz",
+        "name": "PHP 5.6.7 (tar.xz)",
+        "date": "19 Mar 2015",
+        "sha256": "a85522dd2e6f80ee5637e537447ee54896c77a8fabe49d2310830d0e20952787"
+      }
+    ],
+    "date": "19 Mar 2015",
+    "museum": false
+  },
+  "5.5.23": {
+    "announcement": {
+      "English": "/releases/5_5_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.23.tar.bz2",
+        "name": "PHP 5.5.23 (tar.bz2)",
+        "date": "20 Feb 2015",
+        "sha256": "a99ab264dcd40181baa9defeaa4b21eb2c20d4e9316b904cc05f628762e6ada7"
+      },
+      {
+        "filename": "php-5.5.23.tar.gz",
+        "name": "PHP 5.5.23 (tar.gz)",
+        "date": "20 Feb 2015",
+        "sha256": "bf1246d4aca5b1a4e26f5cea273565ad3ee4607f20b7f28a508e3cab1a4d0c82"
+      },
+      {
+        "filename": "php-5.5.23.tar.xz",
+        "name": "PHP 5.5.23 (tar.xz)",
+        "date": "20 Feb 2015",
+        "sha256": "2fc8315606cd6a51dae2e1fe9ac7a9bead76dace3eaf888ba372506695403af4"
+      }
+    ],
+    "date": "20 Feb 2015",
+    "museum": false
+  },
+  "5.6.6": {
+    "announcement": {
+      "English": "/releases/5_6_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.6.tar.bz2",
+        "name": "PHP 5.6.6 (tar.bz2)",
+        "date": "19 Feb 2015",
+        "sha256": "09625c9b65e0c8198dc76995a35f0feec0e13ea4489526e64a00954b12adbb4c"
+      },
+      {
+        "filename": "php-5.6.6.tar.gz",
+        "name": "PHP 5.6.6 (tar.gz)",
+        "date": "19 Feb 2015",
+        "sha256": "164fb27bab0a0ca4902bc67d5f5638e43466c88153aee3b54546d8ec682ec03b"
+      },
+      {
+        "filename": "php-5.6.6.tar.xz",
+        "name": "PHP 5.6.6 (tar.xz)",
+        "date": "19 Feb 2015",
+        "sha256": "b963b2d45baeebeeb421c05ee60889e87971e3e27a4be873d265fee3250fde20"
+      }
+    ],
+    "date": "19 Feb 2015",
+    "museum": false
+  },
+  "5.5.22": {
+    "announcement": {
+      "English": "/releases/5_5_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.22.tar.bz2",
+        "name": "PHP 5.5.22 (tar.bz2)",
+        "date": "20 Feb 2015",
+        "sha256": "c218c184bef2905bc79fcdda6040f3d1738261395fb706396935d1c6f6e162bb"
+      },
+      {
+        "filename": "php-5.5.22.tar.gz",
+        "name": "PHP 5.5.22 (tar.gz)",
+        "date": "20 Feb 2015",
+        "sha256": "cb6174e1e74de233ec7b461302f823a7eacf7bcc946d347486c930e53f2b7db7"
+      },
+      {
+        "filename": "php-5.5.22.tar.xz",
+        "name": "PHP 5.5.22 (tar.xz)",
+        "date": "20 Feb 2015",
+        "sha256": "5256a7e3999eb11f8b4b407408ea4780f60aa959e0c48cfcf376091e721df223"
+      }
+    ],
+    "date": "20 Feb 2015",
+    "museum": false
+  },
+  "5.6.5": {
+    "announcement": {
+      "English": "/releases/5_6_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.5.tar.bz2",
+        "name": "PHP 5.6.5 (tar.bz2)",
+        "date": "22 Jan 2015",
+        "sha256": "adab4c0775512a5ca0ae74e08efdc941d92529b75283e0f44d3f53822cdfd06d"
+      },
+      {
+        "filename": "php-5.6.5.tar.gz",
+        "name": "PHP 5.6.5 (tar.gz)",
+        "date": "22 Jan 2015",
+        "sha256": "f67c480bcf2f6f703ec8d8a772540f4a518f766b08d634d7a919402c13a636cf"
+      },
+      {
+        "filename": "php-5.6.5.tar.xz",
+        "name": "PHP 5.6.5 (tar.xz)",
+        "date": "22 Jan 2015",
+        "sha256": "c5ef4abaef8c1ea66dcfd5a075a2f357b666aff5c5b686fca7c78c1cfd64e996"
+      }
+    ],
+    "date": "22 Jan 2015",
+    "museum": false
+  },
+  "5.5.21": {
+    "announcement": {
+      "English": "/releases/5_5_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.21.tar.bz2",
+        "name": "PHP 5.5.21 (tar.bz2)",
+        "date": "22 Jan 2015",
+        "sha256": "62e9429975c4ca5d7067a5052d5388fbf2ac8c51eeee581d59b04cc5a8da83fe"
+      },
+      {
+        "filename": "php-5.5.21.tar.gz",
+        "name": "PHP 5.5.21 (tar.gz)",
+        "date": "22 Jan 2015",
+        "sha256": "45adba5b4d2519f6174b85fd5b07a77389f397603d84084bdd26c44b3d7dc8af"
+      },
+      {
+        "filename": "php-5.5.21.tar.xz",
+        "name": "PHP 5.5.21 (tar.xz)",
+        "date": "22 Jan 2015",
+        "sha256": "f2583540b2698d7d0ee9cfc071c2b56ccc64a52a2b53101511ba8df5b126d6d2"
+      }
+    ],
+    "date": "22 Jan 2015",
+    "museum": false
+  },
+  "5.6.4": {
+    "announcement": {
+      "English": "/releases/5_6_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.4.tar.bz2",
+        "name": "PHP 5.6.4 (tar.bz2)",
+        "date": "18 Dec 2014",
+        "sha256": "576f9001b612f5ddc22f447311bbec321e2c959b6a52259d664c4ba04ef044f1"
+      },
+      {
+        "filename": "php-5.6.4.tar.gz",
+        "name": "PHP 5.6.4 (tar.gz)",
+        "date": "18 Dec 2014",
+        "sha256": "9c318f10af598e3d0b306a00860cfeb13c34024a9032a59ff53e3cd3c7791e97"
+      },
+      {
+        "filename": "php-5.6.4.tar.xz",
+        "name": "PHP 5.6.4 (tar.xz)",
+        "date": "18 Dec 2014",
+        "sha256": "8cf44c59f467cdc2dd76c1167d1f368575ccff9b12941e199a362eb44a79acea"
+      }
+    ],
+    "date": "18 Dec 2014",
+    "museum": false
+  },
+  "5.5.20": {
+    "announcement": {
+      "English": "/releases/5_5_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.20.tar.bz2",
+        "name": "PHP 5.5.20 (tar.bz2)",
+        "date": "18 Dec 2014",
+        "sha256": "f28a150d1cd8991bd1a41dce4fdff4e343d1dbe01a48b9b44bea74532ce0391a"
+      },
+      {
+        "filename": "php-5.5.20.tar.gz",
+        "name": "PHP 5.5.20 (tar.gz)",
+        "date": "18 Dec 2014",
+        "sha256": "7454e4f2dba3b08b2c88bb178e7bf704ed100f3d7ab6b83ea5046a6e4acb7295"
+      },
+      {
+        "filename": "php-5.5.20.tar.xz",
+        "name": "PHP 5.5.20 (tar.xz)",
+        "date": "18 Dec 2014",
+        "sha256": "a0649450f8b0a23cd4c9ad15d0aa271d956f9516fc37b9e9dc492459b57721c8"
+      }
+    ],
+    "date": "18 Dec 2014",
+    "museum": false
+  },
+  "5.6.3": {
+    "announcement": {
+      "English": "/releases/5_6_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.3.tar.bz2",
+        "name": "PHP 5.6.3 (tar.bz2)",
+        "date": "13 Nov 2014",
+        "sha256": "8986b20124d14430d795165e47801ef065a38d5855bea39d0d47b13ab9ad4009"
+      },
+      {
+        "filename": "php-5.6.3.tar.gz",
+        "name": "PHP 5.6.3 (tar.gz)",
+        "date": "13 Nov 2014",
+        "sha256": "7ac79fe7ef50c2d5893375f5d8854909337adf1632e42bb08b36b66a0d8016a7"
+      },
+      {
+        "filename": "php-5.6.3.tar.xz",
+        "name": "PHP 5.6.3 (tar.xz)",
+        "date": "13 Nov 2014",
+        "sha256": "fad244506cc7f10fe56aba8129b3c39a4f9316d9544a4fba932c3f81fc2244b5"
+      }
+    ],
+    "date": "13 Nov 2014",
+    "museum": false
+  },
+  "5.5.19": {
+    "announcement": {
+      "English": "/releases/5_5_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.19.tar.bz2",
+        "name": "PHP 5.5.19 (tar.bz2)",
+        "date": "13 Nov 2014",
+        "sha256": "4366dbb904cba8c8dd32224ac9408495d20aecaed86a871d78df420f5a23bbff"
+      },
+      {
+        "filename": "php-5.5.19.tar.gz",
+        "name": "PHP 5.5.19 (tar.gz)",
+        "date": "13 Nov 2014",
+        "sha256": "8d39f224424f37644da913353f1e773c20b7fc55bb3cc81526c18f91d1d6394e"
+      },
+      {
+        "filename": "php-5.5.19.tar.xz",
+        "name": "PHP 5.5.19 (tar.xz)",
+        "date": "13 Nov 2014",
+        "sha256": "ccff8dfcd342e48a5b1e8b85c1c8c95d2e2eefab869757dcaa5224f11bb30e21"
+      }
+    ],
+    "date": "13 Nov 2014",
+    "museum": false
+  },
+  "5.6.2": {
+    "announcement": {
+      "English": "/releases/5_6_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.2.tar.bz2",
+        "name": "PHP 5.6.2 (tar.bz2)",
+        "date": "16 Oct 2014",
+        "sha256": "671dcf1f636410c63bb9eb015c4c180d904f5436f81217be0adbf52da9becdb5"
+      },
+      {
+        "filename": "php-5.6.2.tar.gz",
+        "name": "PHP 5.6.2 (tar.gz)",
+        "date": "16 Oct 2014",
+        "sha256": "4bb316831979317caf738bb9e2c590bf3b7951ce60c69b9ca33f26069d9a2f39"
+      },
+      {
+        "filename": "php-5.6.2.tar.xz",
+        "name": "PHP 5.6.2 (tar.xz)",
+        "date": "16 Oct 2014",
+        "sha256": "9be1322d33520fb2164282fb0fcdc212f66ffedcd912bff60955d5696454fe39"
+      }
+    ],
+    "date": "16 Oct 2014",
+    "museum": false
+  },
+  "5.5.18": {
+    "announcement": {
+      "English": "/releases/5_5_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.18.tar.bz2",
+        "name": "PHP 5.5.18 (tar.bz2)",
+        "date": "16 Oct 2014",
+        "sha256": "f974279927b72b672dda4ef4b4362b4847fd3d19ce1d4f2e982230a4e93bb842"
+      },
+      {
+        "filename": "php-5.5.18.tar.gz",
+        "name": "PHP 5.5.18 (tar.gz)",
+        "date": "16 Oct 2014",
+        "sha256": "71f6445cc21c944a3b98592193c62e29a58af3fe26d097312502b4fd400286e4"
+      },
+      {
+        "filename": "php-5.5.18.tar.xz",
+        "name": "PHP 5.5.18 (tar.xz)",
+        "date": "16 Oct 2014",
+        "sha256": "ccfbf6af18d1e56145867454dcbc75d90512f40ee9d3e57fdc6cb5fe3fc9726e"
+      }
+    ],
+    "date": "16 Oct 2014",
+    "museum": false
+  },
+  "5.6.1": {
+    "announcement": {
+      "English": "/releases/5_6_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.1.tar.bz2",
+        "name": "PHP 5.6.1 (tar.bz2)",
+        "date": "02 Oct 2014",
+        "sha256": "82c1ccd17830d697d7a4d75bb60ea12be58fa80b4dba101e97db1a6372ca45f0"
+      },
+      {
+        "filename": "php-5.6.1.tar.gz",
+        "name": "PHP 5.6.1 (tar.gz)",
+        "date": "02 Oct 2014",
+        "sha256": "e34f0ab6b1f431f3115f60094f6d7ded12a90db2361194b8ef9e6eff812db21c"
+      },
+      {
+        "filename": "php-5.6.1.tar.xz",
+        "name": "PHP 5.6.1 (tar.xz)",
+        "date": "02 Oct 2014",
+        "sha256": "57640a700364949292da06e55423f162428a864451d05751a8829ae04d65745e"
+      }
+    ],
+    "date": "02 Oct 2014",
+    "museum": false
+  },
+  "5.5.17": {
+    "announcement": {
+      "English": "/releases/5_5_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.17.tar.bz2",
+        "name": "PHP 5.5.17 (tar.bz2)",
+        "date": "18 Sep 2014",
+        "sha256": "5d81db0c8b2a68da05715c363d037922b82a45c966785d64a77482e5c01e4e1b"
+      },
+      {
+        "filename": "php-5.5.17.tar.gz",
+        "name": "PHP 5.5.17 (tar.gz)",
+        "date": "18 Sep 2014",
+        "sha256": "657169be88ae70625d97bb94dd29140c2b602f1ba8d5e42ca14a400b63cf4720"
+      },
+      {
+        "filename": "php-5.5.17.tar.xz",
+        "name": "PHP 5.5.17 (tar.xz)",
+        "date": "18 Sep 2014",
+        "sha256": "382b2a1cfbf67ca9e30171c9c49bfe260d5e458e07850d4b036e8430e1829093"
+      }
+    ],
+    "date": "18 Sep 2014",
+    "museum": false
+  },
+  "5.6.0": {
+    "announcement": {
+      "English": "/releases/5_6_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.0.tar.bz2",
+        "name": "PHP 5.6.0 (tar.bz2)",
+        "date": "28 Aug 2014",
+        "sha256": "097af1be34fc73965e6f8401fd10e73eb56e1969ed4ffd691fb7e91606d0fc09"
+      },
+      {
+        "filename": "php-5.6.0.tar.gz",
+        "name": "PHP 5.6.0 (tar.gz)",
+        "date": "28 Aug 2014",
+        "sha256": "284b85376c630a6a7163e5278d64b8526fa1324fe5fd5d21174b54e2c056533f"
+      },
+      {
+        "filename": "php-5.6.0.tar.xz",
+        "name": "PHP 5.6.0 (tar.xz)",
+        "date": "28 Aug 2014",
+        "sha256": "8fc5411cd05cc6cc663247e588931fe67b1dc0e42550fa28ab2c943ad84eda02"
+      }
+    ],
+    "date": "28 Aug 2014",
+    "museum": false
+  },
+  "5.5.16": {
+    "announcement": {
+      "English": "/releases/5_5_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.16.tar.bz2",
+        "name": "PHP 5.5.16 (tar.bz2)",
+        "date": "21 Aug 2014",
+        "sha256": "a1d7c4556a80bed744a348211b33bc35303edd56dd0a34e0a75a948c879cc5f6"
+      },
+      {
+        "filename": "php-5.5.16.tar.gz",
+        "name": "PHP 5.5.16 (tar.gz)",
+        "date": "21 Aug 2014",
+        "sha256": "cdea80ab1b0466f4656b46155e341b700799e78569a5cc582eeaededb448086c"
+      },
+      {
+        "filename": "php-5.5.16.tar.xz",
+        "name": "PHP 5.5.16 (tar.xz)",
+        "date": "21 Aug 2014",
+        "sha256": "8276e8de4928e8e7011d1ac6c841c5adfc4561c7329ef2f5e055e7f4e1af0e48"
+      }
+    ],
+    "date": "21 Aug 2014",
+    "museum": false
+  },
+  "5.5.15": {
+    "announcement": {
+      "English": "/releases/5_5_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.15.tar.bz2",
+        "name": "PHP 5.5.15 (tar.bz2)",
+        "date": "24 Jul 2014",
+        "sha256": "00f24226b12fee27e332383b6304f1b9ed3f4d9173dd728a68c5c3f5a59b8ba7"
+      },
+      {
+        "filename": "php-5.5.15.tar.gz",
+        "name": "PHP 5.5.15 (tar.gz)",
+        "date": "24 Jul 2014",
+        "sha256": "578febd686018401c4857699b29502b1aecaf82bf43525d810867f583961ac6e"
+      },
+      {
+        "filename": "php-5.5.15.tar.xz",
+        "name": "PHP 5.5.15 (tar.xz)",
+        "date": "24 Jul 2014",
+        "sha256": "c20e360cf06bd4279ab423a7785d36aba0e2a9fdcd0b817883ab01cf0d914dd6"
+      }
+    ],
+    "date": "24 Jul 2014",
+    "museum": false
+  },
+  "5.5.14": {
+    "announcement": {
+      "English": "/releases/5_5_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.14.tar.bz2",
+        "name": "PHP 5.5.14 (tar.bz2)",
+        "date": "26 Jun 2014",
+        "sha256": "df5a057877f827549e0a60b43fb01e4bd440814bcf04fbd70bacbddf74482610"
+      },
+      {
+        "filename": "php-5.5.14.tar.gz",
+        "name": "PHP 5.5.14 (tar.gz)",
+        "date": "26 Jun 2014",
+        "sha256": "ef7e4f4942c5767e01b96650a5bd4178c663738436f99b5695c3144732ff7166"
+      }
+    ],
+    "date": "26 Jun 2014",
+    "museum": false
+  },
+  "5.5.13": {
+    "announcement": {
+      "English": "/releases/5_5_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.13.tar.bz2",
+        "name": "PHP 5.5.13 (tar.bz2)",
+        "date": "29 May 2014",
+        "sha256": "e58a4a754eb18d2d8b1a120cad5cce4ed24a7db5d49eca5830a40e4c8ca78b9c"
+      },
+      {
+        "filename": "php-5.5.13.tar.gz",
+        "name": "PHP 5.5.13 (tar.gz)",
+        "date": "29 May 2014",
+        "sha256": "15e34eb7c45e66963cbece29fb41e53cc6c6e3ec4a54c291a53cf6a1527771b6"
+      }
+    ],
+    "date": "29 May 2014",
+    "museum": false
+  },
+  "5.5.12": {
+    "announcement": {
+      "English": "/releases/5_5_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.12.tar.bz2",
+        "name": "PHP 5.5.12 (tar.bz2)",
+        "date": "30 Apr 2014",
+        "sha256": "519ee29e28532782676f3d8e31a808ffbfee383e0279ccc8cbd2b12ed53c2335"
+      },
+      {
+        "filename": "php-5.5.12.tar.gz",
+        "name": "PHP 5.5.12 (tar.gz)",
+        "date": "30 Apr 2014",
+        "sha256": "a10c6e6ce1145762d6c15ca7ce1aeaab69662c197d24e1294c2519aa85c97bd6"
+      }
+    ],
+    "date": "30 Apr 2014",
+    "museum": false
+  },
+  "5.5.11": {
+    "announcement": {
+      "English": "/releases/5_5_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.11.tar.bz2",
+        "name": "PHP 5.5.11 (tar.bz2)",
+        "date": "3 Apr 2014",
+        "sha256": "60e14c255f2a461a7a26639b84a2fc448cc2f91c8dead0e9fd00cd8ba27a2e96"
+      },
+      {
+        "filename": "php-5.5.11.tar.gz",
+        "name": "PHP 5.5.11 (tar.gz)",
+        "date": "3 Apr 2014",
+        "sha256": "a8b7bb1049732bf806e94090661f39f8359e0bf36d59ce6b98a53ea80411b450"
+      }
+    ],
+    "date": "3 Apr 2014",
+    "museum": false
+  },
+  "5.5.10": {
+    "announcement": {
+      "English": "/releases/5_5_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.10.tar.bz2",
+        "name": "PHP 5.5.10 (tar.bz2)",
+        "date": "6 Mar 2014",
+        "sha256": "bb34e61f8e6f56c612867bfe85d144d5045cd5e44497539bc126a4e8c6795419"
+      },
+      {
+        "filename": "php-5.5.10.tar.gz",
+        "name": "PHP 5.5.10 (tar.gz)",
+        "date": "6 Mar 2014",
+        "sha256": "abf751810593844e0897007797210828b193a213d9b204f203e0331019cadb90"
+      }
+    ],
+    "date": "6 Mar 2014",
+    "museum": false
+  },
+  "5.5.9": {
+    "announcement": {
+      "English": "/releases/5_5_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.9.tar.bz2",
+        "name": "PHP 5.5.9 (tar.bz2)",
+        "date": "6 Feb 2014",
+        "sha256": "9d1dea5195e2bcd928416130a6e19173d02bd36fb76c382522bf145c458fbed3"
+      },
+      {
+        "filename": "php-5.5.9.tar.gz",
+        "name": "PHP 5.5.9 (tar.gz)",
+        "date": "6 Feb 2014",
+        "sha256": "ec1bf0cb3be80240049dbd92c272d4bf242a614fa5f9dcc42a15adb5fd01ccde"
+      },
+      {
+        "filename": "php-5.5.9.tar.xz",
+        "name": "PHP 5.5.9 (tar.xz)",
+        "date": "6 Feb 2014",
+        "sha256": "7f7a7b1189472e59b234233daab9aa9692bb5eb8404485e9a78221f75ee4664a"
+      }
+    ],
+    "date": "6 Feb 2014",
+    "museum": false
+  },
+  "5.5.8": {
+    "announcement": {
+      "English": "/releases/5_5_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.8.tar.bz2",
+        "name": "PHP 5.5.8 (tar.bz2)",
+        "date": "9 Jan 2014",
+        "sha256": "6d5f45659d13383fc8429f185cc9da0b30c7bb72dcae9baf568f0511eb7f8b68"
+      },
+      {
+        "filename": "php-5.5.8.tar.gz",
+        "name": "PHP 5.5.8 (tar.gz)",
+        "date": "9 Jan 2014",
+        "sha256": "67c74a9a2357dc65f5b1701cadb574f1309c4c3a20a2a5c56aeae4c4be90f2f8"
+      }
+    ],
+    "date": "9 Jan 2014",
+    "museum": false
+  },
+  "5.5.7": {
+    "announcement": {
+      "English": "/releases/5_5_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.7.tar.bz2",
+        "name": "PHP 5.5.7 (tar.bz2)",
+        "date": "12 Dec 2013",
+        "sha256": "2cb9425ef514b984dd233097d82a66f4623b9bf48f2ef265bc7ba25d697d6008"
+      },
+      {
+        "filename": "php-5.5.7.tar.gz",
+        "name": "PHP 5.5.7 (tar.gz)",
+        "date": "12 Dec 2013",
+        "sha256": "7b954338d7dd538ef6fadbc110e6a0f50d0b39dabec2c12a7f000c17332591b8"
+      },
+      {
+        "filename": "php-5.5.7.tar.xz",
+        "name": "PHP 5.5.7 (tar.xz)",
+        "date": "12 Dec 2013",
+        "sha256": "b7bae5d878b8fc3f4b481eb8f2179b5e71d30dfb3bc3640a5068c1b46633f08c"
+      }
+    ],
+    "date": "12 Dec 2013",
+    "museum": false
+  },
+  "5.5.6": {
+    "announcement": {
+      "English": "/releases/5_5_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.6.tar.bz2",
+        "name": "PHP 5.5.6 (tar.bz2)",
+        "date": "14 Nov 2013",
+        "sha256": "a9b7d291199d7e6b90ef1d78eb791d738944d66856e76bde9463ce2645b0e4a4"
+      },
+      {
+        "filename": "php-5.5.6.tar.gz",
+        "name": "PHP 5.5.6 (tar.gz)",
+        "date": "14 Nov 2013",
+        "sha256": "01f9c45154d4c9a47a825aa662bd64493082bd57dafdc720cf899ee194220a67"
+      },
+      {
+        "filename": "php-5.5.6.tar.xz",
+        "name": "PHP 5.5.6 (tar.xz)",
+        "date": "14 Nov 2013",
+        "sha256": "3235a5c15e8fc55498dd80fe43f4aecc51dba35a7fc916aee7ef12d4e1f8767a"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.6 binaries and source"
+      }
+    ],
+    "date": "14 Nov 2013",
+    "museum": false
+  },
+  "5.5.5": {
+    "announcement": {
+      "English": "/releases/5_5_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.5.tar.bz2",
+        "name": "PHP 5.5.5 (tar.bz2)",
+        "date": "17 Oct 2013",
+        "sha256": "a400b324ae288eb0c9285e550fe5fd7f92c0f4e126496c3b05f9041da6cc04de"
+      },
+      {
+        "filename": "php-5.5.5.tar.gz",
+        "name": "PHP 5.5.5 (tar.gz)",
+        "date": "17 Oct 2013",
+        "sha256": "483ff2370fa3a8863e6b023383c4bcfcc3ba462137c30c5fc75043e1755b7d17"
+      },
+      {
+        "filename": "php-5.5.5.tar.xz",
+        "name": "PHP 5.5.5 (tar.xz)",
+        "date": "17 Oct 2013",
+        "sha256": "82cc9c88b946354bfe629917a85ed33d8cfc901460d432a75f823667d94f29ee"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.5 binaries and source"
+      }
+    ],
+    "date": "17 Oct 2013",
+    "museum": false
+  },
+  "5.5.4": {
+    "announcement": {
+      "English": "/releases/5_5_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.4.tar.bz2",
+        "name": "PHP 5.5.4 (tar.bz2)",
+        "md5": "456f2eb1ee36f2a277bd4cc778e720eb",
+        "date": "19 Sep 2013"
+      },
+      {
+        "filename": "php-5.5.4.tar.gz",
+        "name": "PHP 5.5.4 (tar.gz)",
+        "md5": "bf842770ac64a47ff599f463e6cf1334",
+        "date": "19 Sep 2013"
+      },
+      {
+        "filename": "php-5.5.4.tar.xz",
+        "name": "PHP 5.5.4 (tar.xz)",
+        "md5": "32c1dc56701d21def91a39a312392b54",
+        "date": "19 Sep 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.4 binaries and source"
+      }
+    ],
+    "date": "19 Sep 2013",
+    "museum": true
+  },
+  "5.5.3": {
+    "announcement": {
+      "English": "/releases/5_5_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.3.tar.bz2",
+        "name": "PHP 5.5.3 (tar.bz2)",
+        "md5": "886b08ee6865d654911a6bb02ae98ee8",
+        "date": "22 Aug 2013"
+      },
+      {
+        "filename": "php-5.5.3.tar.gz",
+        "name": "PHP 5.5.3 (tar.gz)",
+        "md5": "a5dfdd41ccf539942db966310f7429da",
+        "date": "22 Aug 2013"
+      },
+      {
+        "filename": "php-5.5.3.tar.xz",
+        "name": "PHP 5.5.3 (tar.xz)",
+        "md5": "437e98144ef014dfab0922a9eed36853",
+        "date": "22 Aug 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.3 binaries and source"
+      }
+    ],
+    "date": "22 Aug 2013",
+    "museum": true
+  },
+  "5.5.2": {
+    "announcement": {
+      "English": "/releases/5_5_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.2.tar.bz2",
+        "name": "PHP 5.5.2 (tar.bz2)",
+        "md5": "caf7f4d86514a568fb3c8021b096a9f0",
+        "date": "15 Aug 2013"
+      },
+      {
+        "filename": "php-5.5.2.tar.gz",
+        "name": "PHP 5.5.2 (tar.gz)",
+        "md5": "2a90884749f97868071538098b3debc1",
+        "date": "15 Aug 2013"
+      },
+      {
+        "filename": "php-5.5.2.tar.xz",
+        "name": "PHP 5.5.2 (tar.xz)",
+        "md5": "95c6d7a4c36c475b10447954dea056a5",
+        "date": "15 Aug 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.2 binaries and source"
+      }
+    ],
+    "date": "15 Aug 2013",
+    "museum": true
+  },
+  "5.5.1": {
+    "announcement": {
+      "English": "/releases/5_5_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.1.tar.bz2",
+        "name": "PHP 5.5.1 (tar.bz2)",
+        "md5": "e6520ba8f86e03451f1e9226ca2be681",
+        "date": "18 Jul 2013"
+      },
+      {
+        "filename": "php-5.5.1.tar.gz",
+        "name": "PHP 5.5.1 (tar.gz)",
+        "md5": "a7d9598c0e60b47960b8e803e51c4309",
+        "date": "18 Jul 2013"
+      },
+      {
+        "filename": "php-5.5.1.tar.xz",
+        "name": "PHP 5.5.1 (tar.xz)",
+        "md5": "365403c216d22255c3aa57fe54944f8e",
+        "date": "18 Jul 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.1 binaries and source"
+      }
+    ],
+    "date": "18 Jul 2013",
+    "museum": true
+  },
+  "5.5.0": {
+    "announcement": {
+      "English": "/releases/5_5_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.5.0.tar.bz2",
+        "name": "PHP 5.5.0 (tar.bz2)",
+        "md5": "daf2d54e79def9fd0fb2ac7dfcefb7f3",
+        "date": "20 Jun 2013"
+      },
+      {
+        "filename": "php-5.5.0.tar.gz",
+        "name": "PHP 5.5.0 (tar.gz)",
+        "md5": "79c4e7a8cb0f8e2e072120775b92c523",
+        "date": "20 Jun 2013"
+      },
+      {
+        "filename": "php-5.5.0.tar.xz",
+        "name": "PHP 5.5.0 (tar.xz)",
+        "md5": "c7df0cb28cfff4e277fd9cd9b73cebfb",
+        "date": "20 Jun 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.5",
+        "name": "Windows 5.5.0 binaries and source"
+      }
+    ],
+    "date": "20 Jun 2013",
+    "museum": true
+  },
+  "5.4.45": {
+    "announcement": {
+      "English": "/releases/5_4_45.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.45.tar.bz2",
+        "name": "PHP 5.4.45 (tar.bz2)",
+        "sha256": "4e0d28b1554c95cfaea6fa2b64aac85433f158ce72bb571bcd5574f98f4c6582",
+        "date": "03 Sep 2015"
+      },
+      {
+        "filename": "php-5.4.45.tar.gz",
+        "name": "PHP 5.4.45 (tar.gz)",
+        "sha256": "25bc4723955f4e352935258002af14a14a9810b491a19400d76fcdfa9d04b28f",
+        "date": "03 Sep 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.45 binaries and source"
+      }
+    ],
+    "date": "03 Sep 2015",
+    "museum": false
+  },
+  "5.4.44": {
+    "announcement": {
+      "English": "/releases/5_4_44.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.44.tar.bz2",
+        "name": "PHP 5.4.44 (tar.bz2)",
+        "sha256": "8dd59e5ce9248cf36ac3de5412a518b8b24c01ace6c46ce3d12e4ce981a3856d",
+        "date": "06 Aug 2015"
+      },
+      {
+        "filename": "php-5.4.44.tar.gz",
+        "name": "PHP 5.4.44 (tar.gz)",
+        "sha256": "1799998e48da3d8f34722840628e18789e26ea21741d4e498ade6749b3266602",
+        "date": "06 Aug 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.44 binaries and source"
+      }
+    ],
+    "date": "06 Aug 2015",
+    "museum": false
+  },
+  "5.4.43": {
+    "announcement": {
+      "English": "/releases/5_4_43.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.43.tar.bz2",
+        "name": "PHP 5.4.43 (tar.bz2)",
+        "sha256": "25d7724fb00ad1b520f5bad2173717031153d0a8e3de2c75e7a084c76f8ecd6b",
+        "date": "09 Jul 2015"
+      },
+      {
+        "filename": "php-5.4.43.tar.gz",
+        "name": "PHP 5.4.43 (tar.gz)",
+        "sha256": "cfc2176adc05f009666ecfab4a1cc66cc546c5d071245b2a048b3d113f67a2af",
+        "date": "09 Jul 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.43 binaries and source"
+      }
+    ],
+    "date": "09 Jul 2015",
+    "museum": false
+  },
+  "5.4.42": {
+    "announcement": {
+      "English": "/releases/5_4_42.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.42.tar.bz2",
+        "name": "PHP 5.4.42 (tar.bz2)",
+        "sha256": "6285b2e64bfaa69e5d983d7d981b4f254f5259ad3fd591ca832722a4cc1ae0f9",
+        "date": "11 Jun 2015"
+      },
+      {
+        "filename": "php-5.4.42.tar.gz",
+        "name": "PHP 5.4.42 (tar.gz)",
+        "sha256": "f0b40c097a6f11c4c2f5078d34f50fb9428d79b9e9821117bd7d6cca6af78d11",
+        "date": "11 Jun 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.42 binaries and source"
+      }
+    ],
+    "date": "11 Jun 2015",
+    "museum": false
+  },
+  "5.4.41": {
+    "announcement": {
+      "English": "/releases/5_4_41.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.41.tar.bz2",
+        "name": "PHP 5.4.41 (tar.bz2)",
+        "sha256": "5bc4b45a1280ff80a3cf5b8563716f325cfd0121d7fd25aa54d56ff38b3b8272",
+        "date": "14 May 2015"
+      },
+      {
+        "filename": "php-5.4.41.tar.gz",
+        "name": "PHP 5.4.41 (tar.gz)",
+        "sha256": "638cf19c865bc4eba2a4bab8952116a62691d1a72e1e2c9a9a2aadee92d1ce2e",
+        "date": "14 May 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.41 binaries and source"
+      }
+    ],
+    "date": "14 May 2015",
+    "museum": false
+  },
+  "5.4.40": {
+    "announcement": {
+      "English": "/releases/5_4_40.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.40.tar.bz2",
+        "name": "PHP 5.4.40 (tar.bz2)",
+        "sha256": "4898ffe8ac3ccb2d8cc94f7d76a9ea0414d954f5d4479895ddfccdc2e158a51a",
+        "date": "16 Apr 2015"
+      },
+      {
+        "filename": "php-5.4.40.tar.gz",
+        "name": "PHP 5.4.40 (tar.gz)",
+        "sha256": "663f5d06cd648e81ba4f2d6ad621bb580d83de70240c832dae527c97954da33d",
+        "date": "16 Apr 2015"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.40 binaries and source"
+      }
+    ],
+    "date": "16 Apr 2015",
+    "museum": false
+  },
+  "5.4.39": {
+    "announcement": {
+      "English": "/releases/5_4_39.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.39.tar.bz2",
+        "name": "PHP 5.4.39 (tar.bz2)",
+        "date": "19 Mar 2015",
+        "sha256": "7ceb76538e709c74533210ae41148d5c01c330ac8a73220954bbc4fcae69d77e"
+      },
+      {
+        "filename": "php-5.4.39.tar.gz",
+        "name": "PHP 5.4.39 (tar.gz)",
+        "date": "19 Mar 2015",
+        "sha256": "9af5d2c3782aa94b7336401755dc44b62dc4ea881bf5e39540a4c7181b54d945"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.39 binaries and source"
+      }
+    ],
+    "date": "19 Mar 2015",
+    "museum": false
+  },
+  "5.4.38": {
+    "announcement": {
+      "English": "/releases/5_4_38.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.38.tar.bz2",
+        "name": "PHP 5.4.38 (tar.bz2)",
+        "date": "19 Feb 2015",
+        "sha256": "abf37db0cfadc9bb814f9df35f6aa966ad63f4f4c4475e432ec625568a5d3e88"
+      },
+      {
+        "filename": "php-5.4.38.tar.gz",
+        "name": "PHP 5.4.38 (tar.gz)",
+        "date": "19 Feb 2015",
+        "sha256": "e694b7265f314f73c9df43538e0e54e2495cb72252e8a91c1aec66ffcf47241f"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.38 binaries and source"
+      }
+    ],
+    "date": "19 Feb 2015",
+    "museum": false
+  },
+  "5.4.37": {
+    "announcement": {
+      "English": "/releases/5_4_37.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.37.tar.bz2",
+        "name": "PHP 5.4.37 (tar.bz2)",
+        "date": "22 Jan 2015",
+        "sha256": "857bf6675eeb0ae9c3cd6f9ccdb2a9b7bf89dcfda7f0a80857638fe023f3a8ad"
+      },
+      {
+        "filename": "php-5.4.37.tar.gz",
+        "name": "PHP 5.4.37 (tar.gz)",
+        "date": "22 Jan 2015",
+        "sha256": "6bf3b3ebefa600cfb6dd7f2678f23b17a958e82e8ce2d012286818d7c36dfd31"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.37 binaries and source"
+      }
+    ],
+    "date": "22 Jan 2015",
+    "museum": false
+  },
+  "5.4.36": {
+    "announcement": {
+      "English": "/releases/5_4_36.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.36.tar.bz2",
+        "name": "PHP 5.4.36 (tar.bz2)",
+        "date": "18 Dec 2014",
+        "sha256": "b0951608c3e8afb978a624c7f79a889980210f5258f666c1d997bd6491e13241"
+      },
+      {
+        "filename": "php-5.4.36.tar.gz",
+        "name": "PHP 5.4.36 (tar.gz)",
+        "date": "18 Dec 2014",
+        "sha256": "e11851662222765d6ab6e671adc983c657d5358a183856b43a5bad0c612d2959"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.36 binaries and source"
+      }
+    ],
+    "date": "18 Dec 2014",
+    "museum": false
+  },
+  "5.4.35": {
+    "announcement": {
+      "English": "/releases/5_4_35.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.35.tar.bz2",
+        "name": "PHP 5.4.35 (tar.bz2)",
+        "date": "13 Nov 2014",
+        "sha256": "8cdb4265cd0f778befacd1e6b5939ec23315fff38400e17e77a36e4c55b9746b"
+      },
+      {
+        "filename": "php-5.4.35.tar.gz",
+        "name": "PHP 5.4.35 (tar.gz)",
+        "date": "13 Nov 2014",
+        "sha256": "7ecab4ebb880b6d4f68bd4e3e49d837d4704fe26d81dc992b17b74151ee950a7"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.35 binaries and source"
+      }
+    ],
+    "date": "13 Nov 2014",
+    "museum": false
+  },
+  "5.4.34": {
+    "announcement": {
+      "English": "/releases/5_4_34.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.34.tar.bz2",
+        "name": "PHP 5.4.34 (tar.bz2)",
+        "date": "16 Oct 2014",
+        "sha256": "57d4ea10f0c18b096a7c8fd0a98dcbe40c8f4dc94453fd3ca0a10e35fb2f8234"
+      },
+      {
+        "filename": "php-5.4.34.tar.gz",
+        "name": "PHP 5.4.34 (tar.gz)",
+        "date": "16 Oct 2014",
+        "sha256": "c8d909062ad7616cedb54dc03d85b40d40f6d4adce986ec8cabd9b8b94872096"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.34 binaries and source"
+      }
+    ],
+    "date": "16 Oct 2014",
+    "museum": false
+  },
+  "5.4.33": {
+    "announcement": {
+      "English": "/releases/5_4_33.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.33.tar.bz2",
+        "name": "PHP 5.4.33 (tar.bz2)",
+        "sha256": "1a75b2d0835e74b8886cd3980d9598a0e06691441bb7f91d19b74c2278e40bb5",
+        "date": "18 Sep 2014"
+      },
+      {
+        "filename": "php-5.4.33.tar.gz",
+        "name": "PHP 5.4.33 (tar.gz)",
+        "sha256": "74e542dd2f15ebbc123738a71e867d57d2996a6edb40e6ac62fcf5ab85763d19",
+        "date": "18 Sep 2014"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.33 binaries and source"
+      }
+    ],
+    "date": "18 Sep 2014",
+    "museum": false
+  },
+  "5.4.32": {
+    "announcement": {
+      "English": "/releases/5_4_32.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.32.tar.bz2",
+        "name": "PHP 5.4.32 (tar.bz2)",
+        "date": "21 Aug 2014",
+        "sha256": "26d0717669a098f18cd22dc3ae8282101d38508054500c26775ddcc26ca7c826"
+      },
+      {
+        "filename": "php-5.4.32.tar.gz",
+        "name": "PHP 5.4.32 (tar.gz)",
+        "date": "21 Aug 2014",
+        "sha256": "80ebdf34f91b8e1d516080363804137177368777aa9ecffee600f2957e8b0f94"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.32 binaries and source"
+      }
+    ],
+    "date": "21 Aug 2014",
+    "museum": false
+  },
+  "5.4.31": {
+    "announcement": {
+      "English": "/releases/5_4_31.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.31.tar.bz2",
+        "name": "PHP 5.4.31 (tar.bz2)",
+        "date": "24 Jul 2014",
+        "sha256": "5e8e491431fd1d99df925d762b05da05c80b02cb38c9b3db616e8894a307914d"
+      },
+      {
+        "filename": "php-5.4.31.tar.gz",
+        "name": "PHP 5.4.31 (tar.gz)",
+        "date": "24 Jul 2014",
+        "sha256": "332f62e4f751482d40ad08544ee97e004170d0382c84d01ce8efe405d0972f66"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.31 binaries and source"
+      }
+    ],
+    "date": "24 Jul 2014",
+    "museum": false
+  },
+  "5.4.30": {
+    "announcement": {
+      "English": "/releases/5_4_30.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.30.tar.bz2",
+        "name": "PHP 5.4.30 (tar.bz2)",
+        "date": "26 Jun 2014",
+        "sha256": "32b83644e42d57388d6e5ec700c3502cde5f5e1207395b1e361e4cb2ce496ce6"
+      },
+      {
+        "filename": "php-5.4.30.tar.gz",
+        "name": "PHP 5.4.30 (tar.gz)",
+        "date": "26 Jun 2014",
+        "sha256": "c17da64890b728bdc146bdc69b37085412d4e2585fac98848ac2e824bb564c85"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.30 binaries and source"
+      }
+    ],
+    "date": "26 Jun 2014",
+    "museum": false
+  },
+  "5.4.29": {
+    "announcement": {
+      "English": "/releases/5_4_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.29.tar.bz2",
+        "name": "PHP 5.4.29 (tar.bz2)",
+        "date": "29 May 2014",
+        "sha256": "62ce3ca063cf04f6065eeac82117e43b44e20487bc0a0a8d05436e17a0b1e2a7"
+      },
+      {
+        "filename": "php-5.4.29.tar.gz",
+        "name": "PHP 5.4.29 (tar.gz)",
+        "date": "29 May 2014",
+        "sha256": "9fa51d3e44783802ea51b910719ad524a8994524f7cf7307f683fe89191bc401"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.29 binaries and source"
+      }
+    ],
+    "date": "29 May 2014",
+    "museum": false
+  },
+  "5.4.28": {
+    "announcement": {
+      "English": "/releases/5_4_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.28.tar.bz2",
+        "name": "PHP 5.4.28 (tar.bz2)",
+        "date": "2 May 2014",
+        "sha256": "3fe780e5179e90c4d37276e79acc0d0692f1bc0911985af694b92c664c0ef3c4"
+      },
+      {
+        "filename": "php-5.4.28.tar.gz",
+        "name": "PHP 5.4.28 (tar.gz)",
+        "date": "2 May 2014",
+        "sha256": "5140292c94a0301db7a807e6b3aadf6ee966346d0005aa3d15464bd4c595a786"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.28 binaries and source"
+      }
+    ],
+    "date": "2 May 2014",
+    "museum": false
+  },
+  "5.4.27": {
+    "announcement": {
+      "English": "/releases/5_4_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.27.tar.bz2",
+        "name": "PHP 5.4.27 (tar.bz2)",
+        "date": "3 Apr 2014",
+        "sha256": "09dcc44cded735e1cf1b1b9f2749d1a0fd90e03378b6a70364a662f4740e61e2"
+      },
+      {
+        "filename": "php-5.4.27.tar.gz",
+        "name": "PHP 5.4.27 (tar.gz)",
+        "date": "3 Apr 2014",
+        "sha256": "a70dc68eeed902f8378fded473d53e4e37be645b941554dcf4237559cbda2bb3"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.27 binaries and source"
+      }
+    ],
+    "date": "3 Apr 2014",
+    "museum": false
+  },
+  "5.4.26": {
+    "announcement": {
+      "English": "/releases/5_4_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.26.tar.bz2",
+        "name": "PHP 5.4.26 (tar.bz2)",
+        "date": "6 Mar 2014",
+        "sha256": "5053649317b9331df40bd836c976a32b31dbc5c5d68997d3ae01cb90db22d240"
+      },
+      {
+        "filename": "php-5.4.26.tar.gz",
+        "name": "PHP 5.4.26 (tar.gz)",
+        "date": "6 Mar 2014",
+        "sha256": "ec3f902b5e8cbdd660e01e784b537f1210a12182d9bbd62164776075bc097eca"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.26 binaries and source"
+      }
+    ],
+    "date": "6 Mar 2014",
+    "museum": false
+  },
+  "5.4.25": {
+    "announcement": {
+      "English": "/releases/5_4_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.25.tar.bz2",
+        "name": "PHP 5.4.25 (tar.bz2)",
+        "date": "6 Feb 2014",
+        "sha256": "b6c18c07c6bf34f75e601b28829d636e44c1c9f4267aac4ed013443c32a2245f"
+      },
+      {
+        "filename": "php-5.4.25.tar.gz",
+        "name": "PHP 5.4.25 (tar.gz)",
+        "date": "6 Feb 2014",
+        "sha256": "0c66cec73bfbd31f68c96e5a4d8454599271f0b0462c2ff7dedce4262fda8fe3"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.25 binaries and source"
+      }
+    ],
+    "date": "6 Feb 2014",
+    "museum": false
+  },
+  "5.4.24": {
+    "announcement": {
+      "English": "/releases/5_4_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.24.tar.bz2",
+        "name": "PHP 5.4.24 (tar.bz2)",
+        "date": "9 Jan 2014",
+        "sha256": "97fe70eddaf5b93969714a551870fe03f6b0a387f85b83a6d63a40a76199a327"
+      },
+      {
+        "filename": "php-5.4.24.tar.gz",
+        "name": "PHP 5.4.24 (tar.gz)",
+        "date": "9 Jan 2014",
+        "sha256": "c64d6e3b428e78b44760167557e26cd16a9f83f449a255e69d5e035bdd7057ed"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.24 binaries and source"
+      }
+    ],
+    "date": "9 Jan 2014",
+    "museum": false
+  },
+  "5.4.23": {
+    "announcement": {
+      "English": "/releases/5_4_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.23.tar.bz2",
+        "name": "PHP 5.4.23 (tar.bz2)",
+        "date": "12 Dec 2013",
+        "sha256": "ae7c070fa9b9e16413ef944d910b68f3ba79192eca4010b0af132b8631bd91cc"
+      },
+      {
+        "filename": "php-5.4.23.tar.gz",
+        "name": "PHP 5.4.23 (tar.gz)",
+        "date": "12 Dec 2013",
+        "sha256": "c9add0e59f41298a253bbb9090c47a03064b099120a563ca8ad289e18fcd1ce7"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.23 binaries and source"
+      }
+    ],
+    "date": "12 Dec 2013",
+    "museum": false
+  },
+  "5.4.22": {
+    "announcement": {
+      "English": "/releases/5_4_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.22.tar.bz2",
+        "name": "PHP 5.4.22 (tar.bz2)",
+        "date": "14 Nov 2013",
+        "sha256": "3b8619b030e372f2b64e3a059d05a3ef3354e81f8a72923ba45475bf222f7cca"
+      },
+      {
+        "filename": "php-5.4.22.tar.gz",
+        "name": "PHP 5.4.22 (tar.gz)",
+        "date": "14 Nov 2013",
+        "sha256": "ca6e52a0ba11e9521c6a26f293a602cdc00cad1adbb4658e35b8d3f41057cbb8"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.22 binaries and source"
+      }
+    ],
+    "date": "14 Nov 2013",
+    "museum": false
+  },
+  "5.4.21": {
+    "announcement": {
+      "English": "/releases/5_4_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.21.tar.bz2",
+        "name": "PHP 5.4.21 (tar.bz2)",
+        "md5": "3dcf021e89b039409d0b1c346b936b5f",
+        "date": "17 Oct 2013"
+      },
+      {
+        "filename": "php-5.4.21.tar.gz",
+        "name": "PHP 5.4.21 (tar.gz)",
+        "md5": "cc8da0d18683e3a83b332f264af7ca83",
+        "date": "17 Oct 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.21 binaries and source"
+      }
+    ],
+    "date": "17 Oct 2013",
+    "museum": true
+  },
+  "5.4.20": {
+    "announcement": {
+      "English": "/releases/5_4_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.20.tar.bz2",
+        "name": "PHP 5.4.20 (tar.bz2)",
+        "md5": "e25db5592ed14842b4239be9d990cce8",
+        "date": "19 Sep 2013"
+      },
+      {
+        "filename": "php-5.4.20.tar.gz",
+        "name": "PHP 5.4.20 (tar.gz)",
+        "md5": "e505b63ebe383ef9a378467216ba69d4",
+        "date": "19 Sep 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.20 binaries and source"
+      }
+    ],
+    "date": "19 Sep 2013",
+    "museum": true
+  },
+  "5.4.19": {
+    "announcement": {
+      "English": "/releases/5_4_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.19.tar.bz2",
+        "name": "PHP 5.4.19 (tar.bz2)",
+        "md5": "f06f99b9872b503758adab5ba7a7e755",
+        "date": "22 Aug 2013"
+      },
+      {
+        "filename": "php-5.4.19.tar.gz",
+        "name": "PHP 5.4.19 (tar.gz)",
+        "md5": "9e7ad2494ba3de519328f74267de8342",
+        "date": "22 Aug 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.19 binaries and source"
+      }
+    ],
+    "date": "22 Aug 2013",
+    "museum": true
+  },
+  "5.4.18": {
+    "announcement": {
+      "English": "/releases/5_4_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.18.tar.bz2",
+        "name": "PHP 5.4.18 (tar.bz2)",
+        "md5": "b2e185b46b22a48a385cf21a0dc76e65",
+        "date": "15 Aug 2013"
+      },
+      {
+        "filename": "php-5.4.18.tar.gz",
+        "name": "PHP 5.4.18 (tar.gz)",
+        "md5": "d0a3f55deceaec921f45f76d7b4e764b",
+        "date": "15 Aug 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.18 binaries and source"
+      }
+    ],
+    "date": "04 Jul 2013",
+    "museum": true
+  },
+  "5.4.17": {
+    "announcement": {
+      "English": "/releases/5_4_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.17.tar.bz2",
+        "name": "PHP 5.4.17 (tar.bz2)",
+        "md5": "1e027e99e2a874310fd518e87e3947af",
+        "date": "04 Jul 2013"
+      },
+      {
+        "filename": "php-5.4.17.tar.gz",
+        "name": "PHP 5.4.17 (tar.gz)",
+        "md5": "cc698032dcdcb9ad158edcc90fe798d6",
+        "date": "04 Jul 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.17 binaries and source"
+      }
+    ],
+    "date": "04 Jul 2013",
+    "museum": true
+  },
+  "5.4.16": {
+    "announcement": {
+      "English": "/releases/5_4_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.16.tar.bz2",
+        "name": "PHP 5.4.16 (tar.bz2)",
+        "md5": "3d2c694d28861d707b2622c3cc941cff",
+        "date": "06 Jun 2013"
+      },
+      {
+        "filename": "php-5.4.16.tar.gz",
+        "name": "PHP 5.4.16 (tar.gz)",
+        "md5": "3940a5295872964495f9c56596272d68",
+        "date": "06 Jun 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.16 binaries and source"
+      }
+    ],
+    "date": "09 May 2013",
+    "museum": true
+  },
+  "5.4.15": {
+    "announcement": {
+      "English": "/releases/5_4_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.15.tar.bz2",
+        "name": "PHP 5.4.15 (tar.bz2)",
+        "md5": "145ea5e845e910443ff1eddb3dbcf56a",
+        "date": "09 May 2013"
+      },
+      {
+        "filename": "php-5.4.15.tar.gz",
+        "name": "PHP 5.4.15 (tar.gz)",
+        "md5": "2651b983c18df9d455ec4c69aef45834",
+        "date": "09 May 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.15 binaries and source"
+      }
+    ],
+    "date": "09 May 2013",
+    "museum": true
+  },
+  "5.4.14": {
+    "announcement": {
+      "English": "/releases/5_4_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.14.tar.bz2",
+        "name": "PHP 5.4.14 (tar.bz2)",
+        "md5": "cfdc044be2c582991a1fe0967898fa38",
+        "date": "11 Apr 2013"
+      },
+      {
+        "filename": "php-5.4.14.tar.gz",
+        "name": "PHP 5.4.14 (tar.gz)",
+        "md5": "08df8196af12bc850409a7bff13bf8f0",
+        "date": "11 Apr 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.14 binaries and source"
+      }
+    ],
+    "date": "11 Apr 2013",
+    "museum": true
+  },
+  "5.4.13": {
+    "announcement": {
+      "English": "/releases/5_4_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.13.tar.bz2",
+        "name": "PHP 5.4.13 (tar.bz2)",
+        "md5": "cacd308e978b7cf9ba4993196612ccf7",
+        "date": "14 Mar 2013"
+      },
+      {
+        "filename": "php-5.4.13.tar.gz",
+        "name": "PHP 5.4.13 (tar.gz)",
+        "md5": "445025340677d5bfe22eb670d6db6795",
+        "date": "14 Mar 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.13 binaries and source"
+      }
+    ],
+    "date": "14 Mar 2013",
+    "museum": true
+  },
+  "5.4.12": {
+    "announcement": {
+      "English": "/releases/5_4_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.12.tar.bz2",
+        "name": "PHP 5.4.12 (tar.bz2)",
+        "md5": "5c7b614242ae12e9cacca21c8ab84818",
+        "date": "21 Feb 2013"
+      },
+      {
+        "filename": "php-5.4.12.tar.gz",
+        "name": "PHP 5.4.12 (tar.gz)",
+        "md5": "81b20cac4f977b8764ae904302048d84",
+        "date": "21 Feb 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.12 binaries and source"
+      }
+    ],
+    "date": "21 Feb 2013",
+    "museum": true
+  },
+  "5.4.11": {
+    "announcement": {
+      "English": "/releases/5_4_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.11.tar.bz2",
+        "name": "PHP 5.4.11 (tar.bz2)",
+        "md5": "9975e68c22b86b013b934743ad2d2276",
+        "date": "17 Jan 2013"
+      },
+      {
+        "filename": "php-5.4.11.tar.gz",
+        "name": "PHP 5.4.11 (tar.gz)",
+        "md5": "32fa16b3abd5527316c3c076b3395914",
+        "date": "17 Jan 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.11 binaries and source"
+      }
+    ],
+    "date": "17 Jan 2013",
+    "museum": true
+  },
+  "5.4.10": {
+    "announcement": {
+      "English": "/releases/5_4_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.10.tar.bz2",
+        "name": "PHP 5.4.10 (tar.bz2)",
+        "md5": "cb716b657a30570b9b468b9e7bc551a1",
+        "date": "20 Dec 2012"
+      },
+      {
+        "filename": "php-5.4.10.tar.gz",
+        "name": "PHP 5.4.10 (tar.gz)",
+        "md5": "1e7fbe418658d5433bd315030584c45c",
+        "date": "20 Dec 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.10 binaries and source"
+      }
+    ],
+    "date": "20 Dec 2012",
+    "museum": true
+  },
+  "5.4.9": {
+    "announcement": {
+      "English": "/releases/5_4_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.9.tar.bz2",
+        "name": "PHP 5.4.9 (tar.bz2)",
+        "md5": "076a9f84d861d3f664a2878d5773ba78",
+        "date": "22 Nov 2012"
+      },
+      {
+        "filename": "php-5.4.9.tar.gz",
+        "name": "PHP 5.4.9 (tar.gz)",
+        "md5": "e1ac28e1cf20738f0aeeba8261aa4537",
+        "date": "22 Nov 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.9 binaries and source"
+      }
+    ],
+    "date": "22 Nov 2012",
+    "museum": true
+  },
+  "5.4.8": {
+    "announcement": {
+      "English": "/releases/5_4_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.8.tar.bz2",
+        "name": "PHP 5.4.8 (tar.bz2)",
+        "md5": "bb8c816a9299be8995255ef70c63b800",
+        "date": "18 Oct 2012"
+      },
+      {
+        "filename": "php-5.4.8.tar.gz",
+        "name": "PHP 5.4.8 (tar.gz)",
+        "md5": "b25b735f342efbfdcdaf00b83189f183",
+        "date": "18 Oct 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.8 binaries and source"
+      }
+    ],
+    "date": "18 Oct 2012",
+    "museum": true
+  },
+  "5.4.7": {
+    "announcement": {
+      "English": "/releases/5_4_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.7.tar.bz2",
+        "name": "PHP 5.4.7 (tar.bz2)",
+        "md5": "9cd421f1cc8fa8e7f215e44a1b06199f",
+        "date": "13 Sep 2012"
+      },
+      {
+        "filename": "php-5.4.7.tar.gz",
+        "name": "PHP 5.4.7 (tar.gz)",
+        "md5": "94661b761dcfdfdd5108e8b12e0dd4f8",
+        "date": "13 Sep 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.7 binaries and source"
+      }
+    ],
+    "date": "13 Sep 2012",
+    "museum": true
+  },
+  "5.4.6": {
+    "announcement": {
+      "English": "/releases/5_4_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.6.tar.bz2",
+        "name": "PHP 5.4.6 (tar.bz2)",
+        "md5": "c9aa0f4996d1b91ee9e45afcfaeb5d2e",
+        "date": "16 Aug 2012"
+      },
+      {
+        "filename": "php-5.4.6.tar.gz",
+        "name": "PHP 5.4.6 (tar.gz)",
+        "md5": "efe59afb73190c9bd6d50614998ffceb",
+        "date": "16 Aug 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.6 binaries and source"
+      }
+    ],
+    "date": "16 Aug 2012",
+    "museum": true
+  },
+  "5.4.5": {
+    "announcement": {
+      "English": "/releases/5_4_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.5.tar.bz2",
+        "name": "PHP 5.4.5 (tar.bz2)",
+        "md5": "ffcc7f4dcf2b79d667fe0c110e6cb724",
+        "date": "19 July 2012"
+      },
+      {
+        "filename": "php-5.4.5.tar.gz",
+        "name": "PHP 5.4.5 (tar.gz)",
+        "md5": "51fb5bf974d92359f0606dffc810735a",
+        "date": "19 July 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.5 binaries and source"
+      }
+    ],
+    "date": "19 July 2012",
+    "museum": true
+  },
+  "5.4.4": {
+    "announcement": {
+      "English": "/releases/5_4_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.4.tar.bz2",
+        "name": "PHP 5.4.4 (tar.bz2)",
+        "md5": "1fd98dc3f6f3805cd67bff12a26ed77f",
+        "date": "14 June 2012"
+      },
+      {
+        "filename": "php-5.4.4.tar.gz",
+        "name": "PHP 5.4.4 (tar.gz)",
+        "md5": "8366c3626f2275ab8c7ef5e2d6bc5bd7",
+        "date": "14 June 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.4.4 binaries and source"
+      }
+    ],
+    "date": "14 June 2012",
+    "museum": true
+  },
+  "5.4.3": {
+    "announcement": {
+      "English": "/releases/5_4_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.3.tar.bz2",
+        "name": "PHP 5.4.3 (tar.bz2)",
+        "md5": "51f9488bf8682399b802c48656315cac",
+        "date": "08 May 2012"
+      },
+      {
+        "filename": "php-5.4.3.tar.gz",
+        "name": "PHP 5.4.3 (tar.gz)",
+        "md5": "c9dccc89cc89d39e84f6e6f0cf1c8a65",
+        "date": "08 May 2012"
+      }
+    ],
+    "date": "08 May 2012",
+    "museum": true
+  },
+  "5.4.2": {
+    "announcement": {
+      "English": "/releases/5_4_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.2.tar.bz2",
+        "name": "PHP 5.4.2 (tar.bz2)",
+        "md5": "252a6546db3a26260b419a883c875615",
+        "date": "03 May 2012"
+      },
+      {
+        "filename": "php-5.4.2.tar.gz",
+        "name": "PHP 5.4.2 (tar.gz)",
+        "md5": "4b62935cbea385a23335f17d64d716c7",
+        "date": "03 May 2012"
+      }
+    ],
+    "date": "03 May 2012",
+    "museum": true
+  },
+  "5.4.1": {
+    "announcement": {
+      "English": "/releases/5_4_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.1.tar.bz2",
+        "name": "PHP 5.4.1 (tar.bz2)",
+        "md5": "5b9529ed89dbc48c498e9693d1af3caf",
+        "date": "26 April 2012"
+      },
+      {
+        "filename": "php-5.4.1.tar.gz",
+        "name": "PHP 5.4.1 (tar.gz)",
+        "md5": "acd566dbd70f855c19d17fc3c0e876a2",
+        "date": "26 April 2012"
+      }
+    ],
+    "date": "26 April 2012",
+    "museum": true
+  },
+  "5.4.0": {
+    "announcement": {
+      "English": "/releases/5_4_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.4.0.tar.bz2",
+        "name": "PHP 5.4.0 (tar.bz2)",
+        "md5": "04bb6f9d71ea86ba05685439d50db074",
+        "date": "01 March 2012"
+      },
+      {
+        "filename": "php-5.4.0.tar.gz",
+        "name": "PHP 5.4.0 (tar.gz)",
+        "md5": "46b72e274c6ea7e775245ffdb81c9ce5",
+        "date": "01 March 2012"
+      }
+    ],
+    "date": "01 March 2012",
+    "museum": true
+  },
+  "5.3.29": {
+    "announcement": {
+      "English": "/releases/5_3_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.29.tar.bz2",
+        "name": "PHP 5.3.29 (tar.bz2)",
+        "date": "14 Aug 2014",
+        "sha256": "c4e1cf6972b2a9c7f2777a18497d83bf713cdbecabb65d3ff62ba441aebb0091"
+      },
+      {
+        "filename": "php-5.3.29.tar.gz",
+        "name": "PHP 5.3.29 (tar.gz)",
+        "date": "14 Aug 2014",
+        "sha256": "57cf097de3d6c3152dda342f62b1b2e9c988f4cfe300ccfe3c11f3c207a0e317"
+      },
+      {
+        "filename": "php-5.3.29.tar.xz",
+        "name": "PHP 5.3.29 (tar.xz)",
+        "date": "14 Aug 2014",
+        "sha256": "8438c2f14ab8f3d6cd2495aa37de7b559e33b610f9ab264f0c61b531bf0c262d"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.29 binaries and source"
+      }
+    ],
+    "date": "14 Aug 2014",
+    "museum": false
+  },
+  "5.3.28": {
+    "announcement": {
+      "English": "/releases/5_3_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.28.tar.bz2",
+        "name": "PHP 5.3.28 (tar.bz2)",
+        "date": "12 Dec 2013",
+        "sha256": "0cac960c651c4fbb3d21cf2f2b279a06e21948fb35a0d1439b97296cac1d8513"
+      },
+      {
+        "filename": "php-5.3.28.tar.gz",
+        "name": "PHP 5.3.28 (tar.gz)",
+        "date": "12 Dec 2013",
+        "sha256": "ace8fde82a4275d6dcec4e15feb047416e1813fea46e159dfd113298371396d0"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.28 binaries and source"
+      }
+    ],
+    "date": "11 Jul 2013",
+    "museum": false
+  },
+  "5.3.27": {
+    "announcement": {
+      "English": "/releases/5_3_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.27.tar.bz2",
+        "name": "PHP 5.3.27 (tar.bz2)",
+        "date": "11 Jul 2013",
+        "sha256": "e12db21c623b82a2244c4dd9b06bb75af20868c1b748a105a6829a5acc36b287"
+      },
+      {
+        "filename": "php-5.3.27.tar.gz",
+        "name": "PHP 5.3.27 (tar.gz)",
+        "date": "11 Jul 2013",
+        "sha256": "5ecd737fc79ad33b5c79a9784c0b4211d211ba682d4d721ac6ce975907a5b12b"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.27 binaries and source"
+      }
+    ],
+    "date": "11 Jul 2013",
+    "museum": false
+  },
+  "5.3.26": {
+    "announcement": {
+      "English": "/releases/5_3_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.26.tar.bz2",
+        "name": "PHP 5.3.26 (tar.bz2)",
+        "md5": "d71db8d92edbb48beb5b645b55471139",
+        "date": "06 Jun 2013"
+      },
+      {
+        "filename": "php-5.3.26.tar.gz",
+        "name": "PHP 5.3.26 (tar.gz)",
+        "md5": "a430a48b8939fe1f8915ee38681b0afa",
+        "date": "06 Jun 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.26 binaries and source"
+      }
+    ],
+    "date": "06 Jun 2013",
+    "museum": true
+  },
+  "5.3.25": {
+    "announcement": {
+      "English": "/releases/5_3_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.25.tar.bz2",
+        "name": "PHP 5.3.25 (tar.bz2)",
+        "md5": "d71db8d92edbb48beb5b645b55471139",
+        "date": "09 May 2013"
+      },
+      {
+        "filename": "php-5.3.25.tar.gz",
+        "name": "PHP 5.3.25 (tar.gz)",
+        "md5": "a430a48b8939fe1f8915ee38681b0afa",
+        "date": "09 May 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.25 binaries and source"
+      }
+    ],
+    "date": "09 May 2013",
+    "museum": true
+  },
+  "5.3.24": {
+    "announcement": {
+      "English": "/releases/5_3_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.24.tar.bz2",
+        "name": "PHP 5.3.24 (tar.bz2)",
+        "md5": "9820604df98c648297dcd31ffb8214e8",
+        "date": "11 Apr 2013"
+      },
+      {
+        "filename": "php-5.3.24.tar.gz",
+        "name": "PHP 5.3.24 (tar.gz)",
+        "md5": "cb0311a6a5ed6ffff8f41f713f9d8e84",
+        "date": "11 Apr 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.24 binaries and source"
+      }
+    ],
+    "date": "11 Apr 2013",
+    "museum": true
+  },
+  "5.3.23": {
+    "announcement": {
+      "English": "/releases/5_3_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.23.tar.bz2",
+        "name": "PHP 5.3.23 (tar.bz2)",
+        "md5": "ab7bd1dd3bbc8364cb9fcaa2d79fb502",
+        "date": "14 Mar 2013"
+      },
+      {
+        "filename": "php-5.3.23.tar.gz",
+        "name": "PHP 5.3.23 (tar.gz)",
+        "md5": "9cd92b0de2b51dcd372f46fa623984f4",
+        "date": "14 Mar 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.23 binaries and source"
+      }
+    ],
+    "date": "14 Mar 2013",
+    "museum": true
+  },
+  "5.3.22": {
+    "announcement": {
+      "English": "/releases/5_3_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.22.tar.bz2",
+        "name": "PHP 5.3.22 (tar.bz2)",
+        "md5": "bf351426fc7f97aa13914062958a6100",
+        "date": "21 Feb 2013"
+      },
+      {
+        "filename": "php-5.3.22.tar.gz",
+        "name": "PHP 5.3.22 (tar.gz)",
+        "md5": "5008d8e70195d933e30bfbae3651b4ed",
+        "date": "21 Feb 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.22 binaries and source"
+      }
+    ],
+    "date": "21 Feb 2013",
+    "museum": true
+  },
+  "5.3.21": {
+    "announcement": {
+      "English": "/releases/5_3_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.21.tar.bz2",
+        "name": "PHP 5.3.21 (tar.bz2)",
+        "md5": "1b214fc19bb5f5c0902ba27c74d5f4a2",
+        "date": "17 Jan 2013"
+      },
+      {
+        "filename": "php-5.3.21.tar.gz",
+        "name": "PHP 5.3.21 (tar.gz)",
+        "md5": "f47fbe3407520e5d9d895168950aa683",
+        "date": "17 Jan 2013"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.21 binaries and source"
+      }
+    ],
+    "date": "17 Jan 2013",
+    "museum": true
+  },
+  "5.3.20": {
+    "announcement": {
+      "English": "/releases/5_3_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.20.tar.bz2",
+        "name": "PHP 5.3.20 (tar.bz2)",
+        "md5": "00241b9e89e93adf3baac32c56211e4e",
+        "date": "20 Dec 2012"
+      },
+      {
+        "filename": "php-5.3.20.tar.gz",
+        "name": "PHP 5.3.20 (tar.gz)",
+        "md5": "1e202851bf2ba1ee96d7dc5b48944119",
+        "date": "20 Dec 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.20 binaries and source"
+      }
+    ],
+    "date": "20 Dec 2012",
+    "museum": true
+  },
+  "5.3.19": {
+    "announcement": {
+      "English": "/releases/5_3_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.19.tar.bz2",
+        "name": "PHP 5.3.19 (tar.bz2)",
+        "md5": "e1d2a3ec7849d4b3032bd1abf1916aa4",
+        "date": "22 Nov 2012"
+      },
+      {
+        "filename": "php-5.3.19.tar.gz",
+        "name": "PHP 5.3.19 (tar.gz)",
+        "md5": "e1bcda4f14bb39ba041297abbf18f8d1",
+        "date": "22 Nov 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.4",
+        "name": "Windows 5.3.19 binaries and source"
+      }
+    ],
+    "date": "22 Nov 2012",
+    "museum": true
+  },
+  "5.3.18": {
+    "announcement": {
+      "English": "/releases/5_3_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.18.tar.bz2",
+        "name": "PHP 5.3.18 (tar.bz2)",
+        "md5": "52539c19d0f261560af3c030143dfa8f",
+        "date": "18 Oct 2012"
+      },
+      {
+        "filename": "php-5.3.18.tar.gz",
+        "name": "PHP 5.3.18 (tar.gz)",
+        "md5": "ff2009aadc7c4d1444f6cd8e45f39a41",
+        "date": "18 Oct 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.18 binaries and source"
+      }
+    ],
+    "date": "18 Oct 2012",
+    "museum": true
+  },
+  "5.3.17": {
+    "announcement": {
+      "English": "/releases/5_3_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.17.tar.bz2",
+        "name": "PHP 5.3.17 (tar.bz2)",
+        "md5": "29ee79c941ee85d6c1555c176f12f7ef",
+        "date": "13 Sep 2012"
+      },
+      {
+        "filename": "php-5.3.17.tar.gz",
+        "name": "PHP 5.3.17 (tar.gz)",
+        "md5": "002e02e36c2cbcada8c49a7e5956d787",
+        "date": "13 Sep 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.17 binaries and source"
+      }
+    ],
+    "date": "13 Sep 2012",
+    "museum": true
+  },
+  "5.3.16": {
+    "announcement": {
+      "English": "/releases/5_3_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.16.tar.bz2",
+        "name": "PHP 5.3.16 (tar.bz2)",
+        "md5": "99cfd78531643027f60c900e792d21be",
+        "date": "16 Aug 2012"
+      },
+      {
+        "filename": "php-5.3.16.tar.gz",
+        "name": "PHP 5.3.16 (tar.gz)",
+        "md5": "59b776edeac2897ebe3712dcc94b6706",
+        "date": "16 Aug 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.16 binaries and source"
+      }
+    ],
+    "date": "16 Aug 2012",
+    "museum": true
+  },
+  "5.3.15": {
+    "announcement": {
+      "English": "/releases/5_3_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.15.tar.bz2",
+        "name": "PHP 5.3.15 (tar.bz2)",
+        "md5": "5cfcfd0fa4c4da7576f397073e7993cc",
+        "date": "19 July 2012"
+      },
+      {
+        "filename": "php-5.3.15.tar.gz",
+        "name": "PHP 5.3.15 (tar.gz)",
+        "md5": "7c885c79a611b89f3a1095fce6eae5c6",
+        "date": "19 July 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.15 binaries and source"
+      }
+    ],
+    "date": "19 July 2012",
+    "museum": true
+  },
+  "5.3.14": {
+    "announcement": {
+      "English": "/releases/5_3_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.14.tar.bz2",
+        "name": "PHP 5.3.14 (tar.bz2)",
+        "md5": "370be99c5cdc2e756c82c44d774933c8",
+        "date": "14 June 2012"
+      },
+      {
+        "filename": "php-5.3.14.tar.gz",
+        "name": "PHP 5.3.14 (tar.gz)",
+        "md5": "148730865242a031a638ee3bab4a9d4d",
+        "date": "14 June 2012"
+      },
+      {
+        "link": "http://windows.php.net/download/#php-5.3",
+        "name": "Windows 5.3.14 binaries and source"
+      }
+    ],
+    "date": "14 June 2012",
+    "museum": true
+  },
+  "5.3.13": {
+    "announcement": {
+      "English": "/releases/5_3_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.13.tar.bz2",
+        "name": "PHP 5.3.13 (tar.bz2)",
+        "md5": "370be99c5cdc2e756c82c44d774933c8",
+        "date": "08 May 2012"
+      },
+      {
+        "filename": "php-5.3.13.tar.gz",
+        "name": "PHP 5.3.13 (tar.gz)",
+        "md5": "179c67ce347680f468edbfc3c425476a",
+        "date": "08 May 2012"
+      }
+    ],
+    "date": "08 May 2012",
+    "museum": true
+  },
+  "5.3.12": {
+    "announcement": {
+      "English": "/releases/5_3_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.12.tar.bz2",
+        "name": "PHP 5.3.12 (tar.bz2)",
+        "md5": "cf02c29be279c506cbd4ffc2819d7c82",
+        "date": "03 May 2012"
+      },
+      {
+        "filename": "php-5.3.12.tar.gz",
+        "name": "PHP 5.3.12 (tar.gz)",
+        "md5": "aac80e478eb0785c50855ae8cefe735a",
+        "date": "03 May 2012"
+      }
+    ],
+    "date": "03 May 2012",
+    "museum": true
+  },
+  "5.3.11": {
+    "announcement": {
+      "English": "/releases/5_3_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.11.tar.bz2",
+        "name": "PHP 5.3.11 (tar.bz2)",
+        "md5": "5b9529ed89dbc48c498e9693d1af3caf",
+        "date": "26 April 2012"
+      },
+      {
+        "filename": "php-5.3.11.tar.gz",
+        "name": "PHP 5.3.11 (tar.gz)",
+        "md5": "acd566dbd70f855c19d17fc3c0e876a2",
+        "date": "26 April 2012"
+      }
+    ],
+    "date": "26 April 2012",
+    "museum": true
+  },
+  "5.3.10": {
+    "announcement": {
+      "English": "/releases/5_3_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.10.tar.bz2",
+        "name": "PHP 5.3.10 (tar.bz2)",
+        "md5": "816259e5ca7d0a7e943e56a3bb32b17f",
+        "date": "02 February 2012"
+      },
+      {
+        "filename": "php-5.3.10.tar.gz",
+        "name": "PHP 5.3.10 (tar.gz)",
+        "md5": "2b3d2d0ff22175685978fb6a5cbcdc13",
+        "date": "02 February 2012"
+      }
+    ],
+    "date": "02 February 2012",
+    "museum": true
+  },
+  "5.3.9": {
+    "announcement": {
+      "English": "/releases/5_3_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.9.tar.bz2",
+        "name": "PHP 5.3.9 (tar.bz2)",
+        "md5": "dd3288ed5c08cd61ac5bf619cb357521",
+        "date": "10 January 2012"
+      },
+      {
+        "filename": "php-5.3.9.tar.gz",
+        "name": "PHP 5.3.9 (tar.gz)",
+        "md5": "c79e374c61423beb64a69da1eb5526b7",
+        "date": "10 January 2012"
+      }
+    ],
+    "date": "10 January 2012",
+    "museum": true
+  },
+  "5.3.8": {
+    "announcement": {
+      "English": "/releases/5_3_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.8.tar.bz2",
+        "name": "PHP 5.3.8 (tar.bz2)",
+        "md5": "704cd414a0565d905e1074ffdc1fadfb",
+        "date": "23 August 2011"
+      },
+      {
+        "filename": "php-5.3.8.tar.gz",
+        "name": "PHP 5.3.8 (tar.gz)",
+        "md5": "f4ce40d5d156ca66a996dbb8a0e7666a",
+        "date": "23 August 2011"
+      }
+    ],
+    "date": "23 August 2011",
+    "museum": true
+  },
+  "5.3.7": {
+    "announcement": {
+      "English": "/releases/5_3_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.7.tar.bz2",
+        "name": "PHP 5.3.7 (tar.bz2)",
+        "md5": "2d47d003c96de4e88863ff38da61af33",
+        "date": "18 August 2011"
+      },
+      {
+        "filename": "php-5.3.7.tar.gz",
+        "name": "PHP 5.3.7 (tar.gz)",
+        "md5": "1ec460bf3a40cea4079ee80076558d51",
+        "date": "18 August 2011"
+      }
+    ],
+    "date": "18 August 2011",
+    "museum": true
+  },
+  "5.3.6": {
+    "announcement": {
+      "English": "/releases/5_3_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.6.tar.bz2",
+        "name": "PHP 5.3.6 (tar.bz2)",
+        "md5": "2286f5a82a6e8397955a0025c1c2ad98",
+        "date": "19 March 2011"
+      },
+      {
+        "filename": "php-5.3.6.tar.gz",
+        "name": "PHP 5.3.6 (tar.gz)",
+        "md5": "88a2b00047bc53afbbbdf10ebe28a57e",
+        "date": "19 March 2011"
+      }
+    ],
+    "date": "19 March 2011",
+    "museum": true
+  },
+  "5.3.5": {
+    "announcement": {
+      "English": "/releases/5_3_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.5.tar.bz2",
+        "name": "PHP 5.3.5 (tar.bz2)",
+        "md5": "8aaf20c95e91f25c5b6a591e5d6d61b9",
+        "date": "06 January 2011"
+      },
+      {
+        "filename": "php-5.3.5.tar.gz",
+        "name": "PHP 5.3.5 (tar.gz)",
+        "md5": "fb727a3ac72bf0ce37e1a20468a7bb81",
+        "date": "06 January 2011"
+      }
+    ],
+    "date": "06 January 2011",
+    "museum": true
+  },
+  "5.3.4": {
+    "announcement": {
+      "English": "/releases/5_3_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.4.tar.bz2",
+        "name": "PHP 5.3.4 (tar.bz2)",
+        "md5": "2c069d8f690933e3bf6a8741ed818150",
+        "date": "09 December 2010"
+      },
+      {
+        "filename": "php-5.3.4.tar.gz",
+        "name": "PHP 5.3.4 (tar.gz)",
+        "md5": "b69b36132899c5ca3bf155efa0218676",
+        "date": "09 December 2010"
+      }
+    ],
+    "date": "09 December 2010",
+    "museum": true
+  },
+  "5.2.17": {
+    "announcement": {
+      "English": "/releases/5_2_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.17.tar.bz2",
+        "name": "PHP 5.2.17 (tar.bz2)",
+        "md5": "b27947f3045220faf16e4d9158cbfe13",
+        "date": "06 January 2011"
+      },
+      {
+        "filename": "php-5.2.17.tar.gz",
+        "name": "PHP 5.2.17 (tar.gz)",
+        "md5": "04d321d5aeb9d3a051233dbd24220ef1",
+        "date": "06 January 2011"
+      }
+    ],
+    "date": "06 January 2011",
+    "museum": true
+  },
+  "5.2.16": {
+    "announcement": {
+      "English": "/releases/5_2_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.16.tar.bz2",
+        "name": "PHP 5.2.16 (tar.bz2)",
+        "md5": "3b0bd012bd53bac9a5fefca61eccd5c6",
+        "date": "16 December 2010"
+      },
+      {
+        "filename": "php-5.2.16.tar.gz",
+        "name": "PHP 5.2.16 (tar.gz)",
+        "md5": "68f2c92b5b33d131b1ea70ece9fc40ad",
+        "date": "16 December 2010"
+      }
+    ],
+    "date": "16 December 2010",
+    "museum": true
+  },
+  "5.2.15": {
+    "announcement": {
+      "English": "/releases/5_2_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.15.tar.bz2",
+        "name": "PHP 5.2.15 (tar.bz2)",
+        "md5": "d4ccad187b12835024980a0cea362893",
+        "date": "09 December 2010"
+      },
+      {
+        "filename": "php-5.2.15.tar.gz",
+        "name": "PHP 5.2.15 (tar.gz)",
+        "md5": "dbbb2beed6b51e05d134744f137091a9",
+        "date": "09 December 2010"
+      }
+    ],
+    "date": "09 December 2010",
+    "museum": true
+  },
+  "5.3.3": {
+    "announcement": {
+      "English": "/releases/5_3_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.3.tar.bz2",
+        "name": "PHP 5.3.3 (tar.bz2)",
+        "md5": "21ceeeb232813c10283a5ca1b4c87b48",
+        "date": "22 July 2010"
+      },
+      {
+        "filename": "php-5.3.3.tar.gz",
+        "name": "PHP 5.3.3 (tar.gz)",
+        "md5": "5adf1a537895c2ec933fddd48e78d8a2",
+        "date": "22 July 2010"
+      }
+    ],
+    "date": "22 July 2010",
+    "museum": true
+  },
+  "5.2.14": {
+    "announcement": {
+      "English": "/releases/5_2_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.14.tar.bz2",
+        "name": "PHP 5.2.14 (tar.bz2)",
+        "md5": "21ceeeb232813c10283a5ca1b4c87b48",
+        "date": "22 July 2010"
+      },
+      {
+        "filename": "php-5.2.14.tar.gz",
+        "name": "PHP 5.2.14 (tar.gz)",
+        "md5": "5adf1a537895c2ec933fddd48e78d8a2",
+        "date": "22 July 2010"
+      }
+    ],
+    "date": "22 July 2010",
+    "museum": true
+  },
+  "5.3.2": {
+    "announcement": {
+      "English": "/releases/5_3_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.2.tar.bz2",
+        "name": "PHP 5.3.2 (tar.bz2)",
+        "md5": "46f500816125202c48a458d0133254a4",
+        "date": "04 Mar 2010"
+      },
+      {
+        "filename": "php-5.3.2.tar.gz",
+        "name": "PHP 5.3.2 (tar.gz)",
+        "md5": "4480d7c6d6b4a86de7b8ec8f0c2d1871",
+        "date": "04 Mar 2010"
+      }
+    ],
+    "date": "04 Mar 2010",
+    "museum": true
+  },
+  "5.2.13": {
+    "announcement": {
+      "English": "/releases/5_2_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.13.tar.bz2",
+        "name": "PHP 5.2.13 (tar.bz2)",
+        "md5": "eb4d0766dc4fb9667f05a68b6041e7d1",
+        "date": "25 Feb 2010"
+      },
+      {
+        "filename": "php-5.2.13.tar.gz",
+        "name": "PHP 5.2.13 (tar.gz)",
+        "md5": "cdf95cdc1ebccccce9c96653fd593dd4",
+        "date": "25 Feb 2010"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.13-Win32.zip",
+        "name": "PHP 5.2.13 zip package",
+        "md5": "3074bad887d613acf992ebdfea0e4465",
+        "date": "25 Feb 2010",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.13-win32-installer.msi",
+        "name": "PHP 5.2.13 installer",
+        "md5": "891e3262428851ebe71d5432a97be6d5",
+        "date": "25 Feb 2010",
+        "note": ""
+      },
+      {
+        "filename": "php-debug-pack-5.2.13-Win32.zip",
+        "name": "PHP 5.2.13 Win32 Debug Pack",
+        "md5": "e3382d5acbb527d21b768766f563a75d",
+        "date": "25 Feb 2010"
+      },
+      {
+        "filename": "php-5.2.13-nts-Win32.zip",
+        "name": "PHP 5.2.13 Non-thread-safe zip package",
+        "md5": "a7bd052e7a1413b743c07ae37171980d",
+        "date": "25 Feb 2010",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.13-nts-win32-installer.msi",
+        "name": "PHP 5.2.13 Non-thread-safe installer",
+        "md5": "d0e502db99565afde77b4f58f13fbad2",
+        "date": "25 Feb 2010"
+      },
+      {
+        "filename": "php-debug-pack-5.2.13-nts-Win32.zip",
+        "name": "PHP 5.2.13 Non-thread-safe Win32 Debug Pack",
+        "md5": "3693478973cd41752e2c0a1c3cddb997",
+        "date": "25 Feb 2010"
+      }
+    ],
+    "date": "25 Feb 2010",
+    "museum": true
+  },
+  "5.3.1": {
+    "announcement": {
+      "English": "/releases/5_3_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.1.tar.bz2",
+        "name": "PHP 5.3.1 (tar.bz2)",
+        "md5": "63e97ad450f0f7259e785100b634c797",
+        "date": "19 Nov 2009"
+      },
+      {
+        "filename": "php-5.3.1.tar.gz",
+        "name": "PHP 5.3.1 (tar.gz)",
+        "md5": "41fbb368d86acb13fc3519657d277681",
+        "date": "19 Nov 2009"
+      }
+    ],
+    "date": "19 Nov 2009",
+    "museum": true
+  },
+  "5.2.12": {
+    "announcement": {
+      "English": "/releases/5_2_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.12.tar.bz2",
+        "name": "PHP 5.2.12 (tar.bz2)",
+        "md5": "5b7077e366c7eeab34da31dd860a1923",
+        "date": "17 December 2009"
+      },
+      {
+        "filename": "php-5.2.12.tar.gz",
+        "name": "PHP 5.2.12 (tar.gz)",
+        "md5": "e6d6cc6570c77f60d8d4c99565d42ffd",
+        "date": "17 December 2009"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.12-Win32.zip",
+        "name": "PHP 5.2.12 zip package",
+        "md5": "e04f2944175dc19d7d007b5e889690b4",
+        "date": "17 December 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.12-win32-installer.msi",
+        "name": "PHP 5.2.12 installer",
+        "md5": "df73529935bb855842e38afda8a295d7",
+        "date": "17 December 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-debug-pack-5.2.12-Win32.zip",
+        "name": "PHP 5.2.12 Win32 Debug Pack",
+        "md5": "b21a5abb9e5bae4c657d0983986c4434",
+        "date": "17 December 2009"
+      },
+      {
+        "filename": "php-5.2.12-nts-Win32.zip",
+        "name": "PHP 5.2.12 Non-thread-safe zip package",
+        "md5": "ff0c67bb622c062f0820598e8d6bc12c",
+        "date": "17 December 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.12-nts-win32-installer.msi",
+        "name": "PHP 5.2.12 Non-thread-safe installer",
+        "md5": "418656307a52c99f2175c748da31a9d8",
+        "date": "17 December 2009"
+      },
+      {
+        "filename": "php-debug-pack-5.2.12-nts-Win32.zip",
+        "name": "PHP 5.2.12 Non-thread-safe Win32 Debug Pack",
+        "md5": "e2620df81442ddefc0c3450be58540f9",
+        "date": "17 December 2009"
+      }
+    ],
+    "date": "17 December 2009",
+    "museum": true
+  },
+  "5.2.11": {
+    "announcement": {
+      "English": "/releases/5_2_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.11.tar.bz2",
+        "name": "PHP 5.2.11 (tar.bz2)",
+        "md5": "286bf34630f5643c25ebcedfec5e0a09",
+        "date": "17 September 2009"
+      },
+      {
+        "filename": "php-5.2.11.tar.gz",
+        "name": "PHP 5.2.11 (tar.gz)",
+        "md5": "0223d71f0d6987c06c54b7557ff47f1d",
+        "date": "17 September 2009"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.11-Win32.zip",
+        "name": "PHP 5.2.11 zip package",
+        "md5": "adac50ae1449b76f10ff1865bb4f94f1",
+        "date": "17 September 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.11-win32-installer.msi",
+        "name": "PHP 5.2.11 installer",
+        "md5": "3cedc71fc90f88239d629cdb735d87c0",
+        "date": "17 September 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-debug-pack-5.2.11-Win32.zip",
+        "name": "PHP 5.2.11 Win32 Debug Pack",
+        "md5": "38cb1b783dd08dff41f445b582d2ffed",
+        "date": "17 September 2009"
+      },
+      {
+        "filename": "php-5.2.11-nts-Win32.zip",
+        "name": "PHP 5.2.11 Non-thread-safe zip package",
+        "md5": "b724475450a13af4cd99c518fd495340",
+        "date": "17 September 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.11-nts-win32-installer.msi",
+        "name": "PHP 5.2.11 Non-thread-safe installer",
+        "md5": "4fe1344093e26c2a51a82094bac131ad",
+        "date": "17 September 2009"
+      },
+      {
+        "filename": "php-debug-pack-5.2.11-nts-Win32.zip",
+        "name": "PHP 5.2.11 Non-thread-safe Win32 Debug Pack",
+        "md5": "19d026d6e4322dc64694010ae254e978",
+        "date": "17 September 2009"
+      }
+    ],
+    "date": "17 September 2009",
+    "museum": true
+  },
+  "5.3.0": {
+    "announcement": {
+      "English": "/releases/5_3_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.3.0.tar.bz2",
+        "name": "PHP 5.3.0 (tar.bz2)",
+        "md5": "846760cd655c98dfd86d6d97c3d964b0",
+        "date": "30 June 2009"
+      },
+      {
+        "filename": "php-5.3.0.tar.gz",
+        "name": "PHP 5.3.0 (tar.gz)",
+        "md5": "f4905eca4497da3f0beb5c96863196b4",
+        "date": "30 June 2009"
+      }
+    ],
+    "date": "30 June 2009",
+    "museum": true
+  },
+  "5.2.10": {
+    "announcement": {
+      "English": "/releases/5_2_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.10.tar.bz2",
+        "name": "PHP 5.2.10 (tar.bz2)",
+        "md5": "15c7b5a87f57332d6fc683528e28247b",
+        "date": "18 June 2009"
+      },
+      {
+        "filename": "php-5.2.10.tar.gz",
+        "name": "PHP 5.2.10 (tar.gz)",
+        "md5": "85753ba2909ac9fae5bca516adbda9e9",
+        "date": "18 June 2009"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.10-Win32.zip",
+        "name": "PHP 5.2.10 zip package",
+        "md5": "95ae7ccfcd05b6c81c93aa2e9e792f9e",
+        "date": "18 June 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.10-win32-installer.msi",
+        "name": "PHP 5.2.10 installer",
+        "md5": "38b65bc57f64c66ff73f6f4e2db2cbb4",
+        "date": "18 June 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-debug-pack-5.2.10-Win32.zip",
+        "name": "PHP 5.2.10 Win32 Debug Pack",
+        "md5": "f6bdea0e1f71ca46f78e78c86e86606",
+        "date": "18 June 2009"
+      },
+      {
+        "filename": "php-5.2.10-nts-Win32.zip",
+        "name": "PHP 5.2.10 Non-thread-safe zip package",
+        "md5": "b1c53e6f525133647e621a9c95b09e65",
+        "date": "18 June 2009",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.10-nts-win32-installer.msi",
+        "name": "PHP 5.2.10 Non-thread-safe installer",
+        "md5": "e341deb2872d3f8f4589593da88bbede",
+        "date": "18 June 2009"
+      },
+      {
+        "filename": "php-debug-pack-5.2.10-nts-Win32.zip",
+        "name": "PHP 5.2.10 Non-thread-safe Win32 Debug Pack",
+        "md5": "760a141c861a789f928b91c655c9d58",
+        "date": "18 June 2009"
+      }
+    ],
+    "date": "18 June 2009",
+    "museum": true
+  },
+  "5.2.9": {
+    "announcement": {
+      "English": "/releases/5_2_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.9.tar.bz2",
+        "name": "PHP 5.2.9 (tar.bz2)",
+        "md5": "280d6cda7f72a4fc6de42fda21ac2db7",
+        "date": "26 February 2009"
+      },
+      {
+        "filename": "php-5.2.9.tar.gz",
+        "name": "PHP 5.2.9 (tar.gz)",
+        "md5": "98b647561dc664adefe296106056cf11",
+        "date": "26 February 2009"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.9-2-Win32.zip",
+        "name": "PHP 5.2.9-2 zip package",
+        "md5": "316b9c81bab08e6547a730315ea2abfd",
+        "date": "8 April 2009",
+        "note": "Updated 9th of April: Added the missing oci8 DLL"
+      },
+      {
+        "filename": "php-5.2.9-2-win32-installer.msi",
+        "name": "PHP 5.2.9-2 installer",
+        "md5": "e2162faa3467aed01651df4269aa6944",
+        "date": "8 April 2009",
+        "note": "Updated 9th of April: Added the missing oci8 DLL"
+      },
+      {
+        "filename": "php-debug-pack-5.2.9-2-Win32.zip",
+        "name": "PHP 5.2.9 Win32 Debug Pack",
+        "md5": "b52e9a152e105c7391c832fdfe0fa06f",
+        "date": "8 April 2009"
+      },
+      {
+        "filename": "php-5.2.9-2-nts-Win32.zip",
+        "name": "PHP 5.2.9-2 Non-thread-safe zip package",
+        "md5": "8f85777941f7722fcbfe08e7de358f7d",
+        "date": "8 April 2009",
+        "note": "Updated 9th of April: Added the missing oci8 DLL"
+      },
+      {
+        "filename": "php-5.2.9-2-nts-win32-installer.msi",
+        "name": "PHP 5.2.9-2 Non-thread-safe installer",
+        "md5": "4e7a1bec2b268d3d2d28cb89f629b680",
+        "date": "8 April 2009",
+        "note": "Updated 9th of April: Added the missing oci8 DLL"
+      },
+      {
+        "filename": "php-debug-pack-5.2.9-2-nts-Win32.zip",
+        "name": "PHP 5.2.9 Non-thread-safe Win32 Debug Pack",
+        "md5": "4b7b695a257527f2896312f98dc30fd3",
+        "date": "8 April 2009"
+      }
+    ],
+    "date": "26 February 2009",
+    "museum": true
+  },
+  "5.2.8": {
+    "announcement": {
+      "English": "/releases/5_2_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.8.tar.bz2",
+        "name": "PHP 5.2.8 (tar.bz2)",
+        "md5": "8760a833cf10433d3e72271ab0d0eccf",
+        "date": "08 December 2008"
+      },
+      {
+        "filename": "php-5.2.8.tar.gz",
+        "name": "PHP 5.2.8 (tar.gz)",
+        "md5": "e748cace3cfecb66fb6de9a945f98e2a",
+        "date": "08 December 2008"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.8-Win32.zip",
+        "name": "PHP 5.2.8 zip package",
+        "md5": "71511834881753ea0906f2bca91632b9",
+        "date": "08 December 2008",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.8-win32-installer.msi",
+        "name": "PHP 5.2.8 installer",
+        "md5": "159def484800411060a9eacccafd2253",
+        "date": "08 December 2008",
+        "note": ""
+      },
+      {
+        "filename": "php-debug-pack-5.2.8-Win32.zip",
+        "name": "PHP 5.2.8 Win32 Debug Pack",
+        "md5": "fabc6e79c1c66dc80320165336b5ed54",
+        "date": "08 December 2008"
+      },
+      {
+        "filename": "php-5.2.8-nts-Win32.zip",
+        "name": "PHP 5.2.8 Non-thread-safe zip package",
+        "md5": "207abb02054c5ce996bc350352224acc",
+        "date": "08 December 2008",
+        "note": ""
+      },
+      {
+        "filename": "php-5.2.8-nts-win32-installer.msi",
+        "name": "PHP 5.2.8 Non-thread-safe installer",
+        "md5": "d4490964818542c416644b3d67f5b350",
+        "date": "08 December 2008"
+      },
+      {
+        "filename": "php-debug-pack-5.2.8-nts-Win32.zip",
+        "name": "PHP 5.2.8 Non-thread-safe Win32 Debug Pack",
+        "md5": "240566ce66761ab076ae9901547b7ce2",
+        "date": "08 December 2008"
+      }
+    ],
+    "date": "08 December 2008",
+    "museum": true
+  },
+  "5.2.6": {
+    "announcement": {
+      "English": "/releases/5_2_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.2.6.tar.bz2",
+        "name": "PHP 5.2.6 (tar.bz2)",
+        "md5": "7380ffecebd95c6edb317ef861229ebd",
+        "date": "01 May 2008"
+      },
+      {
+        "filename": "php-5.2.6.tar.gz",
+        "name": "PHP 5.2.6 (tar.gz)",
+        "md5": "1720f95f26c506338f0dba3a51906bbd",
+        "date": "01 May 2008"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.6-Win32.zip",
+        "name": "PHP 5.2.6 zip package",
+        "md5": "c7e5010114f58282858d7d78e6509cdc",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "php-5.2.6-win32-installer.msi",
+        "name": "PHP 5.2.6 installer",
+        "md5": "94e551037e7c9c056f90179f351c0560",
+        "date": "6 May 2008",
+        "note": "Update May 6th: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "pecl-5.2.6-Win32.zip",
+        "name": "PECL 5.2.6 Win32 binaries",
+        "md5": "f0e7b245589d705eef731b51142d5def",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "php-debug-pack-5.2.6-Win32.zip",
+        "name": "PHP 5.2.6 Win32 Debug Pack",
+        "md5": "24dde2726e3e0cefbb83c0c375ea1f84",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "php-5.2.6-nts-Win32.zip",
+        "name": "PHP 5.2.6 Non-thread-safe zip package",
+        "md5": "1d3661a086f352ec7e318e7c2eeba4de",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "php-5.2.6-nts-win32-installer.msi",
+        "name": "PHP 5.2.6 Non-thread-safe installer",
+        "md5": "96a2326b16bda488734d3956a48201b7",
+        "date": "6 May 2008",
+        "note": "Update May 6th: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "php-debug-pack-5.2.6-nts-Win32.zip",
+        "name": "PHP 5.2.6 Win32 Debug Pack",
+        "md5": "4c1fd96c8a78e1896d37da81467ff70d",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      },
+      {
+        "filename": "pecl-5.2.6-nts-Win32.zip",
+        "name": "PECL 5.2.6 Non-thread-safe Win32 binaries",
+        "md5": "62b102221920092dfefc08756aa3e926",
+        "date": "3 May 2008",
+        "note": "Update May 3rd: Added missing XSL and IMAP extension"
+      }
+    ],
+    "date": "01 May 2008",
+    "museum": true
+  },
+  "5.2.5": {
+    "date": "08 November 2007",
+    "source": [
+      {
+        "filename": "php-5.2.5.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "1fe14ca892460b09f06729941a1bb605"
+      },
+      {
+        "filename": "php-5.2.5.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "61a0e1661b70760acc77bc4841900b7a"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.5-Win32.zip",
+        "name": "Windows binary",
+        "md5": "a1e31c0d872ab030a2256b1cd6d3b7d1"
+      },
+      {
+        "filename": "pecl-5.2.5-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.5",
+        "md5": "a3553b61c9332d08a5044cf9bf89f2df"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_5.php"
+    },
+    "museum": true
+  },
+  "5.2.4": {
+    "date": "30 August 2007",
+    "source": [
+      {
+        "filename": "php-5.2.4.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "55c97a671fdabf462cc7a82971a656d2"
+      },
+      {
+        "filename": "php-5.2.4.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "0826e231c3148b29fd039d7a8c893ad3"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.4-Win32.zip",
+        "name": "Windows binary",
+        "md5": "979b8a305b028b296b97ed72322026b2"
+      },
+      {
+        "filename": "pecl-5.2.4-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.4",
+        "md5": "dd98dfe607ceb98e727c394d5bd679fb"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_4.php"
+    },
+    "museum": true
+  },
+  "5.2.3": {
+    "date": "31 May 2007",
+    "source": [
+      {
+        "filename": "php-5.2.3.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "eb50b751c8e1ced05bd012d5a0e4dec3"
+      },
+      {
+        "filename": "php-5.2.3.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "df79b04d63fc4c1ccb6d8ea58a9cf3ac"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.3-Win32.zip",
+        "name": "Windows binary",
+        "md5": "ff6e5dc212823009e68f26d66d85cbac"
+      },
+      {
+        "filename": "pecl-5.2.3-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.3",
+        "md5": "0480ffaf5a5333e83d90d75cece54748"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_3.php"
+    },
+    "museum": true
+  },
+  "5.2.2": {
+    "date": "03 May 2007",
+    "source": [
+      {
+        "filename": "php-5.2.2.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "d084337867d70b50a10322577be0e44e"
+      },
+      {
+        "filename": "php-5.2.2.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "7a920d0096900b2b962b21dc5c55fe3c"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.2-Win32.zip",
+        "name": "Windows binary",
+        "md5": "634cf45c34f80dfb1284cabf1bbb1417"
+      },
+      {
+        "filename": "pecl-5.2.2-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.2",
+        "md5": "5d206368799dfbac983d83954328ae3a"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_2.php"
+    },
+    "museum": true
+  },
+  "5.2.1": {
+    "date": "08 Feb 2007",
+    "source": [
+      {
+        "filename": "php-5.2.1.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "261218e3569a777dbd87c16a15f05c8d"
+      },
+      {
+        "filename": "php-5.2.1.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "604eaee2b834bb037d2c83e53e300d3f"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.1-Win32.zip",
+        "name": "Windows binary",
+        "md5": "682dd66fb03c7dd24c522f474e1b04b6"
+      },
+      {
+        "filename": "pecl-5.2.1-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.1",
+        "md5": "dc8b394146faf7effa6f26df02e8e534"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_1.php"
+    },
+    "museum": true
+  },
+  "5.2.0": {
+    "date": "02 Nov 2006",
+    "source": [
+      {
+        "filename": "php-5.2.0.tar.bz2",
+        "name": "Source (tar.bz2)",
+        "md5": "e6029fafcee029edcfa2ceed7a005333"
+      },
+      {
+        "filename": "php-5.2.0.tar.gz",
+        "name": "Source (tar.gz)",
+        "md5": "52d7e8b3d8d7573e75c97340f131f988"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.2.0-Win32.zip",
+        "name": "Windows binary",
+        "md5": "910734e96f41190020272d80b82ce553"
+      },
+      {
+        "filename": "pecl-5.2.0-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.2.0",
+        "md5": "638f5997884ae3ce35d2b3ec12f399b2"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_2_0.php"
+    },
+    "museum": true
+  },
+  "5.1.6": {
+    "date": "24 Aug 2006",
+    "source": [
+      {
+        "filename": "php-5.1.6.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-5.1.6.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.6-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "pecl-5.1.6-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.6"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_6.php"
+    },
+    "museum": true
+  },
+  "5.1.5": {
+    "date": "17 Aug 2006",
+    "source": [
+      {
+        "filename": "php-5.1.5.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-5.1.5.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.5-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.1.5-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.5"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_5.php"
+    },
+    "museum": true
+  },
+  "5.1.4": {
+    "date": "04 May 2006",
+    "source": [
+      {
+        "filename": "php-5.1.4.tar.bz2",
+        "name": "Source (tar.bz2)"
+      },
+      {
+        "filename": "php-5.1.4.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.4-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.1.4-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.1.4-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.4"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_4.php"
+    },
+    "museum": true
+  },
+  "5.1.3": {
+    "date": "02 May 2006",
+    "source": [
+      {
+        "filename": "php-5.1.3.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.3-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.1.3-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.1.3-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.3"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_3.php"
+    },
+    "museum": true
+  },
+  "5.1.2": {
+    "date": "12 Jan 2006",
+    "source": [
+      {
+        "filename": "php-5.1.2.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.1.2-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.1.2-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.2"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_2.php"
+    },
+    "museum": true
+  },
+  "5.1.1": {
+    "date": "28 Nov 2005",
+    "source": [
+      {
+        "filename": "php-5.1.1.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.1.1-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.1.1-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.1.1"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_1.php"
+    },
+    "museum": true
+  },
+  "5.1.0": {
+    "date": "24 Nov 2005",
+    "source": [
+      {
+        "filename": "php-5.1.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.1.0-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.1.0-installer.exe",
+        "name": "Windows installer"
+      }
+    ],
+    "announcement": {
+      "English": "/releases/5_1_0.php"
+    },
+    "museum": true
+  },
+  "5.0.5": {
+    "date": "05 Sep 2005",
+    "source": [
+      {
+        "filename": "php-5.0.5.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.5-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.0.5-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.0.5-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.5"
+      }
+    ],
+    "museum": true
+  },
+  "5.0.4": {
+    "date": "31 Mar 2005",
+    "source": [
+      {
+        "filename": "php-5.0.4.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.4-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.0.4-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.0.4-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.4"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/55"
+    },
+    "museum": true
+  },
+  "5.0.3": {
+    "date": "15 Dec 2004",
+    "source": [
+      {
+        "filename": "php-5.0.3.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.3-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.0.3-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.0.3-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.3"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/54"
+    },
+    "museum": true
+  },
+  "5.0.2": {
+    "date": "23 Sep 2004",
+    "source": [
+      {
+        "filename": "php-5.0.2.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.2-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.0.2-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.0.2-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.2"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/53"
+    },
+    "museum": true
+  },
+  "5.0.1": {
+    "date": "12 Aug 2004",
+    "source": [
+      {
+        "filename": "php-5.0.1.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.1-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "pecl-5.0.1-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.1"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/51"
+    },
+    "museum": true
+  },
+  "5.0.0": {
+    "date": "13 July 2004",
+    "source": [
+      {
+        "filename": "php-5.0.0.tar.gz",
+        "name": "Source (tar.gz)"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-5.0.0-Win32.zip",
+        "name": "Windows binary"
+      },
+      {
+        "filename": "php-5.0.0-installer.exe",
+        "name": "Windows installer"
+      },
+      {
+        "filename": "pecl-5.0.0-Win32.zip",
+        "name": "Collection of PECL modules for PHP 5.0.0"
+      }
+    ],
+    "announcement": {
+      "English": "http://news.php.net/php.announce/50"
+    },
+    "museum": true
+  }
+}

--- a/php-releases/php-7.json
+++ b/php-releases/php-7.json
@@ -1,0 +1,4903 @@
+{
+  "7.4.33": {
+    "announcement": {
+      "English": "/releases/7_4_33.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "03 Nov 2022",
+    "source": [
+      {
+        "filename": "php-7.4.33.tar.gz",
+        "name": "PHP 7.4.33 (tar.gz)",
+        "sha256": "5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e",
+        "date": "03 Nov 2022"
+      },
+      {
+        "filename": "php-7.4.33.tar.bz2",
+        "name": "PHP 7.4.33 (tar.bz2)",
+        "sha256": "4e8117458fe5a475bf203128726b71bcbba61c42ad463dffadee5667a198a98a",
+        "date": "03 Nov 2022"
+      },
+      {
+        "filename": "php-7.4.33.tar.xz",
+        "name": "PHP 7.4.33 (tar.xz)",
+        "sha256": "924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927",
+        "date": "03 Nov 2022"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.32": {
+    "announcement": {
+      "English": "/releases/7_4_32.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Sep 2022",
+    "source": [
+      {
+        "filename": "php-7.4.32.tar.gz",
+        "name": "PHP 7.4.32 (tar.gz)",
+        "sha256": "197e3372afd69694eb6b230838305eb9e1cbe5db272e0fa3bbe0d38e329a95bc",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-7.4.32.tar.bz2",
+        "name": "PHP 7.4.32 (tar.bz2)",
+        "sha256": "9b4c3c21ffbb4f35d7b865dbf88538bba1742335248ae1cc2afc303d456e3aa6",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-7.4.32.tar.xz",
+        "name": "PHP 7.4.32 (tar.xz)",
+        "sha256": "323332c991e8ef30b1d219cb10f5e30f11b5f319ce4c6642a5470d75ade7864a",
+        "date": "29 Sep 2022"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.30": {
+    "announcement": {
+      "English": "/releases/7_4_30.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jun 2022",
+    "source": [
+      {
+        "filename": "php-7.4.30.tar.gz",
+        "name": "PHP 7.4.30 (tar.gz)",
+        "sha256": "e37ea37e0f79109351ac615da85eb7c2c336101fc5bc802ee79a124a4310dc10",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-7.4.30.tar.bz2",
+        "name": "PHP 7.4.30 (tar.bz2)",
+        "sha256": "b601bb12e53720469b60ea816776cac1c0696b09888a11ad2379b2eee835386e",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-7.4.30.tar.xz",
+        "name": "PHP 7.4.30 (tar.xz)",
+        "sha256": "ea72a34f32c67e79ac2da7dfe96177f3c451c3eefae5810ba13312ed398ba70d",
+        "date": "09 Jun 2022"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.29": {
+    "announcement": {
+      "English": "/releases/7_4_29.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 Apr 2022",
+    "source": [
+      {
+        "filename": "php-7.4.29.tar.gz",
+        "name": "PHP 7.4.29 (tar.gz)",
+        "sha256": "f73f89873bb9447cb99eb4863cf0a0deab4481cb8acf7552c0e70647e6885854",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-7.4.29.tar.bz2",
+        "name": "PHP 7.4.29 (tar.bz2)",
+        "sha256": "7dde58a02b225c25130c6e2ae2cbba7254bb0340f7fe17291478176d866f9482",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-7.4.29.tar.xz",
+        "name": "PHP 7.4.29 (tar.xz)",
+        "sha256": "7d0f07869f33311ff3fe1138dc0d6c0d673c37fcb737eaed2c6c10a949f1aed6",
+        "date": "14 Apr 2022"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.28": {
+    "announcement": {
+      "English": "/releases/7_4_28.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "17 Feb 2022",
+    "source": [
+      {
+        "filename": "php-7.4.28.tar.gz",
+        "name": "PHP 7.4.28 (tar.gz)",
+        "sha256": "a04014cd1646b90547907e2e0ac5371594533960de317b6c7ac70bcb42db92fb",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-7.4.28.tar.bz2",
+        "name": "PHP 7.4.28 (tar.bz2)",
+        "sha256": "2085086a863444b0e39547de1a4969fd1c40a0c188eb58fab2938b649b0c4b58",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-7.4.28.tar.xz",
+        "name": "PHP 7.4.28 (tar.xz)",
+        "sha256": "9cc3b6f6217b60582f78566b3814532c4b71d517876c25013ae51811e65d8fce",
+        "date": "17 Feb 2022"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.27": {
+    "announcement": {
+      "English": "/releases/7_4_27.php"
+    },
+    "tags": [],
+    "date": "16 Dec 2021",
+    "source": [
+      {
+        "filename": "php-7.4.27.tar.gz",
+        "name": "PHP 7.4.27 (tar.gz)",
+        "sha256": "564fd5bc9850370db0cb4058d9087f2f40177fa4921ce698a375416db9ab43ca",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-7.4.27.tar.bz2",
+        "name": "PHP 7.4.27 (tar.bz2)",
+        "sha256": "184aaef313fbf28c9987f6aa07b655cd1b0eae9e7e17061775a3e7d880185563",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-7.4.27.tar.xz",
+        "name": "PHP 7.4.27 (tar.xz)",
+        "sha256": "3f8b937310f155822752229c2c2feb8cc2621e25a728e7b94d0d74c128c43d0c",
+        "date": "16 Dec 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.26": {
+    "announcement": {
+      "English": "/releases/7_4_26.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "18 Nov 2021",
+    "source": [
+      {
+        "filename": "php-7.4.26.tar.gz",
+        "name": "PHP 7.4.26 (tar.gz)",
+        "sha256": "890a7e730f96708a68a77b19fd57fec33cc81573f7249111c870edac42b91a72",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-7.4.26.tar.bz2",
+        "name": "PHP 7.4.26 (tar.bz2)",
+        "sha256": "d68b88a8f8a437648affcc7793e5e062fa0ec5171f7fd0af385b12c78b1c004d",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-7.4.26.tar.xz",
+        "name": "PHP 7.4.26 (tar.xz)",
+        "sha256": "e305b3aafdc85fa73a81c53d3ce30578bc94d1633ec376add193a1e85e0f0ef8",
+        "date": "18 Nov 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.33": {
+    "announcement": {
+      "English": "/releases/7_3_33.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "18 Nov 2021",
+    "source": [
+      {
+        "filename": "php-7.3.33.tar.gz",
+        "name": "PHP 7.3.33 (tar.gz)",
+        "sha256": "9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-7.3.33.tar.bz2",
+        "name": "PHP 7.3.33 (tar.bz2)",
+        "sha256": "f412487d7d953437e7978a0d7b6ec99bf4a85cf3378014438a8577b89535451a",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-7.3.33.tar.xz",
+        "name": "PHP 7.3.33 (tar.xz)",
+        "sha256": "166eaccde933381da9516a2b70ad0f447d7cec4b603d07b9a916032b215b90cc",
+        "date": "18 Nov 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.32": {
+    "announcement": {
+      "English": "/releases/7_3_32.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "28 Oct 2021",
+    "source": [
+      {
+        "filename": "php-7.3.32.tar.gz",
+        "name": "PHP 7.3.32 (tar.gz)",
+        "sha256": "4739160cbd8f5d4529429ac01e181cba9705a515666002e76e4e34891c034fcb",
+        "date": "28 Oct 2021"
+      },
+      {
+        "filename": "php-7.3.32.tar.bz2",
+        "name": "PHP 7.3.32 (tar.bz2)",
+        "sha256": "7c158b306e53434f1e0a88647aa561814308aaff8713ed7d237ed8f1399c216f",
+        "date": "28 Oct 2021"
+      },
+      {
+        "filename": "php-7.3.32.tar.xz",
+        "name": "PHP 7.3.32 (tar.xz)",
+        "sha256": "94effa250b80f031e77fbd98b6950c441157a2a8f9e076ee68e02f5b0b7a3fd9",
+        "date": "28 Oct 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.25": {
+    "announcement": {
+      "English": "/releases/7_4_25.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "21 Oct 2021",
+    "source": [
+      {
+        "filename": "php-7.4.25.tar.gz",
+        "name": "PHP 7.4.25 (tar.gz)",
+        "sha256": "3b2632252c933cac489a20f68b8f4ab769e5a0a3bf22b6ef47427aff6922e31f",
+        "date": "21 Oct 2021"
+      },
+      {
+        "filename": "php-7.4.25.tar.bz2",
+        "name": "PHP 7.4.25 (tar.bz2)",
+        "sha256": "27992570caf3e2e5323ab7b37853c44c1529b1d31ea94d9776efa91d5a781313",
+        "date": "21 Oct 2021"
+      },
+      {
+        "filename": "php-7.4.25.tar.xz",
+        "name": "PHP 7.4.25 (tar.xz)",
+        "sha256": "12a758f1d7fee544387a28d3cf73226f47e3a52fb3049f07fcc37d156d393c0a",
+        "date": "21 Oct 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.31": {
+    "announcement": {
+      "English": "/releases/7_3_31.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Sep 2021",
+    "source": [
+      {
+        "filename": "php-7.3.31.tar.gz",
+        "name": "PHP 7.3.31 (tar.gz)",
+        "sha256": "57ca37b08d3eed4cadc3976e78b0f51d0305bb6e60333f6e8c76e8aee07c3f0f",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-7.3.31.tar.bz2",
+        "name": "PHP 7.3.31 (tar.bz2)",
+        "sha256": "6951f78524684f439186fe039ab14fb2459cea8f47ac829a159724a283f7f32b",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-7.3.31.tar.xz",
+        "name": "PHP 7.3.31 (tar.xz)",
+        "sha256": "d1aa8f44595d01ac061ff340354d95e146d6152f70e799b44d6b8654fb45cbcc",
+        "date": "23 Sep 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.24": {
+    "announcement": {
+      "English": "/releases/7_4_24.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Sep 2021",
+    "source": [
+      {
+        "filename": "php-7.4.24.tar.gz",
+        "name": "PHP 7.4.24 (tar.gz)",
+        "sha256": "8cc1758cf7ff45428c17641b1be84cd917a2909ba40c770f06a814d8b7f36333",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-7.4.24.tar.bz2",
+        "name": "PHP 7.4.24 (tar.bz2)",
+        "sha256": "f50e32b788864349041f19e31dcc65b1fcc65bc19122918f607526432edf2f32",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-7.4.24.tar.xz",
+        "name": "PHP 7.4.24 (tar.xz)",
+        "sha256": "ff7658ee2f6d8af05b48c21146af5f502e121def4e76e862df5ec9fa06e98734",
+        "date": "23 Sep 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.23": {
+    "announcement": {
+      "English": "/releases/7_4_23.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "26 Aug 2021",
+    "source": [
+      {
+        "filename": "php-7.4.23.tar.gz",
+        "name": "PHP 7.4.23 (tar.gz)",
+        "sha256": "2aaa481678ad4d2992e7bcf161e0e98c7268f4979f7ca8b3d97dd6de19c205d6",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-7.4.23.tar.bz2",
+        "name": "PHP 7.4.23 (tar.bz2)",
+        "sha256": "d1e094fe6e4f832e0a64be9c69464ba5d593fb216f914efa8bbb084e0a7a5727",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-7.4.23.tar.xz",
+        "name": "PHP 7.4.23 (tar.xz)",
+        "sha256": "cea52313fcffe56343bcd3c66dbb23cd5507dc559cc2e3547cf8f5452e88a05d",
+        "date": "26 Aug 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.30": {
+    "announcement": {
+      "English": "/releases/7_3_30.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "26 Aug 2021",
+    "source": [
+      {
+        "filename": "php-7.3.30.tar.gz",
+        "name": "PHP 7.3.30 (tar.gz)",
+        "sha256": "3810a9b631eb7f236ecf02b9a78bab8d957b6cfdb1646a29e3b34e01d36c0510",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-7.3.30.tar.bz2",
+        "name": "PHP 7.3.30 (tar.bz2)",
+        "sha256": "ccc532e660761df9b5509b9b913d2dc049b0a9954108fe212aeeb8bc2556b502",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-7.3.30.tar.xz",
+        "name": "PHP 7.3.30 (tar.xz)",
+        "sha256": "0ebfd656df0f3b1ea37ff2887f8f2d1a71cd160fb0292547c0ee0a99e58ffd1b",
+        "date": "26 Aug 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.22": {
+    "announcement": {
+      "English": "/releases/7_4_22.php"
+    },
+    "tags": [],
+    "date": "29 Jul 2021",
+    "source": [
+      {
+        "filename": "php-7.4.22.tar.gz",
+        "name": "PHP 7.4.22 (tar.gz)",
+        "sha256": "4ca2642b99a822237d7f84dc19682be702ad0e2d5d282f7646d84b746d454e34",
+        "date": "29 Jul 2021"
+      },
+      {
+        "filename": "php-7.4.22.tar.bz2",
+        "name": "PHP 7.4.22 (tar.bz2)",
+        "sha256": "5022bbca661bc1ab5dfaee72873bcd0f0980d9dd34f980a682029496f51caae1",
+        "date": "29 Jul 2021"
+      },
+      {
+        "filename": "php-7.4.22.tar.xz",
+        "name": "PHP 7.4.22 (tar.xz)",
+        "sha256": "8e078cd7d2f49ac3fcff902490a5bb1addc885e7e3b0d8dd068f42c68297bde8",
+        "date": "29 Jul 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.29": {
+    "announcement": {
+      "English": "/releases/7_3_29.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Jul 2021",
+    "source": [
+      {
+        "filename": "php-7.3.29.tar.gz",
+        "name": "PHP 7.3.29 (tar.gz)",
+        "sha256": "ba4de3955b0cbd33baee55a83568acc4347605e210a54b5654e4c1e09b544659",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-7.3.29.tar.bz2",
+        "name": "PHP 7.3.29 (tar.bz2)",
+        "sha256": "a83a2878140bd86935f0046bbfe92672c8ab688fbe4ccf9704add6b9605ee4d0",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-7.3.29.tar.xz",
+        "name": "PHP 7.3.29 (tar.xz)",
+        "sha256": "7db2834511f3d86272dca3daee3f395a5a4afce359b8342aa6edad80e12eb4d0",
+        "date": "01 Jul 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.21": {
+    "announcement": {
+      "English": "/releases/7_4_21.php"
+    },
+    "tags": [],
+    "date": "01 Jul 2021",
+    "source": [
+      {
+        "filename": "php-7.4.21.tar.gz",
+        "name": "PHP 7.4.21 (tar.gz)",
+        "sha256": "4b9623accbe4b8923a801212f371f784069535009185e7bf7e4dec66bbea61db",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-7.4.21.tar.bz2",
+        "name": "PHP 7.4.21 (tar.bz2)",
+        "sha256": "36ec6102e757e2c2b7742057a700bbff77c76fa0ccbe9c860398c3d24e32822a",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-7.4.21.tar.xz",
+        "name": "PHP 7.4.21 (tar.xz)",
+        "sha256": "cf43384a7806241bc2ff22022619baa4abb9710f12ec1656d0173de992e32a90",
+        "date": "01 Jul 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.20": {
+    "announcement": {
+      "English": "/releases/7_4_20.php"
+    },
+    "tags": [],
+    "date": "03 Jun 2021",
+    "source": [
+      {
+        "filename": "php-7.4.20.tar.gz",
+        "name": "PHP 7.4.20 (tar.gz)",
+        "sha256": "84b09e4617e960b36dfa15fdbf2e3cd7141a2e877216ea29391b12ae86963cf4",
+        "date": "03 Jun 2021"
+      },
+      {
+        "filename": "php-7.4.20.tar.bz2",
+        "name": "PHP 7.4.20 (tar.bz2)",
+        "sha256": "0ada6bc635e530fa7a4eb55e639dc070077108e5c9885f750b47007fd267b634",
+        "date": "03 Jun 2021"
+      },
+      {
+        "filename": "php-7.4.20.tar.xz",
+        "name": "PHP 7.4.20 (tar.xz)",
+        "sha256": "1fa46ca6790d780bf2cb48961df65f0ca3640c4533f0bca743cd61b71cb66335",
+        "date": "03 Jun 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.28": {
+    "announcement": {
+      "English": "/releases/7_3_28.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Apr 2021",
+    "source": [
+      {
+        "filename": "php-7.3.28.tar.gz",
+        "name": "PHP 7.3.28 (tar.gz)",
+        "sha256": "1f0d9b94e1b11518ffabd19b646c2fee95ea42ca9cd8d337f8d07986fdceede1",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-7.3.28.tar.bz2",
+        "name": "PHP 7.3.28 (tar.bz2)",
+        "sha256": "8f636e644594388436ea05ff34c9eb135e6dc119c1130199e9488d5795439964",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-7.3.28.tar.xz",
+        "name": "PHP 7.3.28 (tar.xz)",
+        "sha256": "a2a84dbec8c1eee3f46c5f249eaaa2ecb3f9e7a6f5d0604d2df44ff8d4904dbe",
+        "date": "29 Apr 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.19": {
+    "announcement": {
+      "English": "/releases/7_4_19.php"
+    },
+    "tags": [],
+    "date": "06 May 2021",
+    "source": [
+      {
+        "filename": "php-7.4.19.tar.gz",
+        "name": "PHP 7.4.19 (tar.gz)",
+        "sha256": "d7062457ba9f8334ab8ae7e4fea8efe27e2506763551b25db9e6ab9beea8ed6f",
+        "date": "06 May 2021"
+      },
+      {
+        "filename": "php-7.4.19.tar.bz2",
+        "name": "PHP 7.4.19 (tar.bz2)",
+        "sha256": "25d09b8145b284d870431c1b40aba7944e4bf1836278538f8e29780e7f85ddea",
+        "date": "06 May 2021"
+      },
+      {
+        "filename": "php-7.4.19.tar.xz",
+        "name": "PHP 7.4.19 (tar.xz)",
+        "sha256": "6c17172c4a411ccb694d9752de899bb63c72a0a3ebe5089116bc13658a1467b2",
+        "date": "06 May 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.18": {
+    "announcement": {
+      "English": "/releases/7_4_18.php"
+    },
+    "tags": [],
+    "date": "29 Apr 2021",
+    "source": [
+      {
+        "filename": "php-7.4.18.tar.gz",
+        "name": "PHP 7.4.18 (tar.gz)",
+        "sha256": "31a8a4a6e7d641f014749cef21421a6d1c9aaba6dce884e181a3370a8e69a04d",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-7.4.18.tar.bz2",
+        "name": "PHP 7.4.18 (tar.bz2)",
+        "sha256": "2e455932e9c6f5889b1dc879f36fdd5744eaf1ff572b1b778958cbb8f5c1842f",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-7.4.18.tar.xz",
+        "name": "PHP 7.4.18 (tar.xz)",
+        "sha256": "ab97f22b128d21dcbc009b50a37aaea0051b2721cbcd122d9e00e6ffc3c4b7e1",
+        "date": "29 Apr 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.16": {
+    "announcement": {
+      "English": "/releases/7_4_16.php"
+    },
+    "tags": [],
+    "date": "04 Mar 2021",
+    "source": [
+      {
+        "filename": "php-7.4.16.tar.gz",
+        "name": "PHP 7.4.16 (tar.gz)",
+        "sha256": "ef2d2b463fc3444895ec599337b663a8832c6ade148d9832417e59aa2b9e93da",
+        "date": "04 Mar 2021"
+      },
+      {
+        "filename": "php-7.4.16.tar.bz2",
+        "name": "PHP 7.4.16 (tar.bz2)",
+        "sha256": "85710f007cfd0fae94e13a02a3a036f4e81ef43693260cae8a2e1ca93659ce3e",
+        "date": "04 Mar 2021"
+      },
+      {
+        "filename": "php-7.4.16.tar.xz",
+        "name": "PHP 7.4.16 (tar.xz)",
+        "sha256": "1c16cefaf88ded4c92eed6a8a41eb682bb2ef42429deb55f1c4ba159053fb98b",
+        "date": "04 Mar 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.27": {
+    "announcement": {
+      "English": "/releases/7_3_27.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "04 Feb 2021",
+    "source": [
+      {
+        "filename": "php-7.3.27.tar.gz",
+        "name": "PHP 7.3.27 (tar.gz)",
+        "sha256": "4b7b9bd0526ad3f2c8d6fd950ea7b0ab2478b5b09755c6a620a4f3bcfbf59154",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-7.3.27.tar.bz2",
+        "name": "PHP 7.3.27 (tar.bz2)",
+        "sha256": "9d2006f5e835acf5e408e34d8050a4935f2121ab18bda42775a27ed59bdae003",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-7.3.27.tar.xz",
+        "name": "PHP 7.3.27 (tar.xz)",
+        "sha256": "65f616e2d5b6faacedf62830fa047951b0136d5da34ae59e6744cbaf5dca148d",
+        "date": "04 Feb 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.15": {
+    "announcement": {
+      "English": "/releases/7_4_15.php"
+    },
+    "tags": [],
+    "date": "04 Feb 2021",
+    "source": [
+      {
+        "filename": "php-7.4.15.tar.gz",
+        "name": "PHP 7.4.15 (tar.gz)",
+        "sha256": "c7403988b69212335dec79e869abe9dbb23d60ea7f6eb16fd6ff99ed6b5f1c87",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-7.4.15.tar.bz2",
+        "name": "PHP 7.4.15 (tar.bz2)",
+        "sha256": "1bd7be0293446c3d3cbe3c9fae6045119af0798fb0869db61932796dc23a7757",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-7.4.15.tar.xz",
+        "name": "PHP 7.4.15 (tar.xz)",
+        "sha256": "9b859c65f0cf7b3eff9d4a28cfab719fb3d36a1db3c20d874a79b5ec44d43cb8",
+        "date": "04 Feb 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.14": {
+    "announcement": {
+      "English": "/releases/7_4_14.php"
+    },
+    "tags": [],
+    "date": "07 Jan 2021",
+    "source": [
+      {
+        "filename": "php-7.4.14.tar.gz",
+        "name": "PHP 7.4.14 (tar.gz)",
+        "sha256": "d359183e2436f4ab30b70d4fbd881b5705a46b2e68cc6069fe91cd63d6e98e13",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-7.4.14.tar.bz2",
+        "name": "PHP 7.4.14 (tar.bz2)",
+        "sha256": "6889ca0605adee3aa7077508cd79fcef1dbd88461cdf25e7c1a86997b8d0a1f6",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-7.4.14.tar.xz",
+        "name": "PHP 7.4.14 (tar.xz)",
+        "sha256": "f9f3c37969fcd9006c1dbb1dd76ab53f28c698a1646fa2dde8547c3f45e02886",
+        "date": "07 Jan 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.26": {
+    "announcement": {
+      "English": "/releases/7_3_26.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "07 Jan 2021",
+    "source": [
+      {
+        "filename": "php-7.3.26.tar.gz",
+        "name": "PHP 7.3.26 (tar.gz)",
+        "sha256": "2b55c2a54d1825e7c3feaf44cf42cdf782b8d5c611314172fbf8e234960b6a99",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-7.3.26.tar.bz2",
+        "name": "PHP 7.3.26 (tar.bz2)",
+        "sha256": "371e5a7c8154fd3c52b14baace5f7d04c4bbb8e841d356c54a2b6a688db39d4e",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-7.3.26.tar.xz",
+        "name": "PHP 7.3.26 (tar.xz)",
+        "sha256": "d93052f4cb2882090b6a37fd1e0c764be1605a2461152b7f6b8f04fa48875208",
+        "date": "07 Jan 2021"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.25": {
+    "announcement": {
+      "English": "/releases/7_3_25.php"
+    },
+    "tags": [],
+    "date": "26 Nov 2020",
+    "source": [
+      {
+        "filename": "php-7.3.25.tar.gz",
+        "name": "PHP 7.3.25 (tar.gz)",
+        "sha256": "097c7a2a2f9189b33799d79ee5a8aac68a4d72696c1cd69c66ef5d0941ce28ad",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-7.3.25.tar.bz2",
+        "name": "PHP 7.3.25 (tar.bz2)",
+        "sha256": "69315a4daa91e3b07c90eef86fe205c8812c4ac5ce119c9953ecc9f42e7702fb",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-7.3.25.tar.xz",
+        "name": "PHP 7.3.25 (tar.xz)",
+        "sha256": "c71c00ad03079efb78d1a6b8623ca4f725be697dbd9a46debacbcc9a2475f329",
+        "date": "26 Nov 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.13": {
+    "announcement": {
+      "English": "/releases/7_4_13.php"
+    },
+    "tags": [],
+    "date": "26 Nov 2020",
+    "source": [
+      {
+        "filename": "php-7.4.13.tar.gz",
+        "name": "PHP 7.4.13 (tar.gz)",
+        "sha256": "0865cff41e7210de2537bcd5750377cfe09a9312b9b44c1a166cf372d5204b8f",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-7.4.13.tar.bz2",
+        "name": "PHP 7.4.13 (tar.bz2)",
+        "sha256": "15a339857e11c92eb47fddcd0dfe8aaa951a9be7c57ab7230ccd497465a31fda",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-7.4.13.tar.xz",
+        "name": "PHP 7.4.13 (tar.xz)",
+        "sha256": "aead303e3abac23106529560547baebbedba0bb2943b91d5aa08fff1f41680f4",
+        "date": "26 Nov 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.34": {
+    "announcement": {
+      "English": "/releases/7_2_34.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Oct 2020",
+    "source": [
+      {
+        "filename": "php-7.2.34.tar.gz",
+        "name": "PHP 7.2.34 (tar.gz)",
+        "sha256": "8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.2.34.tar.bz2",
+        "name": "PHP 7.2.34 (tar.bz2)",
+        "sha256": "0e5816d668a2bb14aca68cef8c430430bd86c3c5233f6c427d1a54aac127abcf",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.2.34.tar.xz",
+        "name": "PHP 7.2.34 (tar.xz)",
+        "sha256": "409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903",
+        "date": "01 Oct 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.24": {
+    "announcement": {
+      "English": "/releases/7_3_24.php"
+    },
+    "tags": [
+      ""
+    ],
+    "date": "29 Oct 2020",
+    "source": [
+      {
+        "filename": "php-7.3.24.tar.bz2",
+        "name": "PHP 7.3.24 (tar.bz2)",
+        "sha256": "55b7afbb2037b0f8fefc481a85f8df4f7a278b4b7f0ed9f674c50ec389cca598",
+        "date": "29 Oct 2020"
+      },
+      {
+        "filename": "php-7.3.24.tar.gz",
+        "name": "PHP 7.3.24 (tar.gz)",
+        "sha256": "ac06577e2aeb69d4bed3c1532ed84a548f01399e5481c144c3e61d146be8ced6",
+        "date": "29 Oct 2020"
+      },
+      {
+        "filename": "php-7.3.24.tar.xz",
+        "name": "PHP 7.3.24 (tar.xz)",
+        "sha256": "78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888",
+        "date": "29 Oct 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.12": {
+    "announcement": {
+      "English": "/releases/7_4_12.php"
+    },
+    "tags": [],
+    "date": "29 Oct 2020",
+    "source": [
+      {
+        "filename": "php-7.4.12.tar.bz2",
+        "name": "PHP 7.4.12 (tar.bz2)",
+        "sha256": "6e6f73cc239edfc462b56a45724019691f85b57b7492e1eb5b4b60f7faa19967",
+        "date": "29 Oct 2020"
+      },
+      {
+        "filename": "php-7.4.12.tar.gz",
+        "name": "PHP 7.4.12 (tar.gz)",
+        "sha256": "f056d74409a71f17218f76538c6a2d7b59ee99db9db7685fa0ab9cd0d4c0f286",
+        "date": "29 Oct 2020"
+      },
+      {
+        "filename": "php-7.4.12.tar.xz",
+        "name": "PHP 7.4.12 (tar.xz)",
+        "sha256": "e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76",
+        "date": "29 Oct 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.11": {
+    "announcement": {
+      "English": "/releases/7_4_11.php"
+    },
+    "tags": [],
+    "date": "01 Oct 2020",
+    "source": [
+      {
+        "filename": "php-7.4.11.tar.bz2",
+        "name": "PHP 7.4.11 (tar.bz2)",
+        "sha256": "5408f255243bd2292f3fbc2fafc27a2ec083fcd852902728f2ba9a3ea616b8c5",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.4.11.tar.gz",
+        "name": "PHP 7.4.11 (tar.gz)",
+        "sha256": "b4fae5c39ca1eedf5597071996d9c85d0674b83f5003126c39b7b44bbfbcd821",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.4.11.tar.xz",
+        "name": "PHP 7.4.11 (tar.xz)",
+        "sha256": "5d31675a9b9c21b5bd03389418218c30b26558246870caba8eb54f5856e2d6ce",
+        "date": "01 Oct 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.23": {
+    "announcement": {
+      "English": "/releases/7_3_23.php"
+    },
+    "tags": [
+      ""
+    ],
+    "date": "01 Oct 2020",
+    "source": [
+      {
+        "filename": "php-7.3.23.tar.bz2",
+        "name": "PHP 7.3.23 (tar.bz2)",
+        "sha256": "fd6666ad4605508042c6964151379475daea36c43e03b11b1e79d4ae6b04c04c",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.3.23.tar.gz",
+        "name": "PHP 7.3.23 (tar.gz)",
+        "sha256": "a21094b9ba2d8fe7fa5838e6566e30cf4bfaf2c8a6dce90ff707c45d0d8d494d",
+        "date": "01 Oct 2020"
+      },
+      {
+        "filename": "php-7.3.23.tar.xz",
+        "name": "PHP 7.3.23 (tar.xz)",
+        "sha256": "2bdd36176f318f451fb3942bf1e935aabb3c2786cac41a9080f084ad6390e034",
+        "date": "01 Oct 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.22": {
+    "announcement": {
+      "English": "/releases/7_3_22.php"
+    },
+    "tags": [
+      ""
+    ],
+    "date": "03 Sep 2020",
+    "source": [
+      {
+        "filename": "php-7.3.22.tar.bz2",
+        "name": "PHP 7.3.22 (tar.bz2)",
+        "sha256": "c790b8172520b2ff773d6cf80774ea0a678a2f16e8ee6b11d68802094448689e",
+        "date": "03 Sep 2020"
+      },
+      {
+        "filename": "php-7.3.22.tar.gz",
+        "name": "PHP 7.3.22 (tar.gz)",
+        "sha256": "759426cb4054e3f23316c39710faff0bb8063fd0ea50fc2c5efa590429af1a22",
+        "date": "03 Sep 2020"
+      },
+      {
+        "filename": "php-7.3.22.tar.xz",
+        "name": "PHP 7.3.22 (tar.xz)",
+        "sha256": "0e66606d3bdab5c2ae3f778136bfe8788e574913a3d8138695e54d98562f1fb5",
+        "date": "03 Sep 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.10": {
+    "announcement": {
+      "English": "/releases/7_4_10.php"
+    },
+    "tags": [],
+    "date": "03 Sep 2020",
+    "source": [
+      {
+        "filename": "php-7.4.10.tar.bz2",
+        "name": "PHP 7.4.10 (tar.bz2)",
+        "sha256": "e90bfc9ed98d24e53b51ffd4eb636cf5cd9d71ed7c6f8e4b6e9981e9882174e7",
+        "date": "03 Sep 2020"
+      },
+      {
+        "filename": "php-7.4.10.tar.gz",
+        "name": "PHP 7.4.10 (tar.gz)",
+        "sha256": "e720f1286f895ca37f1c75a2ca338ad2f2456664d7097298167181b25b212feb",
+        "date": "03 Sep 2020"
+      },
+      {
+        "filename": "php-7.4.10.tar.xz",
+        "name": "PHP 7.4.10 (tar.xz)",
+        "sha256": "c2d90b00b14284588a787b100dee54c2400e7db995b457864d66f00ad64fb010",
+        "date": "03 Sep 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.33": {
+    "announcement": {
+      "English": "/releases/7_2_33.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "06 Aug 2020",
+    "source": [
+      {
+        "filename": "php-7.2.33.tar.bz2",
+        "name": "PHP 7.2.33 (tar.bz2)",
+        "sha256": "03dda3a3a0c8befc9b381bc9cf4638d13862783fc7b8aef43fdd4431ab85854d",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.2.33.tar.gz",
+        "name": "PHP 7.2.33 (tar.gz)",
+        "sha256": "97bb6b88ddfa44f36c4fc84a1a718faef476f61b532d26ea29e3e9f6cd79d839",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.2.33.tar.xz",
+        "name": "PHP 7.2.33 (tar.xz)",
+        "sha256": "0f160a3483ffce36be5962fab7bcf09d605ee66c5707df83e4195cb796bbb03a",
+        "date": "06 Aug 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.9": {
+    "announcement": {
+      "English": "/releases/7_4_9.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "06 Aug 2020",
+    "source": [
+      {
+        "filename": "php-7.4.9.tar.bz2",
+        "name": "PHP 7.4.9 (tar.bz2)",
+        "sha256": "2e270958a4216480da7886743438ccc92b6acf32ea96fefda88d07e0a5095deb",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.4.9.tar.gz",
+        "name": "PHP 7.4.9 (tar.gz)",
+        "sha256": "c0c657b5769bc463f5f028b1f4fef8814d98ecf3459a402a9e30d41d68b2323e",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.4.9.tar.xz",
+        "name": "PHP 7.4.9 (tar.xz)",
+        "sha256": "23733f4a608ad1bebdcecf0138ebc5fd57cf20d6e0915f98a9444c3f747dc57b",
+        "date": "06 Aug 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.21": {
+    "announcement": {
+      "English": "/releases/7_3_21.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "06 Aug 2020",
+    "source": [
+      {
+        "filename": "php-7.3.21.tar.bz2",
+        "name": "PHP 7.3.21 (tar.bz2)",
+        "sha256": "dbb0ea39e7e4b3814d6d1dd3ac5983aed6c38cdf55464645da11a8b134a9f7a7",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.3.21.tar.gz",
+        "name": "PHP 7.3.21 (tar.gz)",
+        "sha256": "f5d6e136768522edd025c4a97b9b6a98a2fda20b68445cbc5ca2efce1e73c7d0",
+        "date": "06 Aug 2020"
+      },
+      {
+        "filename": "php-7.3.21.tar.xz",
+        "name": "PHP 7.3.21 (tar.xz)",
+        "sha256": "4c8b065746ef776d84b7ae47908c21a79e3d4704b86b60d816716b8697c58ce9",
+        "date": "06 Aug 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.8": {
+    "announcement": {
+      "English": "/releases/7_4_8.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jul 2020",
+    "source": [
+      {
+        "filename": "php-7.4.8.tar.bz2",
+        "name": "PHP 7.4.8 (tar.bz2)",
+        "sha256": "6a48d3a605c003b088984ceb53be5df1e698b8b35ddacadd12fe50f49c0e8062",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.4.8.tar.gz",
+        "name": "PHP 7.4.8 (tar.gz)",
+        "sha256": "649f6bcdb60dc38d5edd7f3a7b2905d15d88c1d13e40307e8972ede347cea6ba",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.4.8.tar.xz",
+        "name": "PHP 7.4.8 (tar.xz)",
+        "sha256": "642843890b732e8af01cb661e823ae01472af1402f211c83009c9b3abd073245",
+        "date": "09 Jul 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.20": {
+    "announcement": {
+      "English": "/releases/7_3_20.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jul 2020",
+    "source": [
+      {
+        "filename": "php-7.3.20.tar.bz2",
+        "name": "PHP 7.3.20 (tar.bz2)",
+        "sha256": "c6ed7894911acfe075381c01b07745d92e9259fac510a849f742edb6b95c89de",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.3.20.tar.gz",
+        "name": "PHP 7.3.20 (tar.gz)",
+        "sha256": "d0579b8a6bcdd5e1ae334d83261f2389b0d3d4fd54cc808e20a5031121f97d87",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.3.20.tar.xz",
+        "name": "PHP 7.3.20 (tar.xz)",
+        "sha256": "43292046f6684eb13acb637276d4aa1dd9f66b0b7045e6f1493bc90db389b888",
+        "date": "09 Jul 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.32": {
+    "announcement": {
+      "English": "/releases/7_2_32.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jul 2020",
+    "source": [
+      {
+        "filename": "php-7.2.32.tar.bz2",
+        "name": "PHP 7.2.32 (tar.bz2)",
+        "sha256": "715c0a4274ad17ce449cd0f16b8a7428936e3ba80002d0948a8699a6f75d98a7",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.2.32.tar.gz",
+        "name": "PHP 7.2.32 (tar.gz)",
+        "sha256": "b3aabb99e574c407dd58ad071fc52e27c489608fe06f1330d688d0fb7349089c",
+        "date": "09 Jul 2020"
+      },
+      {
+        "filename": "php-7.2.32.tar.xz",
+        "name": "PHP 7.2.32 (tar.xz)",
+        "sha256": "050fc16ca56d8d2365d980998220a4eb06439da71dfd38de49b42fea72310ef1",
+        "date": "09 Jul 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.7": {
+    "announcement": {
+      "English": "/releases/7_4_7.php"
+    },
+    "tags": [],
+    "date": "11 June 2020",
+    "source": [
+      {
+        "filename": "php-7.4.7.tar.bz2",
+        "name": "PHP 7.4.7 (tar.bz2)",
+        "sha256": "800e0d01f359c8ec41540925c0d4a24c34d5f21ef6addd6d82ff4a52be23d87a",
+        "date": "11 June 2020"
+      },
+      {
+        "filename": "php-7.4.7.tar.gz",
+        "name": "PHP 7.4.7 (tar.gz)",
+        "sha256": "a554a510190e726ebe7157fb00b4aceabdb50c679430510a3b93cbf5d7546e44",
+        "date": "11 June 2020"
+      },
+      {
+        "filename": "php-7.4.7.tar.xz",
+        "name": "PHP 7.4.7 (tar.xz)",
+        "sha256": "53558f8f24cd8ab6fa0ea252ca8198e2650160649681ce5230c1df1dc2b52faf",
+        "date": "11 June 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.31": {
+    "announcement": {
+      "English": "/releases/7_2_31.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 May 2020",
+    "source": [
+      {
+        "filename": "php-7.2.31.tar.bz2",
+        "name": "PHP 7.2.31 (tar.bz2)",
+        "sha256": "1ba7559745d704f39764a5deb002eb94f5cb8d9aaa219a6b8b32b94174e8a700",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.2.31.tar.gz",
+        "name": "PHP 7.2.31 (tar.gz)",
+        "sha256": "796837831ccebf00dc15921ed327cfbac59177da41b33044d9a6c7134cdd250c",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.2.31.tar.xz",
+        "name": "PHP 7.2.31 (tar.xz)",
+        "sha256": "8beaa634bb878a96af9bc8643811ea46973f5f41ad2bfb6ab4cfd290e5a39806",
+        "date": "14 May 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.19": {
+    "announcement": {
+      "English": "/releases/7_3_19.php"
+    },
+    "tags": [],
+    "date": "11 Jun 2020",
+    "source": [
+      {
+        "filename": "php-7.3.19.tar.bz2",
+        "name": "PHP 7.3.19 (tar.bz2)",
+        "sha256": "0d9c1e31e29fb46ff660b48051d169d50cb0285e611d16591449d578320d34a5",
+        "date": "11 Jun 2020"
+      },
+      {
+        "filename": "php-7.3.19.tar.gz",
+        "name": "PHP 7.3.19 (tar.gz)",
+        "sha256": "809126b46d62a1a06c2d5a0f9d7ba61aba40e165f24d2d185396d0f9646d3280",
+        "date": "11 Jun 2020"
+      },
+      {
+        "filename": "php-7.3.19.tar.xz",
+        "name": "PHP 7.3.19 (tar.xz)",
+        "sha256": "6402faa19b1a8c4317c7612632bce985684a5bbae0980a5779a4019439882422",
+        "date": "11 Jun 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.6": {
+    "announcement": {
+      "English": "/releases/7_4_6.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 May 2020",
+    "source": [
+      {
+        "filename": "php-7.4.6.tar.bz2",
+        "name": "PHP 7.4.6 (tar.bz2)",
+        "sha256": "a6ed9475695d2056322a3f2c00fee61a122a7fce138a0e25694320c5dd1d2348",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.4.6.tar.gz",
+        "name": "PHP 7.4.6 (tar.gz)",
+        "sha256": "2a37bab4e308c4e3867083137b7cce4a3f1d996ae231b383c1a83609cec3fed0",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.4.6.tar.xz",
+        "name": "PHP 7.4.6 (tar.xz)",
+        "sha256": "d740322f84f63019622b9f369d64ea5ab676547d2bdcf12be77a5a4cffd06832",
+        "date": "14 May 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.18": {
+    "announcement": {
+      "English": "/releases/7_3_18.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 May 2020",
+    "source": [
+      {
+        "filename": "php-7.3.18.tar.bz2",
+        "name": "PHP 7.3.18 (tar.bz2)",
+        "sha256": "749d21f65deb57153b575f846705f5db54732c6b672e80612b29dcf1a53be8a4",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.3.18.tar.gz",
+        "name": "PHP 7.3.18 (tar.gz)",
+        "sha256": "3211d5d6ea8a27c2794498a551bf26e334bc2b986741971809c9bb650eaa47a3",
+        "date": "14 May 2020"
+      },
+      {
+        "filename": "php-7.3.18.tar.xz",
+        "name": "PHP 7.3.18 (tar.xz)",
+        "sha256": "7b3e2479a8d6fd7666dcdef8aec50d49c4599cc6ee86e48d41724cfd99cc9e58",
+        "date": "14 May 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.5": {
+    "announcement": {
+      "English": "/releases/7_4_5.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "16 Apr 2020",
+    "source": [
+      {
+        "filename": "php-7.4.5.tar.bz2",
+        "name": "PHP 7.4.5 (tar.bz2)",
+        "sha256": "39daa533d5b63c3394da711dc12867dd76c2ec31c940bbba16f14e577df13d6f",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.4.5.tar.gz",
+        "name": "PHP 7.4.5 (tar.gz)",
+        "sha256": "1ef619411b0bd68c0fbfd2a6c622ad6bc524d0bceb8476fb9807a23a0fe9a343",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.4.5.tar.xz",
+        "name": "PHP 7.4.5 (tar.xz)",
+        "sha256": "d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c",
+        "date": "16 Apr 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.17": {
+    "announcement": {
+      "English": "/releases/7_3_17.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "16 Apr 2020",
+    "source": [
+      {
+        "filename": "php-7.3.17.tar.bz2",
+        "name": "PHP 7.3.17 (tar.bz2)",
+        "sha256": "d83e90d9024c999f209933732ed4e1d0e7295a67c66ab79490898ea0a4a29709",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.3.17.tar.gz",
+        "name": "PHP 7.3.17 (tar.gz)",
+        "sha256": "0dd484382b8f17dfa8afd44236a5ccf374e1f03de06ef826ebcbda98eadc7bda",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.3.17.tar.xz",
+        "name": "PHP 7.3.17 (tar.xz)",
+        "sha256": "6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8",
+        "date": "16 Apr 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.30": {
+    "announcement": {
+      "English": "/releases/7_2_30.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "16 Apr 2020",
+    "source": [
+      {
+        "filename": "php-7.2.30.tar.bz2",
+        "name": "PHP 7.2.30 (tar.bz2)",
+        "sha256": "c4cf5c9debe8fd8def0a933231cf2fa3a8bdd22555ae57e825bfac6a87a712bf",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.2.30.tar.gz",
+        "name": "PHP 7.2.30 (tar.gz)",
+        "sha256": "daa53d22510b0fd433904d1c3de460746860a974b776f727ac8acecb44e16e2f",
+        "date": "16 Apr 2020"
+      },
+      {
+        "filename": "php-7.2.30.tar.xz",
+        "name": "PHP 7.2.30 (tar.xz)",
+        "sha256": "aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3",
+        "date": "16 Apr 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.29": {
+    "announcement": {
+      "English": "/releases/7_2_29.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "19 Mar 2020",
+    "source": [
+      {
+        "filename": "php-7.2.29.tar.bz2",
+        "name": "PHP 7.2.29 (tar.bz2)",
+        "sha256": "eaa1f5503f2bf0c8569ec4ae80ffd8ca8cbc260f01c2503dd0e83dfc9cf0b923",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.2.29.tar.gz",
+        "name": "PHP 7.2.29 (tar.gz)",
+        "sha256": "ea5c96309394a03a38828cc182058be0c09dde1f00f35809622c2d05c50ee890",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.2.29.tar.xz",
+        "name": "PHP 7.2.29 (tar.xz)",
+        "sha256": "b117de74136bf4b439d663be9cf0c8e06a260c1f340f6b75ccadb609153a7fe8",
+        "date": "19 Mar 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.4": {
+    "announcement": {
+      "English": "/releases/7_4_4.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "19 Mar 2020",
+    "source": [
+      {
+        "filename": "php-7.4.4.tar.bz2",
+        "name": "PHP 7.4.4 (tar.bz2)",
+        "sha256": "308e8f4182ec8a2767b0b1b8e1e7c69fb149b37cfb98ee4a37475e082fa9829f",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.4.4.tar.gz",
+        "name": "PHP 7.4.4 (tar.gz)",
+        "sha256": "1581b3e10c7854597e1086937d5753cdf92d132865c06a50aed4f4f407138616",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.4.4.tar.xz",
+        "name": "PHP 7.4.4 (tar.xz)",
+        "sha256": "1873c4cefdd3df9a78dcffb2198bba5c2f0464f55c9c960720c84df483fca74c",
+        "date": "19 Mar 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.16": {
+    "announcement": {
+      "English": "/releases/7_3_16.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "19 Mar 2020",
+    "source": [
+      {
+        "filename": "php-7.3.16.tar.bz2",
+        "name": "PHP 7.3.16 (tar.bz2)",
+        "sha256": "b8072d526a283182963b03960b7982392daa43cb31131eca4cf0b996764a042e",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.3.16.tar.gz",
+        "name": "PHP 7.3.16 (tar.gz)",
+        "sha256": "a01ae4f6baf427413c28f8cfddbae86aeff61cdb88658e75404f2d93d98e3255",
+        "date": "19 Mar 2020"
+      },
+      {
+        "filename": "php-7.3.16.tar.xz",
+        "name": "PHP 7.3.16 (tar.xz)",
+        "sha256": "91aaee3dbdc71b69b4f3292f9d99211172a2fa926c3f3bbdb0e85dab03dd2bcb",
+        "date": "19 Mar 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.3": {
+    "announcement": {
+      "English": "/releases/7_4_3.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "20 Feb 2020",
+    "source": [
+      {
+        "filename": "php-7.4.3.tar.bz2",
+        "name": "PHP 7.4.3 (tar.bz2)",
+        "sha256": "c1517ba49578fb2dcc64c73a3edc76d4fc507c4a7ac639981584cc7d3b4c6d14",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.4.3.tar.gz",
+        "name": "PHP 7.4.3 (tar.gz)",
+        "sha256": "58e421a1dba10da8542a014535cac77a78f0271afb901cc2bd363b881895a9ed",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.4.3.tar.xz",
+        "name": "PHP 7.4.3 (tar.xz)",
+        "sha256": "cf1f856d877c268124ded1ede40c9fb6142b125fdaafdc54f855120b8bc6982a",
+        "date": "20 Feb 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.28": {
+    "announcement": {
+      "English": "/releases/7_2_28.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "20 Feb 2020",
+    "source": [
+      {
+        "filename": "php-7.2.28.tar.bz2",
+        "name": "PHP 7.2.28 (tar.bz2)",
+        "sha256": "7c953a5b79db3d8d45c65014aef382a48e1c3435cf0c2574e942957f0cdd52a3",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.2.28.tar.gz",
+        "name": "PHP 7.2.28 (tar.gz)",
+        "sha256": "ed5fede7602ccd8d1294b4e4aef7f92f4e3af58ab040bd349264b3f5dbef3261",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.2.28.tar.xz",
+        "name": "PHP 7.2.28 (tar.xz)",
+        "sha256": "afe1863301da572dee2e0bad8014813bcced162f980ddc8ec8e41fd72263eb2d",
+        "date": "20 Feb 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.15": {
+    "announcement": {
+      "English": "/releases/7_3_15.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "20 Feb 2020",
+    "source": [
+      {
+        "filename": "php-7.3.15.tar.bz2",
+        "name": "PHP 7.3.15 (tar.bz2)",
+        "sha256": "8dbe1507ea0035f4211faa0db80fe95f39df0e39d8408223820fe9123487043d",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.3.15.tar.gz",
+        "name": "PHP 7.3.15 (tar.gz)",
+        "sha256": "c606dd09de2edff1e6b6c5b9f0076214a59f6f1a3272e15d681ed16257737ef6",
+        "date": "20 Feb 2020"
+      },
+      {
+        "filename": "php-7.3.15.tar.xz",
+        "name": "PHP 7.3.15 (tar.xz)",
+        "sha256": "de7ae7cf3d1dbb2824975b26b32991dac2b732886ec22075b8c53b261b018166",
+        "date": "20 Feb 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.2": {
+    "announcement": {
+      "English": "/releases/7_4_2.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Jan 2020",
+    "source": [
+      {
+        "filename": "php-7.4.2.tar.bz2",
+        "name": "PHP 7.4.2 (tar.bz2)",
+        "sha256": "02909974be9c70814ed5652a6bdae9c74220d41c1e5ed5ad921e15d028f8e816",
+        "date": "23 Jan 2020"
+      },
+      {
+        "filename": "php-7.4.2.tar.gz",
+        "name": "PHP 7.4.2 (tar.gz)",
+        "sha256": "e1b8dbf561ac1d871362054ff4cd62dca5e19c8c896567996525dda7c4b320f9",
+        "date": "23 Jan 2020"
+      },
+      {
+        "filename": "php-7.4.2.tar.xz",
+        "name": "PHP 7.4.2 (tar.xz)",
+        "sha256": "98284deac017da0d426117ecae7599a1f1bf62ae3911e8bc16c4403a8f4bdf13",
+        "date": "23 Jan 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.14": {
+    "announcement": {
+      "English": "/releases/7_3_14.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Jan 2020",
+    "source": [
+      {
+        "filename": "php-7.3.14.tar.bz2",
+        "name": "PHP 7.3.14 (tar.bz2)",
+        "sha256": "b9dfcbbbc929ce67995f976de8636c5f46804593ecae6e110509329b9dc6c272",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.3.14.tar.gz",
+        "name": "PHP 7.3.14 (tar.gz)",
+        "sha256": "6aff532a380b0f30c9e295b67dc91d023fee3b0ae14b4771468bf5dda4cbf108",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.3.14.tar.xz",
+        "name": "PHP 7.3.14 (tar.xz)",
+        "sha256": "cc05dd373ca5d36652800762f65c10e828a17de35aaf246262e3efa99d00cdb0",
+        "date": "18 Dec 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.27": {
+    "announcement": {
+      "English": "/releases/7_2_27.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Jan 2020",
+    "source": [
+      {
+        "filename": "php-7.2.27.tar.bz2",
+        "name": "PHP 7.2.27 (tar.bz2)",
+        "sha256": "5bc0695b171b870ceb083c5432c6a758d3dbd3830a0cf6cf35bd9b283a627049",
+        "date": "23 Jan 2020"
+      },
+      {
+        "filename": "php-7.2.27.tar.gz",
+        "name": "PHP 7.2.27 (tar.gz)",
+        "sha256": "e00ace5e89cb162cba0aebd17144541e1c4d965589155a44ca706d9f9c5a8981",
+        "date": "23 Jan 2020"
+      },
+      {
+        "filename": "php-7.2.27.tar.xz",
+        "name": "PHP 7.2.27 (tar.xz)",
+        "sha256": "7bd0fb9e3b63cfe53176d1f3565cd686f90b3926217158de5ba57091f49e4c32",
+        "date": "23 Jan 2020"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.13": {
+    "announcement": {
+      "English": "/releases/7_3_13.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "18 Dec 2019",
+    "source": [
+      {
+        "filename": "php-7.3.13.tar.bz2",
+        "name": "PHP 7.3.13 (tar.bz2)",
+        "sha256": "5c7b89062814f3c3953d1518f63ed463fd452929e3a37110af4170c5d23267bc",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.3.13.tar.gz",
+        "name": "PHP 7.3.13 (tar.gz)",
+        "sha256": "9cf835416a3471d7e6615e9288e76813d55ffaf60e0aa9ce74884a7c228cb6dd",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.3.13.tar.xz",
+        "name": "PHP 7.3.13 (tar.xz)",
+        "sha256": "57ac55fe442d2da650abeb9e6fa161bd3a98ba6528c029f076f8bba43dd5c228",
+        "date": "18 Dec 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.26": {
+    "announcement": {
+      "English": "/releases/7_2_26.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "18 Dec 2019",
+    "source": [
+      {
+        "filename": "php-7.2.26.tar.bz2",
+        "name": "PHP 7.2.26 (tar.bz2)",
+        "sha256": "f36d86eecf57ff919d6f67b064e1f41993f62e3991ea4796038d8d99c74e847b",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.2.26.tar.gz",
+        "name": "PHP 7.2.26 (tar.gz)",
+        "sha256": "e97d0636478bb519cd955a0c17b7970cf173063a840a83fc4afb75c22bc1bf08",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.2.26.tar.xz",
+        "name": "PHP 7.2.26 (tar.xz)",
+        "sha256": "1dd3bc875e105f5c9d21fb4dc240670bd2c22037820ff03890f5ab883c88b78d",
+        "date": "18 Dec 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.1": {
+    "announcement": {
+      "English": "/releases/7_4_1.php"
+    },
+    "tags": [],
+    "date": "18 Dec 2019",
+    "source": [
+      {
+        "filename": "php-7.4.1.tar.bz2",
+        "name": "PHP 7.4.1 (tar.bz2)",
+        "sha256": "6b1ca0f0b83aa2103f1e454739665e1b2802b90b3137fc79ccaa8c242ae48e4e",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.4.1.tar.gz",
+        "name": "PHP 7.4.1 (tar.gz)",
+        "sha256": "67265d6bd48d828f4725964f71ca5c76c3da63b0d07bec5ec4e5acfdd3708073",
+        "date": "18 Dec 2019"
+      },
+      {
+        "filename": "php-7.4.1.tar.xz",
+        "name": "PHP 7.4.1 (tar.xz)",
+        "sha256": "561bb866bdd509094be00f4ece7c3543ec971c4d878645ee81437e291cffc762",
+        "date": "18 Dec 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.25": {
+    "announcement": {
+      "English": "/releases/7_2_25.php"
+    },
+    "tags": [],
+    "date": "21 Nov 2019",
+    "source": [
+      {
+        "filename": "php-7.2.25.tar.bz2",
+        "name": "PHP 7.2.25 (tar.bz2)",
+        "sha256": "7cb336b1ed0f9d87f46bbcb7b3437ee252d0d5060c0fb1a985adb6cbc73a6b9e",
+        "date": "21 Nov 2019"
+      },
+      {
+        "filename": "php-7.2.25.tar.gz",
+        "name": "PHP 7.2.25 (tar.gz)",
+        "sha256": "b2cb1bd46454d33b2c65c2fd559f464cd14e57dd47b953adf5caa77fdf0de52b",
+        "date": "21 Nov 2019"
+      },
+      {
+        "filename": "php-7.2.25.tar.xz",
+        "name": "PHP 7.2.25 (tar.xz)",
+        "sha256": "746efeedc38e6ff7b1ec1432440f5fa801537adf6cd21e4afb3f040e5b0760a9",
+        "date": "21 Nov 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.12": {
+    "announcement": {
+      "English": "/releases/7_3_12.php"
+    },
+    "tags": [],
+    "date": "21 Nov 2019",
+    "source": [
+      {
+        "filename": "php-7.3.12.tar.bz2",
+        "name": "PHP 7.3.12 (tar.bz2)",
+        "sha256": "d317b029f991410578cc38ba4b76c9f764ec29c67e7124e1fec57bceb3ad8c39",
+        "date": "21 Nov 2019"
+      },
+      {
+        "filename": "php-7.3.12.tar.gz",
+        "name": "PHP 7.3.12 (tar.gz)",
+        "sha256": "d617e5116f8472a628083f448ebe4afdbc4ac013c9a890b08946649dcbe61b34",
+        "date": "21 Nov 2019"
+      },
+      {
+        "filename": "php-7.3.12.tar.xz",
+        "name": "PHP 7.3.12 (tar.xz)",
+        "sha256": "aafe5e9861ad828860c6af8c88cdc1488314785962328eb1783607c1fdd855df",
+        "date": "21 Nov 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.4.0": {
+    "announcement": {
+      "English": "/releases/7_4_0.php"
+    },
+    "tags": [],
+    "date": "28 Nov 2019",
+    "source": [
+      {
+        "filename": "php-7.4.0.tar.bz2",
+        "name": "PHP 7.4.0 (tar.bz2)",
+        "sha256": "bf206be96a39e643180013df39ddcd0493966692a2422c4b7d3355b6a15a01c0",
+        "date": "28 Nov 2019"
+      },
+      {
+        "filename": "php-7.4.0.tar.gz",
+        "name": "PHP 7.4.0 (tar.gz)",
+        "sha256": "004a1a8176176ee1b5c112e73d705977507803f425f9e48cb4a84f42b22abf22",
+        "date": "28 Nov 2019"
+      },
+      {
+        "filename": "php-7.4.0.tar.xz",
+        "name": "PHP 7.4.0 (tar.xz)",
+        "sha256": "9bb751b20e5d6cc1ea9b1ebf23ef2d5f07f99b2d9cc417bf1d70c04f8b20ec42",
+        "date": "28 Nov 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.1.33": {
+    "announcement": {
+      "English": "/releases/7_1_33.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "24 Oct 2019",
+    "source": [
+      {
+        "filename": "php-7.1.33.tar.bz2",
+        "name": "PHP 7.1.33 (tar.bz2)",
+        "sha256": "95a5e5f2e2b79b376b737a82d9682c91891e60289fa24183463a2aca158f4f4b",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.1.33.tar.gz",
+        "name": "PHP 7.1.33 (tar.gz)",
+        "sha256": "0055f368ffefe51d5a4483755bd17475e88e74302c08b727952831c5b2682ea2",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.1.33.tar.xz",
+        "name": "PHP 7.1.33 (tar.xz)",
+        "sha256": "bd7c0a9bd5433289ee01fd440af3715309faf583f75832b64fe169c100d52968",
+        "date": "24 Oct 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.24": {
+    "announcement": {
+      "English": "/releases/7_2_24.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "24 Oct 2019",
+    "source": [
+      {
+        "filename": "php-7.2.24.tar.bz2",
+        "name": "PHP 7.2.24 (tar.bz2)",
+        "sha256": "a079934db63068bbcc9bbd2e7b916b9891fc97719862697e5f954c639984f603",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.2.24.tar.gz",
+        "name": "PHP 7.2.24 (tar.gz)",
+        "sha256": "01baf7a34c856d2c552121fbad7296a8cde18389ce83db32f18252bc1cee4dd6",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.2.24.tar.xz",
+        "name": "PHP 7.2.24 (tar.xz)",
+        "sha256": "a6a6cc03388060aa5f8f9e45799b72bce1c7ed7b9d7b3f1187787202aad91d25",
+        "date": "24 Oct 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.11": {
+    "announcement": {
+      "English": "/releases/7_3_11.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "24 Oct 2019",
+    "source": [
+      {
+        "filename": "php-7.3.11.tar.bz2",
+        "name": "PHP 7.3.11 (tar.bz2)",
+        "sha256": "92d1ff4b13c7093635f1ec338a5e6891ca99b10e65fbcadd527e5bb84d11b5e7",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.3.11.tar.gz",
+        "name": "PHP 7.3.11 (tar.gz)",
+        "sha256": "8f385f5bdf9193791f6c0f6303f518f3c324b6655ac108fdb3c426da7f3cf4d4",
+        "date": "24 Oct 2019"
+      },
+      {
+        "filename": "php-7.3.11.tar.xz",
+        "name": "PHP 7.3.11 (tar.xz)",
+        "sha256": "657cf6464bac28e9490c59c07a2cf7bb76c200f09cfadf6e44ea64e95fa01021",
+        "date": "24 Oct 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.1.32": {
+    "announcement": {
+      "English": "/releases/7_1_32.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.1.32.tar.bz2",
+        "name": "PHP 7.1.32 (tar.bz2)",
+        "sha256": "d7c7a1adddc75ac17f63349e966db25930b6b3ce736640349bea9e10909cab7a",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.1.32.tar.gz",
+        "name": "PHP 7.1.32 (tar.gz)",
+        "sha256": "6e51a2fc610352438b2a1c40310468a1e2b5baf2fff43be77f9f408a9111590c",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.1.32.tar.xz",
+        "name": "PHP 7.1.32 (tar.xz)",
+        "sha256": "7f38b5bdaae3184d325a8c70e86c010afcc33651d15faafe277a0db6d2ea2741",
+        "date": "29 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.10": {
+    "announcement": {
+      "English": "/releases/7_3_10.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "26 Sep 2019",
+    "source": [
+      {
+        "filename": "php-7.3.10.tar.bz2",
+        "name": "PHP 7.3.10 (tar.bz2)",
+        "sha256": "506dd871c0fb8f00f872f53dd3b1dfa5f23a9edb4dfc521e5669c78a78c45448",
+        "date": "26 Sep 2019"
+      },
+      {
+        "filename": "php-7.3.10.tar.gz",
+        "name": "PHP 7.3.10 (tar.gz)",
+        "sha256": "fb670723a9b8fda31c89529f27e0dda289d8af4b6ce9f152c8010876639c0fb4",
+        "date": "26 Sep 2019"
+      },
+      {
+        "filename": "php-7.3.10.tar.xz",
+        "name": "PHP 7.3.10 (tar.xz)",
+        "sha256": "42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906",
+        "date": "26 Sep 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.23": {
+    "announcement": {
+      "English": "/releases/7_2_23.php"
+    },
+    "tags": [],
+    "date": "26 Sep 2019",
+    "source": [
+      {
+        "filename": "php-7.2.23.tar.bz2",
+        "name": "PHP 7.2.23 (tar.bz2)",
+        "sha256": "a17af3643d29d7e730f977e3776dc3e325d5ca00b361e41dbfc2368ebad5430d",
+        "date": "26 Sep 2019"
+      },
+      {
+        "filename": "php-7.2.23.tar.gz",
+        "name": "PHP 7.2.23 (tar.gz)",
+        "sha256": "b32b426c84ff45154d6c11f00aff433bcac831a5c0a09bf0297075eefaea8fcc",
+        "date": "26 Sep 2019"
+      },
+      {
+        "filename": "php-7.2.23.tar.xz",
+        "name": "PHP 7.2.23 (tar.xz)",
+        "sha256": "74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14",
+        "date": "26 Sep 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.22": {
+    "announcement": {
+      "English": "/releases/7_2_22.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.2.22.tar.bz2",
+        "name": "PHP 7.2.22 (tar.bz2)",
+        "sha256": "c10a9883b586ada5ef1149f2571625b27efdcc3e70a04fbb9121979633b0f08a",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.2.22.tar.gz",
+        "name": "PHP 7.2.22 (tar.gz)",
+        "sha256": "6e2ccc77484c27971d4550b7071a57b79bc910bfb2d4a74a57ae2c18b78c3dc7",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.2.22.tar.xz",
+        "name": "PHP 7.2.22 (tar.xz)",
+        "sha256": "eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3",
+        "date": "29 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.9": {
+    "announcement": {
+      "English": "/releases/7_3_9.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.3.9.tar.bz2",
+        "name": "PHP 7.3.9 (tar.bz2)",
+        "sha256": "a39c9709a8c9eb7ea8ac4933ef7a78b92f7e5735a405c8b8e42ee39541d963c4",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.3.9.tar.gz",
+        "name": "PHP 7.3.9 (tar.gz)",
+        "sha256": "5ecc1b1ad7228ed2e99a970c45358871644fcab1d9fd079a7b129326a7bde42d",
+        "date": "29 Aug 2019"
+      },
+      {
+        "filename": "php-7.3.9.tar.xz",
+        "name": "PHP 7.3.9 (tar.xz)",
+        "sha256": "4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd",
+        "date": "29 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.1.31": {
+    "announcement": {
+      "English": "/releases/7_1_31.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.1.31.tar.bz2",
+        "name": "PHP 7.1.31 (tar.bz2)",
+        "sha256": "767573c2b732e78cc647602ec61fc948941a941a4071db59b522cf5e076825dd",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.1.31.tar.gz",
+        "name": "PHP 7.1.31 (tar.gz)",
+        "sha256": "ea0558735653b9ce63e9cea41dd8f0d0b90dba6c39d39dd9a6aad5cc58b0bdfc",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.1.31.tar.xz",
+        "name": "PHP 7.1.31 (tar.xz)",
+        "sha256": "5cb53b63592ec4361f0ab12c684b10430344821a024881a387ead4299df78fa5",
+        "date": "01 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.21": {
+    "announcement": {
+      "English": "/releases/7_2_21.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.2.21.tar.bz2",
+        "name": "PHP 7.2.21 (tar.bz2)",
+        "sha256": "343183a1be8336670171885c761d57ffcae99cbbcf1db43da7cb5565056b14ef",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.2.21.tar.gz",
+        "name": "PHP 7.2.21 (tar.gz)",
+        "sha256": "8327682bee4a8fd2edf5bbfcc393d986b945bec433fc74458d05e766701b313c",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.2.21.tar.xz",
+        "name": "PHP 7.2.21 (tar.xz)",
+        "sha256": "de06aff019d8f5079115795bd7d8eedd4cd03daecb62d58abb18f492dd995c95",
+        "date": "01 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.8": {
+    "announcement": {
+      "English": "/releases/7_3_8.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Aug 2019",
+    "source": [
+      {
+        "filename": "php-7.3.8.tar.bz2",
+        "name": "PHP 7.3.8 (tar.bz2)",
+        "sha256": "d566c630175d9fa84a98d3c9170ec033069e9e20c8d23dea49ae2a976b6c76f5",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.3.8.tar.gz",
+        "name": "PHP 7.3.8 (tar.gz)",
+        "sha256": "31af3eff3337fb70733c9b02a3444c3dae662ecab20aeec7fdc3c42e22071490",
+        "date": "01 Aug 2019"
+      },
+      {
+        "filename": "php-7.3.8.tar.xz",
+        "name": "PHP 7.3.8 (tar.xz)",
+        "sha256": "f6046b2ae625d8c04310bda0737ac660dc5563a8e04e8a46c1ee24ea414ad5a5",
+        "date": "01 Aug 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.1.30": {
+    "announcement": {
+      "English": "/releases/7_1_30.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "30 May 2019",
+    "source": [
+      {
+        "filename": "php-7.1.30.tar.bz2",
+        "name": "PHP 7.1.30 (tar.bz2)",
+        "sha256": "664850774fca19d2710b9aa35e9ae91214babbde9cd8d27fd3479cc97171ecb3",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.1.30.tar.gz",
+        "name": "PHP 7.1.30 (tar.gz)",
+        "sha256": "a604edf85d5dfc28e6ff3016dad3954c50b93db69afc42295178b4fdf42e026c",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.1.30.tar.xz",
+        "name": "PHP 7.1.30 (tar.xz)",
+        "sha256": "6310599811536dbe87e4bcf212bf93196bdfaff519d0c821e4c0068efd096a7c",
+        "date": "30 May 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.20": {
+    "announcement": {
+      "English": "/releases/7_2_20.php"
+    },
+    "tags": [],
+    "date": "04 Jul 2019",
+    "source": [
+      {
+        "filename": "php-7.2.20.tar.bz2",
+        "name": "PHP 7.2.20 (tar.bz2)",
+        "sha256": "9fb829e54e54c483ae8892d1db0f7d79115cc698f2f3591a8a5e58d9410dca84",
+        "date": "04 Jul 2019"
+      },
+      {
+        "filename": "php-7.2.20.tar.gz",
+        "name": "PHP 7.2.20 (tar.gz)",
+        "sha256": "d1dbf6f299514c9aa55b2995928b798b27c21811a0447f0688993cdf36be0749",
+        "date": "04 Jul 2019"
+      },
+      {
+        "filename": "php-7.2.20.tar.xz",
+        "name": "PHP 7.2.20 (tar.xz)",
+        "sha256": "eff09da83e235c2ba25c85deea1d4f663bd71d50fd51ad11e1acebe26d733494",
+        "date": "04 Jul 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.3.7": {
+    "announcement": {
+      "English": "/releases/7_3_7.php"
+    },
+    "tags": [],
+    "date": "04 Jul 2019",
+    "source": [
+      {
+        "filename": "php-7.3.7.tar.bz2",
+        "name": "PHP 7.3.7 (tar.bz2)",
+        "sha256": "c3608fa7114642725854119ccffe722f42fc7c31e5e4c00d5cb4cb1a0d16bf18",
+        "date": "04 Jul 2019"
+      },
+      {
+        "filename": "php-7.3.7.tar.gz",
+        "name": "PHP 7.3.7 (tar.gz)",
+        "sha256": "4230bbc862df712b013369de94b131eddea1e5e946a8c5e286b82d441c313328",
+        "date": "04 Jul 2019"
+      },
+      {
+        "filename": "php-7.3.7.tar.xz",
+        "name": "PHP 7.3.7 (tar.xz)",
+        "sha256": "ba067200ba649956b3a92ec8b71a6ed8ce8a099921212443c1bcf3260a29274c",
+        "date": "04 Jul 2019"
+      }
+    ],
+    "museum": false
+  },
+  "7.2.19": {
+    "announcement": {
+      "English": "/releases/19.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.19.tar.bz2",
+        "name": "PHP 7.2.19 (tar.bz2)",
+        "sha256": "ebd0b1f375fe07ed4925acc213d2f5ef76a61bd5de174e7b666b98421a90a099",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.2.19.tar.gz",
+        "name": "PHP 7.2.19 (tar.gz)",
+        "sha256": "1cd2266a058f3224d3cba594540045542606996f026eeef96747f27f6b3d22b6",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.2.19.tar.xz",
+        "name": "PHP 7.2.19 (tar.xz)",
+        "sha256": "4ffa2404a88d60e993a9fe69f829ebec3eb1e006de41b6048ce5e91bbeaa9282",
+        "date": "30 May 2019"
+      }
+    ],
+    "date": "30 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.6": {
+    "announcement": {
+      "English": "/releases/7_3_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.6.tar.bz2",
+        "name": "PHP 7.3.6 (tar.bz2)",
+        "sha256": "1e5ac8700154835c0910e3a814517da9b87bb4a82cc7011fea1a82096b6f6f77",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.3.6.tar.gz",
+        "name": "PHP 7.3.6 (tar.gz)",
+        "sha256": "72fbf223ff8659a61eed08eebffb4ede0256e7a69d2151ae24affa5377b70bb8",
+        "date": "30 May 2019"
+      },
+      {
+        "filename": "php-7.3.6.tar.xz",
+        "name": "PHP 7.3.6 (tar.xz)",
+        "sha256": "fefc8967daa30ebc375b2ab2857f97da94ca81921b722ddac86b29e15c54a164",
+        "date": "30 May 2019"
+      }
+    ],
+    "date": "30 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.29": {
+    "announcement": {
+      "English": "/releases/7_1_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.29.tar.bz2",
+        "name": "PHP 7.1.29 (tar.bz2)",
+        "sha256": "8528d17efe82662dc740d96ddb32217f4e161a597d709f19571b0c82fbb88335",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.1.29.tar.gz",
+        "name": "PHP 7.1.29 (tar.gz)",
+        "sha256": "bdd0e1707100c8b87f1be516f5b95a26e3eb4114d4316eaf0663bf292ead35bb",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.1.29.tar.xz",
+        "name": "PHP 7.1.29 (tar.xz)",
+        "sha256": "b9a9b094687edc2d9c9553d5531e38e249b569127cf3b32fe1c84280509746fb",
+        "date": "02 May 2019"
+      }
+    ],
+    "date": "02 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.18": {
+    "announcement": {
+      "English": "/releases/7_2_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.18.tar.bz2",
+        "name": "PHP 7.2.18 (tar.bz2)",
+        "sha256": "fa1a27b12d1173207e81e798a48d4a7f77ba897f5c5200ac0b5d62aa8b4c4b72",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.2.18.tar.gz",
+        "name": "PHP 7.2.18 (tar.gz)",
+        "sha256": "48aeb291814f3cd3ba03c52e79e8e61896d0271fd4c228198f80a072e568f84b",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.2.18.tar.xz",
+        "name": "PHP 7.2.18 (tar.xz)",
+        "sha256": "9970dbb3ab1298c9e6aac54bebfa841c8ad14b18eead65594a68fa841364cb8d",
+        "date": "02 May 2019"
+      }
+    ],
+    "date": "30 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.5": {
+    "announcement": {
+      "English": "/releases/7_3_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.5.tar.bz2",
+        "name": "PHP 7.3.5 (tar.bz2)",
+        "sha256": "4380b80ef98267c3823c3416eb05f7729ba7a33de6b3d14ec96013215d62c35e",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.3.5.tar.gz",
+        "name": "PHP 7.3.5 (tar.gz)",
+        "sha256": "c953749b7f3310a3a74f920ef698f6d1c04636d11656ac9ffb3ab10d34e30e1e",
+        "date": "02 May 2019"
+      },
+      {
+        "filename": "php-7.3.5.tar.xz",
+        "name": "PHP 7.3.5 (tar.xz)",
+        "sha256": "e1011838a46fd4a195c8453b333916622d7ff5bce4aca2d9d99afac142db2472",
+        "date": "02 May 2019"
+      }
+    ],
+    "date": "02 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.28": {
+    "announcement": {
+      "English": "/releases/7_1_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.28.tar.bz2",
+        "name": "PHP 7.1.28 (tar.bz2)",
+        "sha256": "739e8733fe1fc5e69e6226da6dba7a31bacfd2e3871ad2c97a792638f22c54c9",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.1.28.tar.gz",
+        "name": "PHP 7.1.28 (tar.gz)",
+        "sha256": "4df587338d4c5dfe27050c7ac72a6b7583ecaee9d3fbfc03427667a86e081999",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.1.28.tar.xz",
+        "name": "PHP 7.1.28 (tar.xz)",
+        "sha256": "45131497ec0a947e3f9145c000e8fcc1f86b46518ee3f6810d80efa2d39521e2",
+        "date": "04 Apr 2019"
+      }
+    ],
+    "date": "02 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.17": {
+    "announcement": {
+      "English": "/releases/7_2_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.17.tar.bz2",
+        "name": "PHP 7.2.17 (tar.bz2)",
+        "sha256": "91a811ab6f6d7acb312159cf6b0a3cffe968676fdebf042e9253245cc6094f75",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.2.17.tar.gz",
+        "name": "PHP 7.2.17 (tar.gz)",
+        "sha256": "e1c6c2553cdb7edbfa65b89e259690ed01b31b12d57349c90b6ed00a410f62b5",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.2.17.tar.xz",
+        "name": "PHP 7.2.17 (tar.xz)",
+        "sha256": "a3e5f51a9ae08813b3925bea3a4de02cd4906fcccf75646e267a213bb63bcf84",
+        "date": "04 Apr 2019"
+      }
+    ],
+    "date": "02 May 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.4": {
+    "announcement": {
+      "English": "/releases/7_3_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.4.tar.bz2",
+        "name": "PHP 7.3.4 (tar.bz2)",
+        "sha256": "2e2c3d8212c83649e443b61efffbd03df4b9edd0f9c7a679081fe4cb2da12b78",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.3.4.tar.gz",
+        "name": "PHP 7.3.4 (tar.gz)",
+        "sha256": "dd41ecf43fe1172030f41d2581909457a0af7bd137a057c3874e0b0f3c2e8761",
+        "date": "04 Apr 2019"
+      },
+      {
+        "filename": "php-7.3.4.tar.xz",
+        "name": "PHP 7.3.4 (tar.xz)",
+        "sha256": "6fe79fa1f8655f98ef6708cde8751299796d6c1e225081011f4104625b923b83",
+        "date": "04 Apr 2019"
+      }
+    ],
+    "date": "04 Apr 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.27": {
+    "announcement": {
+      "English": "/releases/7_1_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.27.tar.bz2",
+        "name": "PHP 7.1.27 (tar.bz2)",
+        "sha256": "dad7ecd30941911528e471c555a01911a68aa9219696bfc1e005f8b669f4ec4b",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.1.27.tar.gz",
+        "name": "PHP 7.1.27 (tar.gz)",
+        "sha256": "353b9ed341048388cc95e6fa6dab587eee44a3d4d297989aa297936090864357",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.1.27.tar.xz",
+        "name": "PHP 7.1.27 (tar.xz)",
+        "sha256": "25672a3a6060eff37c865a0c84e284da50b7ee8cd57174c78f0ae244b90a96a8",
+        "date": "07 Mar 2019"
+      }
+    ],
+    "date": "07 Mar 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.16": {
+    "announcement": {
+      "English": "/releases/7_2_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.16.tar.bz2",
+        "name": "PHP 7.2.16 (tar.bz2)",
+        "sha256": "2c0ad10053d58694cd14323248ecd6d9ba71d2733d160973c356ad01d09e7f38",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.2.16.tar.gz",
+        "name": "PHP 7.2.16 (tar.gz)",
+        "sha256": "fb95e0bb69caba1dfd3bbac4eeef7a0485e5ea3d6191d35ad5657e18243aa02d",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.2.16.tar.xz",
+        "name": "PHP 7.2.16 (tar.xz)",
+        "sha256": "7d91ed3c1447c6358a3d53f84599ef854aca4c3622de7435e2df115bf196e482",
+        "date": "07 Mar 2019"
+      }
+    ],
+    "date": "04 Apr 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.3": {
+    "announcement": {
+      "English": "/releases/7_3_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.3.tar.bz2",
+        "name": "PHP 7.3.3 (tar.bz2)",
+        "sha256": "61969e943adfea79701a34b8e701edd3f95be829d16601a4aabeb05f83023ce6",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.3.3.tar.gz",
+        "name": "PHP 7.3.3 (tar.gz)",
+        "sha256": "9bde40cbf8608ae9c595a6643a02cf0c692c131e2b3619af3fd2af8425d8e677",
+        "date": "07 Mar 2019"
+      },
+      {
+        "filename": "php-7.3.3.tar.xz",
+        "name": "PHP 7.3.3 (tar.xz)",
+        "sha256": "6bb03e79a183d0cb059a6d117bbb2e0679cab667fb713a13c6a16f56bebab9b3",
+        "date": "07 Mar 2019"
+      }
+    ],
+    "date": "07 Mar 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.26": {
+    "announcement": {
+      "English": "/releases/7_1_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.26.tar.bz2",
+        "name": "PHP 7.1.26 (tar.bz2)",
+        "sha256": "5b351ca86bc7e4600778aaf1d61ab9e4e38864efa86ab4cc4d5b02ea7f542ae6",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.1.26.tar.gz",
+        "name": "PHP 7.1.26 (tar.gz)",
+        "sha256": "069315d3c3f964fd165bbbb3c2fc56005813e2cf97bed05055318dcc4e775328",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.1.26.tar.xz",
+        "name": "PHP 7.1.26 (tar.xz)",
+        "sha256": "10b7ae634c12852fae52a22dc2262e5f12418ad59fd20da2d00d71a212235d31",
+        "date": "10 Jan 2019"
+      }
+    ],
+    "date": "10 Jan 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.15": {
+    "announcement": {
+      "English": "/releases/7_2_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.15.tar.bz2",
+        "name": "PHP 7.2.15 (tar.bz2)",
+        "sha256": "c93e7616946a463911818c7e9f9e21276c7793fb8c7cb15877188dd0546d0554",
+        "date": "07 Feb 2019"
+      },
+      {
+        "filename": "php-7.2.15.tar.gz",
+        "name": "PHP 7.2.15 (tar.gz)",
+        "sha256": "9b13bde9f5a32d6f6bdb8b911bb55bb818d0c4073538f8dc48aa2deb560f55a3",
+        "date": "07 Feb 2019"
+      },
+      {
+        "filename": "php-7.2.15.tar.xz",
+        "name": "PHP 7.2.15 (tar.xz)",
+        "sha256": "75e90012faef700dffb29311f3d24fa25f1a5e0f70254a9b8d5c794e25e938ce",
+        "date": "07 Feb 2019"
+      }
+    ],
+    "date": "07 Mar 2019",
+    "museum": false
+  },
+  "7.3.2": {
+    "announcement": {
+      "English": "/releases/7_3_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.2.tar.bz2",
+        "name": "PHP 7.3.2 (tar.bz2)",
+        "sha256": "946f50dacbd2f61e643bb737021cbe8b1816e780ee7ad3e0cd999a1892ab0add",
+        "date": "07 Feb 2019"
+      },
+      {
+        "filename": "php-7.3.2.tar.gz",
+        "name": "PHP 7.3.2 (tar.gz)",
+        "sha256": "4597294b00edc1c63a021b6c7838eb43384f62eeb9e392f0b91c38a3c090f499",
+        "date": "07 Feb 2019"
+      },
+      {
+        "filename": "php-7.3.2.tar.xz",
+        "name": "PHP 7.3.2 (tar.xz)",
+        "sha256": "010b868b4456644ae227d05ad236c8b0a1f57dc6320e7e5ad75e86c5baf0a9a8",
+        "date": "07 Feb 2019"
+      }
+    ],
+    "date": "07 Feb 2019",
+    "museum": false
+  },
+  "7.2.14": {
+    "announcement": {
+      "English": "/releases/7_2_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.14.tar.bz2",
+        "name": "PHP 7.2.14 (tar.bz2)",
+        "sha256": "f56132d248c7bf1e0efc8a680a4b598d6ff73fc6b9c84b5d7b539ad8db7a6597",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.2.14.tar.gz",
+        "name": "PHP 7.2.14 (tar.gz)",
+        "sha256": "87e13d80b0c3a66bd463d1cb47dc101335884a0d192ab924f547f8aed7f70c08",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.2.14.tar.xz",
+        "name": "PHP 7.2.14 (tar.xz)",
+        "sha256": "ee3f1cc102b073578a3c53ba4420a76da3d9f0c981c02b1664ae741ca65af84f",
+        "date": "10 Jan 2019"
+      }
+    ],
+    "date": "07 Feb 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.1": {
+    "announcement": {
+      "English": "/releases/7_3_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.1.tar.bz2",
+        "name": "PHP 7.3.1 (tar.bz2)",
+        "sha256": "afef2b0cd7f2641274a1a0aabe67e30f2334970d7c530382dfa9d79cfe74388e",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.3.1.tar.gz",
+        "name": "PHP 7.3.1 (tar.gz)",
+        "sha256": "8006211f7a041dde22fffedc416d142e0ebf22066014077ca936d7e6f655ead5",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-7.3.1.tar.xz",
+        "name": "PHP 7.3.1 (tar.xz)",
+        "sha256": "cfe93e40be0350cd53c4a579f52fe5d8faf9c6db047f650a4566a2276bf33362",
+        "date": "10 Jan 2019"
+      }
+    ],
+    "date": "10 Jan 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.33": {
+    "announcement": {
+      "English": "/releases/7_0_33.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.33.tar.bz2",
+        "name": "PHP 7.0.33 (tar.bz2)",
+        "sha256": "4933ea74298a1ba046b0246fe3771415c84dfb878396201b56cb5333abe86f07",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.0.33.tar.gz",
+        "name": "PHP 7.0.33 (tar.gz)",
+        "sha256": "d71a6ecb6b13dc53fed7532a7f8f949c4044806f067502f8fb6f9facbb40452a",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.0.33.tar.xz",
+        "name": "PHP 7.0.33 (tar.xz)",
+        "sha256": "ab8c5be6e32b1f8d032909dedaaaa4bbb1a209e519abb01a52ce3914f9a13d96",
+        "date": "06 Dec 2018"
+      }
+    ],
+    "date": "10 Jan 2019",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.25": {
+    "announcement": {
+      "English": "/releases/7_1_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.25.tar.bz2",
+        "name": "PHP 7.1.25 (tar.bz2)",
+        "sha256": "002cdc880ac7cfaede2c389204d366108847db0f3ac72edf1ba95c0577f9aaac",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.1.25.tar.gz",
+        "name": "PHP 7.1.25 (tar.gz)",
+        "sha256": "7dc40e202140e8b4fb3d992c15a68d98dc06b805e6b218497d260abbe51f5958",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.1.25.tar.xz",
+        "name": "PHP 7.1.25 (tar.xz)",
+        "sha256": "0fd8dad1903cd0b2d615a1fe4209f99e53b7292403c8ffa1919c0f4dd1eada88",
+        "date": "06 Dec 2018"
+      }
+    ],
+    "date": "06 Dec 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.3.0": {
+    "announcement": {
+      "English": "/releases/7_3_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.3.0.tar.bz2",
+        "name": "PHP 7.3.0 (tar.bz2)",
+        "sha256": "7a267daec9969a997c5c8028c350229646748e0fcc71e2f2dbb157ddcee87c67",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.3.0.tar.gz",
+        "name": "PHP 7.3.0 (tar.gz)",
+        "sha256": "391bd0f91d9bdd01ab47ef9607bad8c65e35bc9bb098fb7777b2556e2c847b11",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.3.0.tar.xz",
+        "name": "PHP 7.3.0 (tar.xz)",
+        "sha256": "7d195cad55af8b288c3919c67023a14ff870a73e3acc2165a6d17a4850a560b5",
+        "date": "06 Dec 2018"
+      }
+    ],
+    "date": "06 Dec 2018",
+    "museum": false
+  },
+  "7.2.13": {
+    "announcement": {
+      "English": "/releases/7_2_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.13.tar.bz2",
+        "name": "PHP 7.2.13 (tar.bz2)",
+        "sha256": "5b4a46fb76491bcd3eee1213773382e570f6ecf9b22d623b24e2822298b3e92d",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.2.13.tar.gz",
+        "name": "PHP 7.2.13 (tar.gz)",
+        "sha256": "e563cee406b1ec96649c22ed2b35796cfe4e9aa9afa6eab6be4cf2fe5d724744",
+        "date": "06 Dec 2018"
+      },
+      {
+        "filename": "php-7.2.13.tar.xz",
+        "name": "PHP 7.2.13 (tar.xz)",
+        "sha256": "14b0429abdb46b65c843e5882c9a8c46b31dfbf279c747293b8ab950c2644a4b",
+        "date": "06 Dec 2018"
+      }
+    ],
+    "date": "06 Dec 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.32": {
+    "announcement": {
+      "English": "/releases/7_0_32.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.32.tar.bz2",
+        "name": "PHP 7.0.32 (tar.bz2)",
+        "sha256": "56e8d8cf9c08178afa8663589805f83bdb01634efd98131977038e24066492e1",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.0.32.tar.gz",
+        "name": "PHP 7.0.32 (tar.gz)",
+        "sha256": "08d13389f611ec55f3b9164347a97e410099238a3dd85946e556a288ce366fbe",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.0.32.tar.xz",
+        "name": "PHP 7.0.32 (tar.xz)",
+        "sha256": "ff6f62afeb32c71b3b89ecbd42950ef6c5e0c329cc6e1c58ffac47e6f1f883c4",
+        "date": "13 Sep 2018"
+      }
+    ],
+    "date": "13 Sep 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.24": {
+    "announcement": {
+      "English": "/releases/7_1_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.24.tar.bz2",
+        "name": "PHP 7.1.24 (tar.bz2)",
+        "sha256": "66de24e73c7f6006f090c1b187d6b218c8fa6a513acca4ff5c14b695a7391e0b",
+        "date": "08 Nov 2018"
+      },
+      {
+        "filename": "php-7.1.24.tar.gz",
+        "name": "PHP 7.1.24 (tar.gz)",
+        "sha256": "1e780b1af3eeb8fba9e5af6205c960184a0c3a0ef091aaa192e7b7d6b67405d0",
+        "date": "08 Nov 2018"
+      },
+      {
+        "filename": "php-7.1.24.tar.xz",
+        "name": "PHP 7.1.24 (tar.xz)",
+        "sha256": "e70dcec0ae28b6bc308b78972ec15aa850808819cc765f505aa51e5a7e2fa5d7",
+        "date": "08 Nov 2018"
+      }
+    ],
+    "date": "08 Nov 2018",
+    "museum": false
+  },
+  "7.2.12": {
+    "announcement": {
+      "English": "/releases/7_2_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.12.tar.bz2",
+        "name": "PHP 7.2.12 (tar.bz2)",
+        "sha256": "b724c4c20347b6105be109d98cc395a610174e8aadb506c82e8cb645b65ef6b6",
+        "date": "08 Nov 2018"
+      },
+      {
+        "filename": "php-7.2.12.tar.gz",
+        "name": "PHP 7.2.12 (tar.gz)",
+        "sha256": "d7cabdf4e51db38121daf0d494dc074743b24b6c79e592037eeedd731f1719dd",
+        "date": "08 Nov 2018"
+      },
+      {
+        "filename": "php-7.2.12.tar.xz",
+        "name": "PHP 7.2.12 (tar.xz)",
+        "sha256": "989c04cc879ee71a5e1131db867f3c5102f1f7565f805e2bb8bde33f93147fe1",
+        "date": "08 Nov 2018"
+      }
+    ],
+    "date": "08 Nov 2018",
+    "museum": false
+  },
+  "7.1.23": {
+    "announcement": {
+      "English": "/releases/7_1_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.23.tar.bz2",
+        "name": "PHP 7.1.23 (tar.bz2)",
+        "sha256": "2d79aa86d8f0faa760a712a1d7be50b57838a9770c1dff34020876630c2ecc4b",
+        "date": "11 Oct 2018"
+      },
+      {
+        "filename": "php-7.1.23.tar.gz",
+        "name": "PHP 7.1.23 (tar.gz)",
+        "sha256": "b839a4de32e6770d10b87c2495c070d09277fe61008804b2992466f0dcc5f0fa",
+        "date": "11 Oct 2018"
+      },
+      {
+        "filename": "php-7.1.23.tar.xz",
+        "name": "PHP 7.1.23 (tar.xz)",
+        "sha256": "227a3c76133c3dc1cec937989456cbd89ed00e68e7260c651900dbe1f5b798bc",
+        "date": "11 Oct 2018"
+      }
+    ],
+    "date": "11 Oct 2018",
+    "museum": false
+  },
+  "7.2.11": {
+    "announcement": {
+      "English": "/releases/7_2_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.11.tar.bz2",
+        "name": "PHP 7.2.11 (tar.bz2)",
+        "sha256": "4a0d7f402d07966b37a600796283f4ca4079d955d96d5bec024dd02009d8b4c5",
+        "date": "11 Oct 2018"
+      },
+      {
+        "filename": "php-7.2.11.tar.gz",
+        "name": "PHP 7.2.11 (tar.gz)",
+        "sha256": "180c63a9647c0a50d438b6bd5c7a8e7a11bceee8ad613a59d3ef15151fc158d4",
+        "date": "11 Oct 2018"
+      },
+      {
+        "filename": "php-7.2.11.tar.xz",
+        "name": "PHP 7.2.11 (tar.xz)",
+        "sha256": "da1a705c0bc46410e330fc6baa967666c8cd2985378fb9707c01a8e33b01d985",
+        "date": "11 Oct 2018"
+      }
+    ],
+    "date": "11 Oct 2018",
+    "museum": false
+  },
+  "7.1.22": {
+    "announcement": {
+      "English": "/releases/7_1_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.22.tar.bz2",
+        "name": "PHP 7.1.22 (tar.bz2)",
+        "sha256": "c8e91f19c8aa810ae95f228ff31cf0e4805cb89f4c10870ee12c85491b26e763",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.1.22.tar.gz",
+        "name": "PHP 7.1.22 (tar.gz)",
+        "sha256": "1d275115593a33315647094a5a4ee9bd73c7960c08686cee35dc2e683a68b157",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.1.22.tar.xz",
+        "name": "PHP 7.1.22 (tar.xz)",
+        "sha256": "9194c9b3a592d8376fde837dde711ec01ee26f8607fc2884047ef6f7c089b15d",
+        "date": "13 Sep 2018"
+      }
+    ],
+    "date": "13 Sep 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.10": {
+    "announcement": {
+      "English": "/releases/7_2_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.10.tar.bz2",
+        "name": "PHP 7.2.10 (tar.bz2)",
+        "sha256": "01b6129a0921a1636b07da9bc598a876669e45a462cef4b5844fc26862dbda9d",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.2.10.tar.gz",
+        "name": "PHP 7.2.10 (tar.gz)",
+        "sha256": "d2d908b49b6005e65dcc46cdc986603a19b7ff103119fce8ddd4648586d430a4",
+        "date": "13 Sep 2018"
+      },
+      {
+        "filename": "php-7.2.10.tar.xz",
+        "name": "PHP 7.2.10 (tar.xz)",
+        "sha256": "01c2154a3a8e3c0818acbdbc1a956832c828a0380ce6d1d14fea495ea21804f0",
+        "date": "13 Sep 2018"
+      }
+    ],
+    "date": "13 Sep 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.21": {
+    "announcement": {
+      "English": "/releases/7_1_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.21.tar.bz2",
+        "name": "PHP 7.1.21 (tar.bz2)",
+        "sha256": "c2409c574bde23763b48a96b93922f530156df044585ff60108bce7b27b19580",
+        "date": "17 Aug 2018"
+      },
+      {
+        "filename": "php-7.1.21.tar.gz",
+        "name": "PHP 7.1.21 (tar.gz)",
+        "sha256": "4b448ba9b3c81b88543c1e1fbef465391fecd64d7f19a744df26e9923295dd00",
+        "date": "17 Aug 2018"
+      },
+      {
+        "filename": "php-7.1.21.tar.xz",
+        "name": "PHP 7.1.21 (tar.xz)",
+        "sha256": "d4da6dc69d3fe1e6b2b80f16b262f391037bfeb21213c966e026bd45d7ca2813",
+        "date": "17 Aug 2018"
+      }
+    ],
+    "date": "13 Sep 2018",
+    "museum": false
+  },
+  "7.0.31": {
+    "announcement": {
+      "English": "/releases/7_0_31.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.31.tar.bz2",
+        "name": "PHP 7.0.31 (tar.bz2)",
+        "sha256": "7e8bd73eced6e679a179d39571e8fee6c83e51c86f43338f65c2dc88c1106b91",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.0.31.tar.gz",
+        "name": "PHP 7.0.31 (tar.gz)",
+        "sha256": "182f36e5709837158bd4970ce57fe80735bdf79025133c00d6ad882d1c4d98dd",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.0.31.tar.xz",
+        "name": "PHP 7.0.31 (tar.xz)",
+        "sha256": "68f57b3f4587071fb54a620cb83a1cfb3f0bd4ee071e0ce3bf7046a5f2d2f3cf",
+        "date": "19 Jul 2018"
+      }
+    ],
+    "date": "19 Jul 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.9": {
+    "announcement": {
+      "English": "/releases/7_2_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.9.tar.bz2",
+        "name": "PHP 7.2.9 (tar.bz2)",
+        "sha256": "e9e3aaa6c317b7fea78246a758b017544366049d2789ad5a44fe9398464c53a8",
+        "date": "16 Aug 2018"
+      },
+      {
+        "filename": "php-7.2.9.tar.gz",
+        "name": "PHP 7.2.9 (tar.gz)",
+        "sha256": "23fcc1e4d10e06ddfdbc1163a8f0d147a7813467273f7946eb0de1b825d1d3e6",
+        "date": "16 Aug 2018"
+      },
+      {
+        "filename": "php-7.2.9.tar.xz",
+        "name": "PHP 7.2.9 (tar.xz)",
+        "sha256": "3585c1222e00494efee4f5a65a8e03a1e6eca3dfb834814236ee7f02c5248ae0",
+        "date": "16 Aug 2018"
+      }
+    ],
+    "date": "16 Aug 2018",
+    "museum": false
+  },
+  "7.1.20": {
+    "announcement": {
+      "English": "/releases/7_1_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.20.tar.bz2",
+        "name": "PHP 7.1.20 (tar.bz2)",
+        "sha256": "3a1b476c88fb81254ea572e891a1d65053ab54068348e00c75e8b54fae691d45",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.1.20.tar.gz",
+        "name": "PHP 7.1.20 (tar.gz)",
+        "sha256": "77a2091f4ab50367a6c68274a0d92e0da9ecdbf428b280c9836c5c6d512da450",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.1.20.tar.xz",
+        "name": "PHP 7.1.20 (tar.xz)",
+        "sha256": "cd7d1006201459d43fae0790cce4eb3451add5c87f4cadb13b228d4c179b850c",
+        "date": "19 Jul 2018"
+      }
+    ],
+    "date": "16 Aug 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.8": {
+    "announcement": {
+      "English": "/releases/7_2_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.8.tar.bz2",
+        "name": "PHP 7.2.8 (tar.bz2)",
+        "sha256": "1f8068f520a60fff3db19be1b849f0c02a33a0fd8b34b7ae05556ef682187ee6",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.2.8.tar.gz",
+        "name": "PHP 7.2.8 (tar.gz)",
+        "sha256": "a0cb9bf2f78498fc090eb553df03cdacc198785dec0818efa7a1804c2b7a8722",
+        "date": "19 Jul 2018"
+      },
+      {
+        "filename": "php-7.2.8.tar.xz",
+        "name": "PHP 7.2.8 (tar.xz)",
+        "sha256": "53ba0708be8a7db44256e3ae9fcecc91b811e5b5119e6080c951ffe7910ffb0f",
+        "date": "19 Jul 2018"
+      }
+    ],
+    "date": "19 Jul 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.19": {
+    "announcement": {
+      "English": "/releases/7_1_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.19.tar.bz2",
+        "name": "PHP 7.1.19 (tar.bz2)",
+        "sha256": "13c43e7be3040ad53f192b0770c7ed99e5b3e348dfc6674666179d557fd770f3",
+        "date": "21 Jun 2018"
+      },
+      {
+        "filename": "php-7.1.19.tar.gz",
+        "name": "PHP 7.1.19 (tar.gz)",
+        "sha256": "e1ae477b72bed02cdcb04f0157b8f8767bd4f6030416ae06408b4f6d85ee66a1",
+        "date": "21 Jun 2018"
+      },
+      {
+        "filename": "php-7.1.19.tar.xz",
+        "name": "PHP 7.1.19 (tar.xz)",
+        "sha256": "7cab88f269b90a8a38dbcccf3ec0d5c6eba86122431a53eaa94405bbb60370a8",
+        "date": "21 Jun 2018"
+      }
+    ],
+    "date": "21 Jun 2018",
+    "museum": false
+  },
+  "7.0.30": {
+    "announcement": {
+      "English": "/releases/7_0_30.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.30.tar.bz2",
+        "name": "PHP 7.0.30 (tar.bz2)",
+        "sha256": "213f38400c239b8fab2f6f59d6f4d4bd463d0a75bd4edf723dd4d5fea8850b50",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.0.30.tar.gz",
+        "name": "PHP 7.0.30 (tar.gz)",
+        "sha256": "54e7615205123b940b996300bf99c707c2317b6b78388061a204b23ab3388a26",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.0.30.tar.xz",
+        "name": "PHP 7.0.30 (tar.xz)",
+        "sha256": "c90892fb68ab9b8476519658d3f78f6388f2609ae1309bdc2a2e1cc9f92dd686",
+        "date": "26 Apr 2018"
+      }
+    ],
+    "date": "26 Apr 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.7": {
+    "announcement": {
+      "English": "/releases/7_2_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.7.tar.bz2",
+        "name": "PHP 7.2.7 (tar.bz2)",
+        "sha256": "cc81675a96af4dd18d8ffc02f26a36c622abadf86af7ecfea7bcde8d3c96d5a3",
+        "date": "21 Jun 2018"
+      },
+      {
+        "filename": "php-7.2.7.tar.gz",
+        "name": "PHP 7.2.7 (tar.gz)",
+        "sha256": "014f0560cfa22e6301b0024a6fd888c3612a0dc102ff355fa2b49544d16d43b1",
+        "date": "21 Jun 2018"
+      },
+      {
+        "filename": "php-7.2.7.tar.xz",
+        "name": "PHP 7.2.7 (tar.xz)",
+        "sha256": "eb01c0153b3baf1f64b8b044013ce414b52fede222df3f509e8ff209478f31f0",
+        "date": "21 Jun 2018"
+      }
+    ],
+    "date": "21 Jun 2018",
+    "museum": false
+  },
+  "7.1.18": {
+    "announcement": {
+      "English": "/releases/7_1_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.18.tar.bz2",
+        "name": "PHP 7.1.18 (tar.bz2)",
+        "sha256": "580e375515ede831a6d82e13c0ec25dd08b225c6d87dfc24d7cd5f3bd542bf8e",
+        "date": "24 May 2018"
+      },
+      {
+        "filename": "php-7.1.18.tar.gz",
+        "name": "PHP 7.1.18 (tar.gz)",
+        "sha256": "07c24ae4dd59d81d3dc0ce89025ae667979150e2ee0e9e30dd89e04e31d510fb",
+        "date": "24 May 2018"
+      },
+      {
+        "filename": "php-7.1.18.tar.xz",
+        "name": "PHP 7.1.18 (tar.xz)",
+        "sha256": "8bd91cea072ea5b368cc9b4533a1a683eb426abdacbf024bb6ffa9b799cd3b01",
+        "date": "24 May 2018"
+      }
+    ],
+    "date": "24 May 2018",
+    "museum": false
+  },
+  "7.2.6": {
+    "announcement": {
+      "English": "/releases/7_2_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.6.tar.bz2",
+        "name": "PHP 7.2.6 (tar.bz2)",
+        "sha256": "ae5d3e8ada80b9d293d0c8bd643d07c2d988538ff1052a3f7144c6b0cd0ff2c3",
+        "date": "24 May 2018"
+      },
+      {
+        "filename": "php-7.2.6.tar.gz",
+        "name": "PHP 7.2.6 (tar.gz)",
+        "sha256": "a9f30daf6af82ac02e692465cfd65b04a60d56106c961926e264d2621d313f0e",
+        "date": "24 May 2018"
+      },
+      {
+        "filename": "php-7.2.6.tar.xz",
+        "name": "PHP 7.2.6 (tar.xz)",
+        "sha256": "1f004e049788a3effc89ef417f06a6cf704c95ae2a718b2175185f2983381ae7",
+        "date": "24 May 2018"
+      }
+    ],
+    "date": "24 May 2018",
+    "museum": false
+  },
+  "7.1.17": {
+    "announcement": {
+      "English": "/releases/7_1_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.17.tar.bz2",
+        "name": "PHP 7.1.17 (tar.bz2)",
+        "sha256": "e124e3ac552c50f3890ed981d07b2ee473cac961885e75186ded0bbb5b78dbcf",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.1.17.tar.gz",
+        "name": "PHP 7.1.17 (tar.gz)",
+        "sha256": "aba44265bf814a020282afa63321323e1f81da61bd7318ab2b941857a15cb144",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.1.17.tar.xz",
+        "name": "PHP 7.1.17 (tar.xz)",
+        "sha256": "1a784806866e06367f7a5c88775d239d6f30041c7ce65a8232d03a3d4de56d56",
+        "date": "26 Apr 2018"
+      }
+    ],
+    "date": "26 Apr 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.5": {
+    "announcement": {
+      "English": "/releases/7_2_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.5.tar.bz2",
+        "name": "PHP 7.2.5 (tar.bz2)",
+        "sha256": "f3820efa8efa79628b6e1b5b2f8c1b04c08d32e6721fa1654039ce5f89796031",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.2.5.tar.gz",
+        "name": "PHP 7.2.5 (tar.gz)",
+        "sha256": "c198aedd4cd16db0803e0ef955036722a1f4ce9ad3827546709fac05f1567ba5",
+        "date": "26 Apr 2018"
+      },
+      {
+        "filename": "php-7.2.5.tar.xz",
+        "name": "PHP 7.2.5 (tar.xz)",
+        "sha256": "af70a33b3f7a51510467199b39af151333fbbe4cc21923bad9c7cf64268cddb2",
+        "date": "26 Apr 2018"
+      }
+    ],
+    "date": "26 Apr 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.16": {
+    "announcement": {
+      "English": "/releases/7_1_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.16.tar.bz2",
+        "name": "PHP 7.1.16 (tar.bz2)",
+        "sha256": "348e2af9c7c0f327a57a972674078777dfde189e2598acbcb8618b9645b0e7e5",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.1.16.tar.gz",
+        "name": "PHP 7.1.16 (tar.gz)",
+        "sha256": "c8e6fed5b350b29a5b9eaa9fce7c5e8618629346e9a58212f3dc380046065442",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.1.16.tar.xz",
+        "name": "PHP 7.1.16 (tar.xz)",
+        "sha256": "a5d67e477248a3911af7ef85c8400c1ba8cd632184186fd31070b96714e669f1",
+        "date": "29 Mar 2018"
+      }
+    ],
+    "date": "29 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.29": {
+    "announcement": {
+      "English": "/releases/7_0_29.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.29.tar.bz2",
+        "name": "PHP 7.0.29 (tar.bz2)",
+        "sha256": "989142d5c5ff7a11431254f9c1995235bad61a3364b99c966e11e06aa10d3fbc",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.0.29.tar.gz",
+        "name": "PHP 7.0.29 (tar.gz)",
+        "sha256": "5efe45e345f967cb20f9ff92cd514753872a65feffea1bf311c71864344bd8e8",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.0.29.tar.xz",
+        "name": "PHP 7.0.29 (tar.xz)",
+        "sha256": "ca79d3ecc123bff4b623d4a1bbf5ad53ad39f5f2f5912fecc0ea97e95eba21cc",
+        "date": "29 Mar 2018"
+      }
+    ],
+    "date": "29 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.4": {
+    "announcement": {
+      "English": "/releases/7_2_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.4.tar.bz2",
+        "name": "PHP 7.2.4 (tar.bz2)",
+        "sha256": "11658a0d764dc94023b9fb60d4b5eb75d438ad17981efe70abb0d0d09a447ef3",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.2.4.tar.gz",
+        "name": "PHP 7.2.4 (tar.gz)",
+        "sha256": "58e28e978baea0fe9009432bcb436934eaacccfdcb5f5409c7526431a595857b",
+        "date": "29 Mar 2018"
+      },
+      {
+        "filename": "php-7.2.4.tar.xz",
+        "name": "PHP 7.2.4 (tar.xz)",
+        "sha256": "7916b1bd148ddfd46d7f8f9a517d4b09cd8a8ad9248734e7c8dd91ef17057a88",
+        "date": "29 Mar 2018"
+      }
+    ],
+    "date": "29 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.15": {
+    "announcement": {
+      "English": "/releases/7_1_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.15.tar.bz2",
+        "name": "PHP 7.1.15 (tar.bz2)",
+        "sha256": "e117a54738e9485de5fc75673d39dbe937dd87f0f9cc9e281960ef9b961adcbd",
+        "date": "1 Mar 2018"
+      },
+      {
+        "filename": "php-7.1.15.tar.gz",
+        "name": "PHP 7.1.15 (tar.gz)",
+        "sha256": "0669c68a52cbd2f1cfa83354918ed03b0bcaa34ed9bafaee7dfd343461b881d4",
+        "date": "1 Mar 2018"
+      },
+      {
+        "filename": "php-7.1.15.tar.xz",
+        "name": "PHP 7.1.15 (tar.xz)",
+        "sha256": "0e17192fb43532e4ebaa190ecec9c7e59deea7dadb7dab67b19c2081a68bd817",
+        "date": "1 Mar 2018"
+      }
+    ],
+    "date": "1 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.3": {
+    "announcement": {
+      "English": "/releases/7_2_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.3.tar.bz2",
+        "name": "PHP 7.2.3 (tar.bz2)",
+        "sha256": "4a735aac0ba764dd8208ea29007d3916396c5292e003ba8d3bec49edcdd5bf92",
+        "date": "1 Mar 2018"
+      },
+      {
+        "filename": "php-7.2.3.tar.gz",
+        "name": "PHP 7.2.3 (tar.gz)",
+        "sha256": "5dc98f2266db40c5e4d9b5edf5e29e2449e819fff8321a07eb3830cf0b104bbb",
+        "date": "1 Mar 2018"
+      },
+      {
+        "filename": "php-7.2.3.tar.xz",
+        "name": "PHP 7.2.3 (tar.xz)",
+        "sha256": "b3a94f1b562f413c0b96f54bc309706d83b29ac65d9b172bc7ed9fb40a5e651f",
+        "date": "1 Mar 2018"
+      }
+    ],
+    "date": "1 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.28": {
+    "announcement": {
+      "English": "/releases/7_0_28.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.28.tar.bz2",
+        "name": "PHP 7.0.28 (tar.bz2)",
+        "sha256": "ae5491b4613f3710e3d09e688ba3d30d3acc1112c7b96a8703663b8a95063c7f",
+        "date": "01 Mar 2018"
+      },
+      {
+        "filename": "php-7.0.28.tar.gz",
+        "name": "PHP 7.0.28 (tar.gz)",
+        "sha256": "cd2fd94feb0d5809ffb9d900138643fa74e70656436e5f2595b03239dd97aa9c",
+        "date": "01 Mar 2018"
+      },
+      {
+        "filename": "php-7.0.28.tar.xz",
+        "name": "PHP 7.0.28 (tar.xz)",
+        "sha256": "e738ffce2c30bc0e84be9446af86bef0a0607d321f1a3d04bbfe2402fb5f6de0",
+        "date": "01 Mar 2018"
+      }
+    ],
+    "date": "01 Mar 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.14": {
+    "announcement": {
+      "English": "/releases/7_1_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.14.tar.bz2",
+        "name": "PHP 7.1.14 (tar.bz2)",
+        "sha256": "63b2fd139ed7656756b0fa290bc42f8fff854723c3d2710a700e646370c581f4",
+        "date": "1 Feb 2018"
+      },
+      {
+        "filename": "php-7.1.14.tar.gz",
+        "name": "PHP 7.1.14 (tar.gz)",
+        "sha256": "8c7360209d255ee46d388bdcd43ef1a2d14b370c331be30ea628ece18a1e7683",
+        "date": "1 Feb 2018"
+      },
+      {
+        "filename": "php-7.1.14.tar.xz",
+        "name": "PHP 7.1.14 (tar.xz)",
+        "sha256": "c09f0c1074f5689b492d79034adb84e6a6c6d08c6763c02282e6318d41156779",
+        "date": "1 Feb 2018"
+      }
+    ],
+    "date": "1 Feb 2018",
+    "museum": false
+  },
+  "7.2.2": {
+    "announcement": {
+      "English": "/releases/7_2_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.2.tar.bz2",
+        "name": "PHP 7.2.2 (tar.bz2)",
+        "sha256": "f841ac58e17471f2241ea892b34edb01dc9b93ad9f661ffe4e3f1f476a8f4aee",
+        "date": "1 Feb 2018"
+      },
+      {
+        "filename": "php-7.2.2.tar.gz",
+        "name": "PHP 7.2.2 (tar.gz)",
+        "sha256": "5963df05fec21927c03fe9f7bf379be2d1eacde6c0f9dcde6143c7133e55abd4",
+        "date": "1 Feb 2018"
+      },
+      {
+        "filename": "php-7.2.2.tar.xz",
+        "name": "PHP 7.2.2 (tar.xz)",
+        "sha256": "47d7607d38a1d565fc43ea942c92229a7cd165f156737f210937e375b243cb11",
+        "date": "1 Feb 2018"
+      }
+    ],
+    "date": "1 Feb 2018",
+    "museum": false
+  },
+  "7.0.27": {
+    "announcement": {
+      "English": "/releases/7_0_27.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.27.tar.bz2",
+        "name": "PHP 7.0.27 (tar.bz2)",
+        "sha256": "99fa2563bb4c4c1cde9febe87cfe97324227d7b4b8828f2e936e507127394131",
+        "date": "04 Jan 2018"
+      },
+      {
+        "filename": "php-7.0.27.tar.gz",
+        "name": "PHP 7.0.27 (tar.gz)",
+        "sha256": "809c0181e970dd17c6a6cabbf64518e719c7253e7490f8e1279bc1e1fbdf7996",
+        "date": "04 Jan 2018"
+      },
+      {
+        "filename": "php-7.0.27.tar.xz",
+        "name": "PHP 7.0.27 (tar.xz)",
+        "sha256": "4b2bc823e806dbf7b62fe0b92b0d14b0c6e03f88c3fc5d96278416c54ce11f6c",
+        "date": "04 Jan 2018"
+      }
+    ],
+    "date": "04 Jan 2018",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.2.1": {
+    "announcement": {
+      "English": "/releases/7_2_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.1.tar.bz2",
+        "name": "PHP 7.2.1 (tar.bz2)",
+        "sha256": "fe06793f268a4dd29cbc5f4ef415f01e786877152b02221ad7d18dbb6864eb79",
+        "date": "4 Jan 2018"
+      },
+      {
+        "filename": "php-7.2.1.tar.gz",
+        "name": "PHP 7.2.1 (tar.gz)",
+        "sha256": "8ecb2950571054a00687ccbd023874a4a075ccd1e2ec3dc00fc25ef589a77dba",
+        "date": "4 Jan 2018"
+      },
+      {
+        "filename": "php-7.2.1.tar.xz",
+        "name": "PHP 7.2.1 (tar.xz)",
+        "sha256": "6c6cf82fda6660ed963821eb0525214bb3547e8e29f447b9c15b2d8e6efd8822",
+        "date": "4 Jan 2018"
+      }
+    ],
+    "date": "4 Jan 2018",
+    "museum": false
+  },
+  "7.1.13": {
+    "announcement": {
+      "English": "/releases/7_1_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.13.tar.bz2",
+        "name": "PHP 7.1.13 (tar.bz2)",
+        "sha256": "35fda51d2d44600940185fd5818d336a79e77ab3c98e2bd075091f2f91cf98a1",
+        "date": "4 Jan 2018"
+      },
+      {
+        "filename": "php-7.1.13.tar.gz",
+        "name": "PHP 7.1.13 (tar.gz)",
+        "sha256": "12fcbf59c9eb9af215ef38815d5da39b9d74549092c34b0dfc31442699740ce9",
+        "date": "4 Jan 2018"
+      },
+      {
+        "filename": "php-7.1.13.tar.xz",
+        "name": "PHP 7.1.13 (tar.xz)",
+        "sha256": "1a0b3f2fb61959b57a3ee01793a77ed3f19bde5aa90c43dcacc85ea32f64fc10",
+        "date": "4 Jan 2018"
+      }
+    ],
+    "date": "4 Jan 2018",
+    "museum": false
+  },
+  "7.2.0": {
+    "announcement": {
+      "English": "/releases/7_2_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.2.0.tar.bz2",
+        "name": "PHP 7.2.0 (tar.bz2)",
+        "sha256": "2bfefae4226b9b97879c9d33078e50bdb5c17f45ff6e255951062a529720c64a",
+        "date": "30 Nov 2017"
+      },
+      {
+        "filename": "php-7.2.0.tar.gz",
+        "name": "PHP 7.2.0 (tar.gz)",
+        "sha256": "801876abd52e0dc58a44701344252035fd50702d8f510cda7fdb317ab79897bc",
+        "date": "30 Nov 2017"
+      },
+      {
+        "filename": "php-7.2.0.tar.xz",
+        "name": "PHP 7.2.0 (tar.xz)",
+        "sha256": "87572a6b924670a5d4aac276aaa4a94321936283df391d702c845ffc112db095",
+        "date": "30 Nov 2017"
+      }
+    ],
+    "date": "30 Nov 2017",
+    "museum": false
+  },
+  "7.1.12": {
+    "announcement": {
+      "English": "/releases/7_1_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.12.tar.bz2",
+        "name": "PHP 7.1.12 (tar.bz2)",
+        "sha256": "f9ce3361ab99dce8f3f2fba663695ac9b18a3579bc8014dc280368d1577d87c4",
+        "date": "23 Nov 2017"
+      },
+      {
+        "filename": "php-7.1.12.tar.gz",
+        "name": "PHP 7.1.12 (tar.gz)",
+        "sha256": "188c67d8e424ce7a6fe93475aa64f53182c1d80ca3ac99439651ca91569d969c",
+        "date": "23 Nov 2017"
+      },
+      {
+        "filename": "php-7.1.12.tar.xz",
+        "name": "PHP 7.1.12 (tar.xz)",
+        "sha256": "a0118850774571b1f2d4e30b4fe7a4b958ca66f07d07d65ebdc789c54ba6eeb3",
+        "date": "23 Nov 2017"
+      }
+    ],
+    "date": "23 Nov 2017",
+    "museum": false
+  },
+  "7.0.26": {
+    "announcement": {
+      "English": "/releases/7_0_26.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.26.tar.bz2",
+        "name": "PHP 7.0.26 (tar.bz2)",
+        "sha256": "2590d722f7b23b6a903c5a00cf04e7ee728df79d10ae473e3a81ba41588509a7",
+        "date": "23 Nov 2017"
+      },
+      {
+        "filename": "php-7.0.26.tar.gz",
+        "name": "PHP 7.0.26 (tar.gz)",
+        "sha256": "04c345f7c9e3f1cd02f275bfec893a4e0290e724073f2f3d7282a219128b537c",
+        "date": "23 Nov 2017"
+      },
+      {
+        "filename": "php-7.0.26.tar.xz",
+        "name": "PHP 7.0.26 (tar.xz)",
+        "sha256": "ed5cbb4bbb0ddef8985f100bba2e94002ad22a230b5da2dccfe148915df5f199",
+        "date": "23 Nov 2017"
+      }
+    ],
+    "date": "23 Nov 2017",
+    "museum": false
+  },
+  "7.1.11": {
+    "announcement": {
+      "English": "/releases/7_1_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.11.tar.bz2",
+        "name": "PHP 7.1.11 (tar.bz2)",
+        "sha256": "7646d7de701fc969e3305eeeb2eddda3d46af6a88ee20ef4a47270c447228573",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-7.1.11.tar.gz",
+        "name": "PHP 7.1.11 (tar.gz)",
+        "sha256": "de41b2c166bc5ec8ea96a337d4dd675c794f7b115a8a47bb04595c03dbbdf425",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-7.1.11.tar.xz",
+        "name": "PHP 7.1.11 (tar.xz)",
+        "sha256": "074093e9d7d21afedc5106904218a80a47b854abe368d2728ed22184c884893e",
+        "date": "26 Oct 2017"
+      }
+    ],
+    "date": "26 Oct 2017",
+    "museum": false
+  },
+  "7.0.25": {
+    "announcement": {
+      "English": "/releases/7_0_25.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.25.tar.bz2",
+        "name": "PHP 7.0.25 (tar.bz2)",
+        "sha256": "95a24d96d126a196e1550e394182b43a6460cdd2026f1a77bef01e422415cc25",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-7.0.25.tar.gz",
+        "name": "PHP 7.0.25 (tar.gz)",
+        "sha256": "081b46bf588d38c636fd6cd1dab8855b6b3e171550d1e65f770f53aede594ee7",
+        "date": "26 Oct 2017"
+      },
+      {
+        "filename": "php-7.0.25.tar.xz",
+        "name": "PHP 7.0.25 (tar.xz)",
+        "sha256": "5cc14bd20fb2226f6d34465662425cd100441bde9042ea1cef2e4506d6ded8cc",
+        "date": "26 Oct 2017"
+      }
+    ],
+    "date": "26 Oct 2017",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.10": {
+    "announcement": {
+      "English": "/releases/7_1_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.10.tar.bz2",
+        "name": "PHP 7.1.10 (tar.bz2)",
+        "sha256": "0ee51b9b1ae7eca3e9558f772ce20cbacd1f76420009b3af630c87027f9a41af",
+        "date": "28 Sep 2017"
+      },
+      {
+        "filename": "php-7.1.10.tar.gz",
+        "name": "PHP 7.1.10 (tar.gz)",
+        "sha256": "edc6a7c3fe89419525ce51969c5f48610e53613235bbef255c3a4db33b458083",
+        "date": "28 Sep 2017"
+      },
+      {
+        "filename": "php-7.1.10.tar.xz",
+        "name": "PHP 7.1.10 (tar.xz)",
+        "sha256": "2b8efa771a2ead0bb3ae67b530ca505b5b286adc873cca9ce97a6e1d6815c50b",
+        "date": "28 Sep 2017"
+      }
+    ],
+    "date": "28 Sep 2017",
+    "museum": false
+  },
+  "7.0.24": {
+    "announcement": {
+      "English": "/releases/7_0_24.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.24.tar.bz2",
+        "name": "PHP 7.0.24 (tar.bz2)",
+        "sha256": "9bf91982694f178821c0aaf03563a20494873ece6933e2eeecfd76f325bdcf19",
+        "date": "28 Sep 2017"
+      },
+      {
+        "filename": "php-7.0.24.tar.gz",
+        "name": "PHP 7.0.24 (tar.gz)",
+        "sha256": "151015b578c14a4ab47d1e5894b36c85cf5655237599b805a08d106fe18a8c8e",
+        "date": "28 Sep 2017"
+      },
+      {
+        "filename": "php-7.0.24.tar.xz",
+        "name": "PHP 7.0.24 (tar.xz)",
+        "sha256": "4dba7aa365193c9229f89f1975fad4c01135d29922a338ffb4a27e840d6f1c98",
+        "date": "28 Sep 2017"
+      }
+    ],
+    "date": "28 Sep 2017",
+    "museum": false
+  },
+  "7.1.9": {
+    "announcement": {
+      "English": "/releases/7_1_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.9.tar.bz2",
+        "name": "PHP 7.1.9 (tar.bz2)",
+        "sha256": "314dcc10dfdd7c4443edb4fe1e133a44f2b2a8351be8c9eb6ab9222d45fd9bae",
+        "date": "31 Aug 2017"
+      },
+      {
+        "filename": "php-7.1.9.tar.gz",
+        "name": "PHP 7.1.9 (tar.gz)",
+        "sha256": "499c31ad19b2ff553ae686ebf53749aa2351af7d955ee9f1986f144089561a4b",
+        "date": "31 Aug 2017"
+      },
+      {
+        "filename": "php-7.1.9.tar.xz",
+        "name": "PHP 7.1.9 (tar.xz)",
+        "sha256": "ec9ca348dd51f19a84dc5d33acfff1fba1f977300604bdac08ed46ae2c281e8c",
+        "date": "31 Aug 2017"
+      }
+    ],
+    "date": "31 Aug 2017",
+    "museum": false
+  },
+  "7.0.23": {
+    "announcement": {
+      "English": "/releases/7_0_23.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.23.tar.bz2",
+        "name": "PHP 7.0.23 (tar.bz2)",
+        "sha256": "6fe94cefc7d2c60ee2c1648b977beed756ad9cd0a7e4ea8bb8cf521d9355a09c",
+        "date": "31 Aug 2017"
+      },
+      {
+        "filename": "php-7.0.23.tar.gz",
+        "name": "PHP 7.0.23 (tar.gz)",
+        "sha256": "d511089ecaf386f3ab752efba76558c03558afa6b5b3fe71d84881c76644b466",
+        "date": "31 Aug 2017"
+      },
+      {
+        "filename": "php-7.0.23.tar.xz",
+        "name": "PHP 7.0.23 (tar.xz)",
+        "sha256": "8e526e3551a58e00c8055fa4a72804aa1bd3ee1c0411b25bf1504cc4992609df",
+        "date": "31 Aug 2017"
+      }
+    ],
+    "date": "31 Aug 2017",
+    "museum": false
+  },
+  "7.1.8": {
+    "announcement": {
+      "English": "/releases/7_1_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.8.tar.bz2",
+        "name": "PHP 7.1.8 (tar.bz2)",
+        "sha256": "7064a00a9450565190890c7a4be04e646e0be73b2e0f8c46ae34419f343ca2f8",
+        "date": "03 Aug 2017"
+      },
+      {
+        "filename": "php-7.1.8.tar.gz",
+        "name": "PHP 7.1.8 (tar.gz)",
+        "sha256": "63517b3264f7cb17fb58e1ce60a6cd8903160239b7cf568d52024e9cf4d6cb04",
+        "date": "03 Aug 2017"
+      },
+      {
+        "filename": "php-7.1.8.tar.xz",
+        "name": "PHP 7.1.8 (tar.xz)",
+        "sha256": "8943858738604acb33ecedb865d6c4051eeffe4e2d06f3a3c8f794daccaa2aab",
+        "date": "03 Aug 2017"
+      }
+    ],
+    "date": "03 Aug 2017",
+    "museum": false
+  },
+  "7.0.22": {
+    "announcement": {
+      "English": "/releases/7_0_22.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.22.tar.bz2",
+        "name": "PHP 7.0.22 (tar.bz2)",
+        "sha256": "88e0b27f69abdd12ecde81f000c5a9ea479af7218456ea7f6557edb43c6dfdde",
+        "date": "03 Aug 2017"
+      },
+      {
+        "filename": "php-7.0.22.tar.gz",
+        "name": "PHP 7.0.22 (tar.gz)",
+        "sha256": "04292eaea0eeb75e9b6a36a3db8e90a3d43f939646fd9d7d1e083e5b70884383",
+        "date": "03 Aug 2017"
+      },
+      {
+        "filename": "php-7.0.22.tar.xz",
+        "name": "PHP 7.0.22 (tar.xz)",
+        "sha256": "408c3fbc235ec940433bfac1f3ed4bf797f61b4a1693b9fb0b6a04b2c1832501",
+        "date": "03 Aug 2017"
+      }
+    ],
+    "date": "03 Aug 2017",
+    "museum": false
+  },
+  "7.1.7": {
+    "announcement": {
+      "English": "/releases/7_1_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.7.tar.bz2",
+        "name": "PHP 7.1.7 (tar.bz2)",
+        "sha256": "079b6792987f38dc485f92258c04f9e02dedd593f9d260ebe725343f812d1ff8",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-7.1.7.tar.gz",
+        "name": "PHP 7.1.7 (tar.gz)",
+        "sha256": "e0dbab8da601ee5119368d6f93dc1a86ad53b799d2f8c1209d6b827a2b259f92",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-7.1.7.tar.xz",
+        "name": "PHP 7.1.7 (tar.xz)",
+        "sha256": "0d42089729be7b2bb0308cbe189c2782f9cb4b07078c8a235495be5874fff729",
+        "date": "06 Jul 2017"
+      }
+    ],
+    "date": "06 Jul 2017",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.21": {
+    "announcement": {
+      "English": "/releases/7_0_21.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.21.tar.bz2",
+        "name": "PHP 7.0.21 (tar.bz2)",
+        "sha256": "2ba133c392de6f86aacced8c54e0adefd1c81d3840ac323b9926b8ed3dc6231f",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-7.0.21.tar.gz",
+        "name": "PHP 7.0.21 (tar.gz)",
+        "sha256": "f2f05f629dd02c75834ddf033916bd5ff92a720602839d81fd8b6d90e37b6225",
+        "date": "06 Jul 2017"
+      },
+      {
+        "filename": "php-7.0.21.tar.xz",
+        "name": "PHP 7.0.21 (tar.xz)",
+        "sha256": "6713fe3024365d661593235b525235045ef81f18d0043654658c9de1bcb8b9e3",
+        "date": "06 Jul 2017"
+      }
+    ],
+    "date": "06 Jul 2017",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.6": {
+    "announcement": {
+      "English": "/releases/7_1_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.6.tar.bz2",
+        "name": "PHP 7.1.6 (tar.bz2)",
+        "sha256": "6e3576ca77672a18461a4b089c5790647f1b2c19f82e4f5e94c962609aabffcf",
+        "date": "08 Jun 2017"
+      },
+      {
+        "filename": "php-7.1.6.tar.gz",
+        "name": "PHP 7.1.6 (tar.gz)",
+        "sha256": "7ff8c01af791c7e499ee77e1b82e4b1d56e379efe1f706b1203d48751481fd9f",
+        "date": "08 Jun 2017"
+      },
+      {
+        "filename": "php-7.1.6.tar.xz",
+        "name": "PHP 7.1.6 (tar.xz)",
+        "sha256": "01584dc521ab7ec84b502b61952f573652fe6aa00c18d6d844fb9209f14b245b",
+        "date": "08 Jun 2017"
+      }
+    ],
+    "date": "08 Jun 2017",
+    "museum": false
+  },
+  "7.0.20": {
+    "announcement": {
+      "English": "/releases/7_0_20.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.20.tar.bz2",
+        "name": "PHP 7.0.20 (tar.bz2)",
+        "sha256": "cdfddfe01cc615218e333e34a1c761c9ef8fdf5199b27617264a02705eda7fc3",
+        "date": "08 Jun 2017"
+      },
+      {
+        "filename": "php-7.0.20.tar.gz",
+        "name": "PHP 7.0.20 (tar.gz)",
+        "sha256": "b44947f0c1926928d5c2f176506b878c32b5cd09ce3b5b52bbbecf4328ab812d",
+        "date": "08 Jun 2017"
+      },
+      {
+        "filename": "php-7.0.20.tar.xz",
+        "name": "PHP 7.0.20 (tar.xz)",
+        "sha256": "31b9cf1fb83fe3cd82c2f6603a0ae81ae6abacb5286827e362d8f85e68908e0a",
+        "date": "08 Jun 2017"
+      }
+    ],
+    "date": "08 Jun 2017",
+    "museum": false
+  },
+  "7.1.5": {
+    "announcement": {
+      "English": "/releases/7_1_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.5.tar.bz2",
+        "name": "PHP 7.1.5 (tar.bz2)",
+        "sha256": "28eaa4784f1bd8b7dc71206dc8c4375510199432dc17af6906b14d16b3058697",
+        "date": "11 May 2017"
+      },
+      {
+        "filename": "php-7.1.5.tar.gz",
+        "name": "PHP 7.1.5 (tar.gz)",
+        "sha256": "f7ff8039f5c3a7da4d62a3cce6378280224acfa27ab5a5bee25b7439bce01c17",
+        "date": "11 May 2017"
+      },
+      {
+        "filename": "php-7.1.5.tar.xz",
+        "name": "PHP 7.1.5 (tar.xz)",
+        "sha256": "d149a3c396c45611f5dc6bf14be190f464897145a76a8e5851cf18ff7094f6ac",
+        "date": "11 May 2017"
+      }
+    ],
+    "date": "11 May 2017",
+    "museum": false
+  },
+  "7.0.19": {
+    "announcement": {
+      "English": "/releases/7_0_19.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.19.tar.bz2",
+        "name": "PHP 7.0.19 (tar.bz2)",
+        "sha256": "0f3ac0afc02aec22f6b1659045da9287453e9309439d0499622bc8e94a7f7d59",
+        "date": "11 May 2017"
+      },
+      {
+        "filename": "php-7.0.19.tar.gz",
+        "name": "PHP 7.0.19 (tar.gz)",
+        "sha256": "4b4120acdbb8cbf5f7a18625c2eb5cdd2fdb4fc69a4831bc7ffdfd1ee78b1ce0",
+        "date": "11 May 2017"
+      },
+      {
+        "filename": "php-7.0.19.tar.xz",
+        "name": "PHP 7.0.19 (tar.xz)",
+        "sha256": "640e5e3377d15a6d19adce2b94a9d876eeddabdb862d154a5e347987f4225ef6",
+        "date": "11 May 2017"
+      }
+    ],
+    "date": "11 May 2017",
+    "museum": false
+  },
+  "7.1.4": {
+    "announcement": {
+      "English": "/releases/7_1_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.4.tar.bz2",
+        "name": "PHP 7.1.4 (tar.bz2)",
+        "sha256": "39bf697836e2760b3a44ea322e9e5f1f5b1f07abeb0111f6495eff7538e25805",
+        "date": "13 Apr 2017"
+      },
+      {
+        "filename": "php-7.1.4.tar.gz",
+        "name": "PHP 7.1.4 (tar.gz)",
+        "sha256": "ed0006c86de503684dde04c6dd811ea2354a3b6d10ebd9f0cb103dcd28f0e70f",
+        "date": "13 Apr 2017"
+      },
+      {
+        "filename": "php-7.1.4.tar.xz",
+        "name": "PHP 7.1.4 (tar.xz)",
+        "sha256": "71514386adf3e963df087c2044a0b3747900b8b1fc8da3a99f0a0ae9180d300b",
+        "date": "13 Apr 2017"
+      }
+    ],
+    "date": "13 Apr 2017",
+    "museum": false
+  },
+  "7.0.18": {
+    "announcement": {
+      "English": "/releases/7_0_18.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.18.tar.bz2",
+        "name": "PHP 7.0.18 (tar.bz2)",
+        "sha256": "b20cc63d507032b39d8bb14cb64784e460b0e47997e90a8704b703bcbb233fd1",
+        "date": "13 Apr 2017"
+      },
+      {
+        "filename": "php-7.0.18.tar.gz",
+        "name": "PHP 7.0.18 (tar.gz)",
+        "sha256": "e0fb336749d72e6c9cfcebb9b48497f004fa99f93b68c21cb3eb657053665e1d",
+        "date": "13 Apr 2017"
+      },
+      {
+        "filename": "php-7.0.18.tar.xz",
+        "name": "PHP 7.0.18 (tar.xz)",
+        "sha256": "679cffcdf2495dee5ab89bda595e678a1096136678b3a1d08f1f57ba347c234d",
+        "date": "13 Apr 2017"
+      }
+    ],
+    "date": "13 Apr 2017",
+    "museum": false
+  },
+  "7.1.3": {
+    "announcement": {
+      "English": "/releases/7_1_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.3.tar.bz2",
+        "name": "PHP 7.1.3 (tar.bz2)",
+        "sha256": "c145924d91b7a253eccc31f8d22f15b61589cd24d78105e56240c1bb6413b94f",
+        "date": "16 Mar 2017"
+      },
+      {
+        "filename": "php-7.1.3.tar.gz",
+        "name": "PHP 7.1.3 (tar.gz)",
+        "sha256": "4bfadd0012b966eced448497272150ffeede13136a961aacb9e71553b8e929ec",
+        "date": "16 Mar 2017"
+      },
+      {
+        "filename": "php-7.1.3.tar.xz",
+        "name": "PHP 7.1.3 (tar.xz)",
+        "sha256": "e4887c2634778e37fd962fbdf5c4a7d32cd708482fe07b448804625570cb0bb0",
+        "date": "16 Mar 2017"
+      }
+    ],
+    "date": "16 Mar 2017",
+    "museum": false
+  },
+  "7.0.17": {
+    "announcement": {
+      "English": "/releases/7_0_17.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.17.tar.bz2",
+        "name": "PHP 7.0.17 (tar.bz2)",
+        "sha256": "aee503926b96d807692fac3e0fd64e3259788f5139819a983152679cb6e91d4b",
+        "date": "30 Mar 2017"
+      },
+      {
+        "filename": "php-7.0.17.tar.gz",
+        "name": "PHP 7.0.17 (tar.gz)",
+        "sha256": "1f42ffe9895dad746baf4a0e8d81f2272f55fdef66cf298ac911d8791ceb1e80",
+        "date": "30 Mar 2017"
+      },
+      {
+        "filename": "php-7.0.17.tar.xz",
+        "name": "PHP 7.0.17 (tar.xz)",
+        "sha256": "471c16fcdd6a5e1a37199e97bcaeea6117626229785185be7532aaa7c6ee04be",
+        "date": "30 Mar 2017"
+      }
+    ],
+    "date": "30 Mar 2017",
+    "museum": false
+  },
+  "7.1.2": {
+    "announcement": {
+      "English": "/releases/7_1_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.2.tar.bz2",
+        "name": "PHP 7.1.2 (tar.bz2)",
+        "sha256": "e0f2214e2366434ee231156ba70cfefd0c59790f050d8727a3f1dc2affa67004",
+        "date": "16 Feb 2017"
+      },
+      {
+        "filename": "php-7.1.2.tar.gz",
+        "name": "PHP 7.1.2 (tar.gz)",
+        "sha256": "e6773217c9c719ca22abb104ae3d437d53daceaf31faf2e5eeb1f9f5028005d8",
+        "date": "16 Feb 2017"
+      },
+      {
+        "filename": "php-7.1.2.tar.xz",
+        "name": "PHP 7.1.2 (tar.xz)",
+        "sha256": "d815a0c39fd57bab1434a77ff0610fb507c22f790c66cd6f26e27030c4b3e971",
+        "date": "16 Feb 2017"
+      }
+    ],
+    "date": "16 Feb 2017",
+    "museum": false
+  },
+  "7.0.16": {
+    "announcement": {
+      "English": "/releases/7_0_16.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.16.tar.bz2",
+        "name": "PHP 7.0.16 (tar.bz2)",
+        "sha256": "83c5f57575dc0feca563af529d6f1d60183bf9c2c13e98a6da131fbd0a3597ab",
+        "date": "16 Feb 2017"
+      },
+      {
+        "filename": "php-7.0.16.tar.gz",
+        "name": "PHP 7.0.16 (tar.gz)",
+        "sha256": "bc6709dc7612957d0533c09c9c8a9c2e7c4fd9d64e697707bb1b39670eab61d4",
+        "date": "16 Feb 2017"
+      },
+      {
+        "filename": "php-7.0.16.tar.xz",
+        "name": "PHP 7.0.16 (tar.xz)",
+        "sha256": "244ac39bc657448962860aa7a590e4417f68513ad5e86ee2727b1328b0537309",
+        "date": "16 Feb 2017"
+      }
+    ],
+    "date": "16 Feb 2017",
+    "museum": false
+  },
+  "7.1.1": {
+    "announcement": {
+      "English": "/releases/7_1_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.1.tar.bz2",
+        "name": "PHP 7.1.1 (tar.bz2)",
+        "sha256": "d791d39d7b54ec42441a05a5f06d68a495647d843210e3ae4f2c6adb99c675bc",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-7.1.1.tar.gz",
+        "name": "PHP 7.1.1 (tar.gz)",
+        "sha256": "c136279d539c3c2c25176bf149c14913670e79bb27ee6b73e1cd69003985a70d",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-7.1.1.tar.xz",
+        "name": "PHP 7.1.1 (tar.xz)",
+        "sha256": "b3565b0c1441064eba204821608df1ec7367abff881286898d900c2c2a5ffe70",
+        "date": "19 Jan 2017"
+      }
+    ],
+    "date": "19 Jan 2017",
+    "museum": false
+  },
+  "7.0.15": {
+    "announcement": {
+      "English": "/releases/7_0_15.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.15.tar.bz2",
+        "name": "PHP 7.0.15 (tar.bz2)",
+        "sha256": "a8c8f947335683fa6dd1b7443ed70f2a42bc33e8b6c215f139138cee89e47dd9",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-7.0.15.tar.gz",
+        "name": "PHP 7.0.15 (tar.gz)",
+        "sha256": "c24324c6d4bf27e8bc1d12da0aae4f15a43c8374f681e23e9b1e67f5b719c3a6",
+        "date": "19 Jan 2017"
+      },
+      {
+        "filename": "php-7.0.15.tar.xz",
+        "name": "PHP 7.0.15 (tar.xz)",
+        "sha256": "300364d57fc4a6176ff7d52d390ee870ab6e30df121026649f8e7e0b9657fe93",
+        "date": "19 Jan 2017"
+      }
+    ],
+    "date": "19 Jan 2017",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.14": {
+    "announcement": {
+      "English": "/releases/7_0_14.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.14.tar.bz2",
+        "name": "PHP 7.0.14 (tar.bz2)",
+        "sha256": "fbc4369a0d42b55fd1ce75eb4f3d17b012da754a67567d8e3288fbfbb7490534",
+        "date": "08 Dec 2016"
+      },
+      {
+        "filename": "php-7.0.14.tar.gz",
+        "name": "PHP 7.0.14 (tar.gz)",
+        "sha256": "320cfd2184e7252d3d77eae5d5474554fa04ab9fbee7c6094c07e8bd3b5b632b",
+        "date": "08 Dec 2016"
+      },
+      {
+        "filename": "php-7.0.14.tar.xz",
+        "name": "PHP 7.0.14 (tar.xz)",
+        "sha256": "0f1dff6392a1cc2ed126b9695f580a2ed77eb09d2c23b41cabfb41e6f27a8c89",
+        "date": "08 Dec 2016"
+      }
+    ],
+    "date": "08 Dec 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.1.0": {
+    "announcement": {
+      "English": "/releases/7_1_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.1.0.tar.bz2",
+        "name": "PHP 7.1.0 (tar.bz2)",
+        "sha256": "68bcfd7deed5b3474d81dec9f74d122058327e2bed0ac25bbc9ec70995228e61",
+        "date": "01 Dec 2016"
+      },
+      {
+        "filename": "php-7.1.0.tar.gz",
+        "name": "PHP 7.1.0 (tar.gz)",
+        "sha256": "9e84c5b13005c56374730edf534fe216f6a2e63792a9703d4b894e770bbccbae",
+        "date": "01 Dec 2016"
+      },
+      {
+        "filename": "php-7.1.0.tar.xz",
+        "name": "PHP 7.1.0 (tar.xz)",
+        "sha256": "a810b3f29c21407c24caa88f50649320d20ba6892ae1923132598b8a0ca145b6",
+        "date": "01 Dec 2016"
+      }
+    ],
+    "date": "01 Dec 2016",
+    "museum": false
+  },
+  "7.0.13": {
+    "announcement": {
+      "English": "/releases/7_0_13.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.13.tar.bz2",
+        "name": "PHP 7.0.13 (tar.bz2)",
+        "sha256": "d090bb523812117ec0c08d8f0b5c5f0616aa7a29a2eeee0374efe53a7cfe88c1",
+        "date": "10 Nov 2016"
+      },
+      {
+        "filename": "php-7.0.13.tar.gz",
+        "name": "PHP 7.0.13 (tar.gz)",
+        "sha256": "c8d8cf1b29e7f7e89be9ee64f453cb7ef6d20e1d13a83cba037bd654ef2da42c",
+        "date": "10 Nov 2016"
+      },
+      {
+        "filename": "php-7.0.13.tar.xz",
+        "name": "PHP 7.0.13 (tar.xz)",
+        "sha256": "357ba7f93975d7d836abed0852dc3ed96a988af539e87750613294cbee82f1bf",
+        "date": "10 Nov 2016"
+      }
+    ],
+    "date": "10 Nov 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.12": {
+    "announcement": {
+      "English": "/releases/7_0_12.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.12.tar.bz2",
+        "name": "PHP 7.0.12 (tar.bz2)",
+        "sha256": "38c47294fe8fb239b0230dc63a93c3e4044f472ab93b5dff8b65feb4103a6a27",
+        "date": "13 Oct 2016"
+      },
+      {
+        "filename": "php-7.0.12.tar.gz",
+        "name": "PHP 7.0.12 (tar.gz)",
+        "sha256": "c4693cc363b4bbc7224294cc94faf3598e616cbe8540dd6975f68c7d3c52682f",
+        "date": "13 Oct 2016"
+      },
+      {
+        "filename": "php-7.0.12.tar.xz",
+        "name": "PHP 7.0.12 (tar.xz)",
+        "sha256": "f3d6c49e1c242e5995dec15e503fde996c327eb86cd7ec45c690e93c971b83ff",
+        "date": "13 Oct 2016"
+      }
+    ],
+    "date": "13 Oct 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.11": {
+    "announcement": {
+      "English": "/releases/7_0_11.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.11.tar.bz2",
+        "name": "PHP 7.0.11 (tar.bz2)",
+        "sha256": "f99b729dc1149858844b18af1e8c0de6dd1cdfdd52e22fbb4de2aa78bf9bf7f1",
+        "date": "15 Sep 2016"
+      },
+      {
+        "filename": "php-7.0.11.tar.gz",
+        "name": "PHP 7.0.11 (tar.gz)",
+        "sha256": "02d27b5d140dbad8d400a95af808e1e9ce87aa8d2a2100870734ba26e6700d79",
+        "date": "15 Sep 2016"
+      },
+      {
+        "filename": "php-7.0.11.tar.xz",
+        "name": "PHP 7.0.11 (tar.xz)",
+        "sha256": "d4cccea8da1d27c11b89386f8b8e95692ad3356610d571253d00ca67d524c735",
+        "date": "15 Sep 2016"
+      }
+    ],
+    "date": "15 Sep 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.10": {
+    "announcement": {
+      "English": "/releases/7_0_10.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.10.tar.bz2",
+        "name": "PHP 7.0.10 (tar.bz2)",
+        "sha256": "8055bbe5a736986931c0c6a08b765d6d778271ec7d2d56c50a1ad259ec09f6de",
+        "date": "18 Aug 2016"
+      },
+      {
+        "filename": "php-7.0.10.tar.gz",
+        "name": "PHP 7.0.10 (tar.gz)",
+        "sha256": "46216e05db09c0fffbf832e3b64f3722ccbdd6d4ae16d9791e41adf0a4b00641",
+        "date": "18 Aug 2016"
+      },
+      {
+        "filename": "php-7.0.10.tar.xz",
+        "name": "PHP 7.0.10 (tar.xz)",
+        "sha256": "348476ff7ba8d95a1e28e1059430c10470c5f8110f6d9133d30153dda4cdf56a",
+        "date": "18 Aug 2016"
+      }
+    ],
+    "date": "18 Aug 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.9": {
+    "announcement": {
+      "English": "/releases/7_0_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.9.tar.bz2",
+        "name": "PHP 7.0.9 (tar.bz2)",
+        "sha256": "2ee6968b5875f2f38700c58a189aad859a6a0b85fc337aa102ec2dc3652c3b7b",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-7.0.9.tar.gz",
+        "name": "PHP 7.0.9 (tar.gz)",
+        "sha256": "93895a6a610c94751c890e5ee91a7f4bc0eae476b95fe30425d13f7ae88753d5",
+        "date": "21 Jul 2016"
+      },
+      {
+        "filename": "php-7.0.9.tar.xz",
+        "name": "PHP 7.0.9 (tar.xz)",
+        "sha256": "970c322ba3e472cb0264b8ba9d4d92e87918da5d0cca53c4aba2a70545b8626d",
+        "date": "21 Jul 2016"
+      }
+    ],
+    "date": "21 Jul 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.8": {
+    "announcement": {
+      "English": "/releases/7_0_8.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.8.tar.bz2",
+        "name": "PHP 7.0.8 (tar.bz2)",
+        "sha256": "66dc7ba388490e07b1313fe3a06b1fa822e1310585fe29f4909995f131e27c8d",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-7.0.8.tar.gz",
+        "name": "PHP 7.0.8 (tar.gz)",
+        "sha256": "1f024fa6d87594b99fa312e3185c357dcffa42e07d21c726f41d1fa6f773720b",
+        "date": "23 Jun 2016"
+      },
+      {
+        "filename": "php-7.0.8.tar.xz",
+        "name": "PHP 7.0.8 (tar.xz)",
+        "sha256": "0a2142c458b0846f556b16da1c927d74c101aa951bb840549abe5c58584fb394",
+        "date": "23 Jun 2016"
+      }
+    ],
+    "date": "23 Jun 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.7": {
+    "announcement": {
+      "English": "/releases/7_0_7.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.7.tar.bz2",
+        "name": "PHP 7.0.7 (tar.bz2)",
+        "sha256": "474f2925c4782b94016e3afbb17b14ff9cc6f4fdb6f6e231b36a378bb18a3d1a",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-7.0.7.tar.gz",
+        "name": "PHP 7.0.7 (tar.gz)",
+        "sha256": "66282ff4a9f88fe9607d9574e15bf335885b964245591a1740adb3f79c514a67",
+        "date": "26 May 2016"
+      },
+      {
+        "filename": "php-7.0.7.tar.xz",
+        "name": "PHP 7.0.7 (tar.xz)",
+        "sha256": "9cc64a7459242c79c10e79d74feaf5bae3541f604966ceb600c3d2e8f5fe4794",
+        "date": "26 May 2016"
+      }
+    ],
+    "date": "26 May 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.6": {
+    "announcement": {
+      "English": "/releases/7_0_6.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.6.tar.bz2",
+        "name": "PHP 7.0.6 (tar.bz2)",
+        "sha256": "14ddf192a9965c858c1e742a61456be2f34a4db87556172c0d76f08de96329b7",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-7.0.6.tar.gz",
+        "name": "PHP 7.0.6 (tar.gz)",
+        "sha256": "f6b47cb3e02530d96787ae5c7888aefbd1db6ae4164d68b88808ee6f4da94277",
+        "date": "28 Apr 2016"
+      },
+      {
+        "filename": "php-7.0.6.tar.xz",
+        "name": "PHP 7.0.6 (tar.xz)",
+        "sha256": "1b237a9455e5476a425dbb9d99966bad68107747c601958cb9558a7fb49ab419",
+        "date": "28 Apr 2016"
+      }
+    ],
+    "date": "28 Apr 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.5": {
+    "announcement": {
+      "English": "/releases/7_0_5.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.5.tar.bz2",
+        "name": "PHP 7.0.5 (tar.bz2)",
+        "sha256": "2c09af7fe64537ea795f098b9b542ead407ef83f7cdc65b3787115ccbbb51de9",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-7.0.5.tar.gz",
+        "name": "PHP 7.0.5 (tar.gz)",
+        "sha256": "f9d93419031b4df663fc48f03b8a833545de8776225e46637563e2be6029908d",
+        "date": "31 Mar 2016"
+      },
+      {
+        "filename": "php-7.0.5.tar.xz",
+        "name": "PHP 7.0.5 (tar.xz)",
+        "sha256": "c41f1a03c24119c0dd9b741cdb67880486e64349fc33527767f6dc28d3803abb",
+        "date": "31 Mar 2016"
+      }
+    ],
+    "date": "31 Mar 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.4": {
+    "announcement": {
+      "English": "/releases/7_0_4.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.4.tar.bz2",
+        "name": "PHP 7.0.4 (tar.bz2)",
+        "sha256": "a246c503709c189ba8e1e22ed2cb22abc27da43a997ff1b3318e181baf529dcc",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-7.0.4.tar.gz",
+        "name": "PHP 7.0.4 (tar.gz)",
+        "sha256": "f6cdac2fd37da0ac0bbcee0187d74b3719c2f83973dfe883d5cde81c356fe0a8",
+        "date": "03 Mar 2016"
+      },
+      {
+        "filename": "php-7.0.4.tar.xz",
+        "name": "PHP 7.0.4 (tar.xz)",
+        "sha256": "584e0e374e357a71b6e95175a2947d787453afc7f9ab7c55651c10491c4df532",
+        "date": "03 Mar 2016"
+      }
+    ],
+    "date": "03 Mar 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.3": {
+    "announcement": {
+      "English": "/releases/7_0_3.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.3.tar.bz2",
+        "name": "PHP 7.0.3 (tar.bz2)",
+        "sha256": "826823d754f09c779222a99becf9c53a4dc719dba2d777aca7807c6ca68e6fc6",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-7.0.3.tar.gz",
+        "name": "PHP 7.0.3 (tar.gz)",
+        "sha256": "5521df8db153aba35c90cf1a1829106b6bbdac32425216d440f9cc29f00a7c08",
+        "date": "04 Feb 2016"
+      },
+      {
+        "filename": "php-7.0.3.tar.xz",
+        "name": "PHP 7.0.3 (tar.xz)",
+        "sha256": "3af2b62617a0e46214500fc3e7f4a421067224913070844d3665d6cc925a1cca",
+        "date": "04 Feb 2016"
+      }
+    ],
+    "date": "04 Feb 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.2": {
+    "announcement": {
+      "English": "/releases/7_0_2.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.2.tar.bz2",
+        "name": "PHP 7.0.2 (tar.bz2)",
+        "sha256": "9b1b75fbd9c92c6b0003b234e550965038826d11ea1f430bf279964da9da2236",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-7.0.2.tar.gz",
+        "name": "PHP 7.0.2 (tar.gz)",
+        "sha256": "040198aef3dc5f17c253c1282160aabc6a05ca0b18b3d6fc9213970363083412",
+        "date": "07 Jan 2016"
+      },
+      {
+        "filename": "php-7.0.2.tar.xz",
+        "name": "PHP 7.0.2 (tar.xz)",
+        "sha256": "556121271a34c442b48e3d7fa3d3bbb4413d91897abbb92aaeced4a7df5f2ab2",
+        "date": "07 Jan 2016"
+      }
+    ],
+    "date": "07 Jan 2016",
+    "museum": false,
+    "tags": [
+      "security"
+    ]
+  },
+  "7.0.1": {
+    "announcement": {
+      "English": "/releases/7_0_1.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.1.tar.bz2",
+        "name": "PHP 7.0.1 (tar.bz2)",
+        "sha256": "04ce3bd1da001397b342c2219a5093be9ecbbc97f022e1e6a0ec2fedc3d93e42",
+        "date": "17 Dec 2015"
+      },
+      {
+        "filename": "php-7.0.1.tar.gz",
+        "name": "PHP 7.0.1 (tar.gz)",
+        "sha256": "d12aaba2bead056322aa53bd5fbe762b27a42d37f451cd42ff2e7a549ca21dbf",
+        "date": "17 Dec 2015"
+      },
+      {
+        "filename": "php-7.0.1.tar.xz",
+        "name": "PHP 7.0.1 (tar.xz)",
+        "sha256": "84fcb8b9c61f70db802d3b6636c6ba602470a375e593375c0c744483aa0c0357",
+        "date": "17 Dec 2015"
+      }
+    ],
+    "date": "17 Dec 2015",
+    "museum": false
+  },
+  "7.0.0": {
+    "announcement": {
+      "English": "/releases/7_0_0.php"
+    },
+    "source": [
+      {
+        "filename": "php-7.0.0.tar.bz2",
+        "name": "PHP 7.0.0 (tar.bz2)",
+        "sha256": "a92a54306832167a39f7c0ec00524fc6f3f7d985c806caa7632561d0ddedfcea",
+        "date": "03 Dec 2015"
+      },
+      {
+        "filename": "php-7.0.0.tar.gz",
+        "name": "PHP 7.0.0 (tar.gz)",
+        "sha256": "d6ae7b4a2e5c43a9945a97e83b6b3adfb7d0df0b91ef78b647a6dffefaa9c71b",
+        "date": "03 Dec 2015"
+      },
+      {
+        "filename": "php-7.0.0.tar.xz",
+        "name": "PHP 7.0.0 (tar.xz)",
+        "sha256": "7dbdda74c502960febe0544b3e3a7c430389a7a4260e94c73fd8ca26c33b8540",
+        "date": "03 Dec 2015"
+      }
+    ],
+    "date": "03 Dec 2015",
+    "museum": false
+  }
+}

--- a/php-releases/php-8.json
+++ b/php-releases/php-8.json
@@ -1,0 +1,2459 @@
+{
+  "8.3.7": {
+    "announcement": true,
+    "tags": [],
+    "date": "09 May 2024",
+    "source": [
+      {
+        "filename": "php-8.3.7.tar.gz",
+        "name": "PHP 8.3.7 (tar.gz)",
+        "sha256": "2e11d10b651459a8767401e66b5d70e3b048e446579fcdeb0b69bcba789af8c4",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.3.7.tar.bz2",
+        "name": "PHP 8.3.7 (tar.bz2)",
+        "sha256": "01c20cde1c5a5696651875ed22f507849679fba740f8c421616b7d43d7f797da",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.3.7.tar.xz",
+        "name": "PHP 8.3.7 (tar.xz)",
+        "sha256": "d53433c1ca6b2c8741afa7c524272e6806c1e895e5912a058494fea89988570a",
+        "date": "09 May 2024"
+      }
+    ]
+  },
+  "8.2.19": {
+    "announcement": true,
+    "tags": [],
+    "date": "09 May 2024",
+    "source": [
+      {
+        "filename": "php-8.2.19.tar.gz",
+        "name": "PHP 8.2.19 (tar.gz)",
+        "sha256": "8bfdd20662b41a238a5acd84fab3e05c36a685fcb56e6d8ac18eeb87057ab2bc",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.2.19.tar.bz2",
+        "name": "PHP 8.2.19 (tar.bz2)",
+        "sha256": "3c18f7ce51b7c7b26b797e1f97079d386b30347eb04e817f5e6c8e9b275e2a6a",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.2.19.tar.xz",
+        "name": "PHP 8.2.19 (tar.xz)",
+        "sha256": "aecd63f3ebea6768997f5c4fccd98acbf897762ed5fc25300e846197a9485c13",
+        "date": "09 May 2024"
+      }
+    ]
+  },
+  "8.1.28": {
+    "announcement": true,
+    "tags": [
+      "security"
+    ],
+    "date": "11 Apr 2024",
+    "source": [
+      {
+        "filename": "php-8.1.28.tar.gz",
+        "name": "PHP 8.1.28 (tar.gz)",
+        "sha256": "a2a9d853f4a4c9ff8631da5dc3a6cec5ab083ef37a214877b0240dcfcdfdefea",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.1.28.tar.bz2",
+        "name": "PHP 8.1.28 (tar.bz2)",
+        "sha256": "8be450096e0153c47d75384e7dd595cc897f1d53ce0060708ce9589bcc3141ee",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.1.28.tar.xz",
+        "name": "PHP 8.1.28 (tar.xz)",
+        "sha256": "95d0b2e9466108fd750dab5c30a09e5c67f5ad2cb3b1ffb3625a038a755ad080",
+        "date": "11 Apr 2024"
+      }
+    ]
+  },
+  "8.3.6": {
+    "announcement": {
+      "English": "/releases/8_3_6.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "11 Apr 2024",
+    "source": [
+      {
+        "filename": "php-8.3.6.tar.gz",
+        "name": "PHP 8.3.6 (tar.gz)",
+        "sha256": "39695f5bd107892e36fd2ed6b3d3a78140fd4b05d556d6c6531a921633cacb5f",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.3.6.tar.bz2",
+        "name": "PHP 8.3.6 (tar.bz2)",
+        "sha256": "6324b1ddd8eb3025b041034b88dc2bc0b4819b0022129eeaeba37e47803108bc",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.3.6.tar.xz",
+        "name": "PHP 8.3.6 (tar.xz)",
+        "sha256": "53c8386b2123af97626d3438b3e4058e0c5914cb74b048a6676c57ac647f5eae",
+        "date": "11 Apr 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.18": {
+    "announcement": {
+      "English": "/releases/8_2_18.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "11 Apr 2024",
+    "source": [
+      {
+        "filename": "php-8.2.18.tar.gz",
+        "name": "PHP 8.2.18 (tar.gz)",
+        "sha256": "b934ca7e8c82945c5cbf0aa2a3f66727eb5b5098e551819e1b090572d6a51ead",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.2.18.tar.bz2",
+        "name": "PHP 8.2.18 (tar.bz2)",
+        "sha256": "ca0b07c254200320f518ac5b3df540a9cf14d866f3c93edc3013b52e06fac796",
+        "date": "11 Apr 2024"
+      },
+      {
+        "filename": "php-8.2.18.tar.xz",
+        "name": "PHP 8.2.18 (tar.xz)",
+        "sha256": "44b306fc021e56441f691da6c3108788bd9e450f293b3bc70fcd64b08dd41a50",
+        "date": "11 Apr 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.27": {
+    "announcement": {
+      "English": "/releases/8_1_27.php"
+    },
+    "tags": [],
+    "date": "21 Dec 2023",
+    "source": [
+      {
+        "filename": "php-8.1.27.tar.gz",
+        "name": "PHP 8.1.27 (tar.gz)",
+        "sha256": "9aa5d7a29389d799885d90740932697006d5d0f55d1def67678e0c14f6ab7b2d",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.1.27.tar.bz2",
+        "name": "PHP 8.1.27 (tar.bz2)",
+        "sha256": "a15fd73ea44f2df30b07d24786e07d1948b0ea3eed0b8b845735d500dc28bff1",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.1.27.tar.xz",
+        "name": "PHP 8.1.27 (tar.xz)",
+        "sha256": "479e65c3f05714d4aace1370e617d78e49e996ec7a7579a5be47535be61f0658",
+        "date": "21 Dec 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.3.4": {
+    "announcement": {
+      "English": "/releases/8_3_4.php"
+    },
+    "tags": [],
+    "date": "14 Mar 2024",
+    "source": [
+      {
+        "filename": "php-8.3.4.tar.gz",
+        "name": "PHP 8.3.4 (tar.gz)",
+        "sha256": "0e2801e47fb1b92d2743204fcf650ce2fcad1a13ef7a44fe05738101a383e4a2",
+        "date": "14 Mar 2024"
+      },
+      {
+        "filename": "php-8.3.4.tar.bz2",
+        "name": "PHP 8.3.4 (tar.bz2)",
+        "sha256": "3c5caf18e0c0a243aaec913a39ecb092043195adde4c3fc42e945da5b9277695",
+        "date": "14 Mar 2024"
+      },
+      {
+        "filename": "php-8.3.4.tar.xz",
+        "name": "PHP 8.3.4 (tar.xz)",
+        "sha256": "39a337036a546e5c28aea76cf424ac172db5156bd8a8fd85252e389409a5ba63",
+        "date": "14 Mar 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.17": {
+    "announcement": {
+      "English": "/releases/8_2_17.php"
+    },
+    "tags": [],
+    "date": "14 Mar 2024",
+    "source": [
+      {
+        "filename": "php-8.2.17.tar.gz",
+        "name": "PHP 8.2.17 (tar.gz)",
+        "sha256": "1d8ab98e1c09518c672c5afcbef0e61f9003173c7638fc686461ae670d12742e",
+        "date": "14 Mar 2024"
+      },
+      {
+        "filename": "php-8.2.17.tar.bz2",
+        "name": "PHP 8.2.17 (tar.bz2)",
+        "sha256": "191316c203267d96160b47d22f955d4dc11793de8a5f327e0c2a76275a6894ea",
+        "date": "14 Mar 2024"
+      },
+      {
+        "filename": "php-8.2.17.tar.xz",
+        "name": "PHP 8.2.17 (tar.xz)",
+        "sha256": "1cc4ef733ba58f6557db648012471f1916e5bac316303aa165535bedab08ee35",
+        "date": "14 Mar 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.3.3": {
+    "announcement": {
+      "English": "/releases/8_3_3.php"
+    },
+    "tags": [],
+    "date": "15 Feb 2024",
+    "source": [
+      {
+        "filename": "php-8.3.3.tar.gz",
+        "name": "PHP 8.3.3 (tar.gz)",
+        "sha256": "61285ae17a93d172c9f2ebfe4280058d05bda17cadab705ca5b51ba3e6f3a5ac",
+        "date": "15 Feb 2024"
+      },
+      {
+        "filename": "php-8.3.3.tar.bz2",
+        "name": "PHP 8.3.3 (tar.bz2)",
+        "sha256": "aafb613ba79594a23fe722f8e90ad473300610bf80e74b8aa52da9cac2dc4e2a",
+        "date": "15 Feb 2024"
+      },
+      {
+        "filename": "php-8.3.3.tar.xz",
+        "name": "PHP 8.3.3 (tar.xz)",
+        "sha256": "b0a996276fe21fe9ca8f993314c8bc02750f464c7b0343f056fb0894a8dfa9d1",
+        "date": "15 Feb 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.16": {
+    "announcement": {
+      "English": "/releases/8_2_16.php"
+    },
+    "tags": [],
+    "date": "15 Feb 2024",
+    "source": [
+      {
+        "filename": "php-8.2.16.tar.gz",
+        "name": "PHP 8.2.16 (tar.gz)",
+        "sha256": "62a92ef7c2c6f44b12e459d8f3d649aa8ebac5e05845f7479fe55a7580cd2dd0",
+        "date": "15 Feb 2024"
+      },
+      {
+        "filename": "php-8.2.16.tar.bz2",
+        "name": "PHP 8.2.16 (tar.bz2)",
+        "sha256": "2658c1b8935ab6b53a7f209354602761ab07066e66920bc472b8815fd1b43f71",
+        "date": "15 Feb 2024"
+      },
+      {
+        "filename": "php-8.2.16.tar.xz",
+        "name": "PHP 8.2.16 (tar.xz)",
+        "sha256": "28cdc995b7d5421711c7044294885fcde4390c9f67504a994b4cf9bc1b5cc593",
+        "date": "15 Feb 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.15": {
+    "announcement": {
+      "English": "/releases/8_2_15.php"
+    },
+    "tags": [],
+    "date": "18 Jan 2024",
+    "source": [
+      {
+        "filename": "php-8.2.15.tar.gz",
+        "name": "PHP 8.2.15 (tar.gz)",
+        "sha256": "f9390d23708c65f428e868583dce7ab4a69e88ab6f377137a56643076f966b8f",
+        "date": "18 Jan 2024"
+      },
+      {
+        "filename": "php-8.2.15.tar.bz2",
+        "name": "PHP 8.2.15 (tar.bz2)",
+        "sha256": "50c3e220b7aa63a85716233c902eb44cc0a4667ed0b8335722ae2391b1355e7a",
+        "date": "18 Jan 2024"
+      },
+      {
+        "filename": "php-8.2.15.tar.xz",
+        "name": "PHP 8.2.15 (tar.xz)",
+        "sha256": "eca5deac02d77d806838275f8a3024b38b35ac0a5d9853dcc71c6cbe3f1f8765",
+        "date": "18 Jan 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.3.2": {
+    "announcement": {
+      "English": "/releases/8_3_2.php"
+    },
+    "tags": [],
+    "date": "18 Jan 2024",
+    "source": [
+      {
+        "filename": "php-8.3.2.tar.gz",
+        "name": "PHP 8.3.2 (tar.gz)",
+        "sha256": "decf0f51e5415b21fb6350753e45b6c3be5cc0868e4ec561e5c89326c8e6ef16",
+        "date": "18 Jan 2024"
+      },
+      {
+        "filename": "php-8.3.2.tar.bz2",
+        "name": "PHP 8.3.2 (tar.bz2)",
+        "sha256": "582b3c837a8d952efffe274a5e49706c43a88c162830c2a8c358089fe7449284",
+        "date": "18 Jan 2024"
+      },
+      {
+        "filename": "php-8.3.2.tar.xz",
+        "name": "PHP 8.3.2 (tar.xz)",
+        "sha256": "4ffa3e44afc9c590e28dc0d2d31fc61f0139f8b335f11880a121b9f9b9f0634e",
+        "date": "18 Jan 2024"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.14": {
+    "announcement": {
+      "English": "/releases/8_2_14.php"
+    },
+    "tags": [],
+    "date": "21 Dec 2023",
+    "source": [
+      {
+        "filename": "php-8.2.14.tar.gz",
+        "name": "PHP 8.2.14 (tar.gz)",
+        "sha256": "4c1fbb55a10ece7f4532feba9f3f88b9b211c11320742977588738374c03255f",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.2.14.tar.bz2",
+        "name": "PHP 8.2.14 (tar.bz2)",
+        "sha256": "f871e131333d60ae6c537b1adddbc2aea54c436c562af986fb8309c060040b9e",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.2.14.tar.xz",
+        "name": "PHP 8.2.14 (tar.xz)",
+        "sha256": "763ecd39fcf51c3815af6ef6e43fa9aa0d0bd8e5a615009e5f4780c92705f583",
+        "date": "21 Dec 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.3.1": {
+    "announcement": {
+      "English": "/releases/8_3_1.php"
+    },
+    "tags": [],
+    "date": "21 Dec 2023",
+    "source": [
+      {
+        "filename": "php-8.3.1.tar.gz",
+        "name": "PHP 8.3.1 (tar.gz)",
+        "sha256": "2b10218b5e81915d1708ab4b6351362d073556ec73a790553c61fd89c119924e",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.3.1.tar.bz2",
+        "name": "PHP 8.3.1 (tar.bz2)",
+        "sha256": "c40fae9197fa68a532f6a062c316dafe3b04c545136b54b9ead4932fc26c6ae1",
+        "date": "21 Dec 2023"
+      },
+      {
+        "filename": "php-8.3.1.tar.xz",
+        "name": "PHP 8.3.1 (tar.xz)",
+        "sha256": "56445b1771b2ba5b7573453f9e8a9451e2d810b1741a352fa05259733b1e9758",
+        "date": "21 Dec 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.13": {
+    "announcement": {
+      "English": "/releases/8_2_13.php"
+    },
+    "tags": [],
+    "date": "23 Nov 2023",
+    "source": [
+      {
+        "filename": "php-8.2.13.tar.gz",
+        "name": "PHP 8.2.13 (tar.gz)",
+        "sha256": "6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.2.13.tar.bz2",
+        "name": "PHP 8.2.13 (tar.bz2)",
+        "sha256": "66529f43b213131e6b253c5602bef05f049458d21292730fccd63b48a06d67ba",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.2.13.tar.xz",
+        "name": "PHP 8.2.13 (tar.xz)",
+        "sha256": "2629bba10117bf78912068a230c68a8fd09b7740267bd8ebd3cfce91515d454b",
+        "date": "23 Nov 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.26": {
+    "announcement": {
+      "English": "/releases/8_1_26.php"
+    },
+    "tags": [],
+    "date": "23 Nov 2023",
+    "source": [
+      {
+        "filename": "php-8.1.26.tar.gz",
+        "name": "PHP 8.1.26 (tar.gz)",
+        "sha256": "d954cecfc3d294c2fccbe2b1a6bef784ce0d6c5d44a9e28f8a527e092825f2cb",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.1.26.tar.bz2",
+        "name": "PHP 8.1.26 (tar.bz2)",
+        "sha256": "83bde249c84aa1a043a8c8d0eea09345c2cae69b9784cdf02229fc916fbb9ea0",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.1.26.tar.xz",
+        "name": "PHP 8.1.26 (tar.xz)",
+        "sha256": "17f87133596449327451ad4b8d9911bfaea59ff5109f3a6f2bb679f967a8ea0f",
+        "date": "23 Nov 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.3.0": {
+    "announcement": {
+      "English": "/releases/8_3_0.php"
+    },
+    "tags": [],
+    "date": "23 Nov 2023",
+    "source": [
+      {
+        "filename": "php-8.3.0.tar.gz",
+        "name": "PHP 8.3.0 (tar.gz)",
+        "sha256": "557ae14650f1d1984d3213e3fcd8d93a5f11418b3f8026d3a2d5022251163951",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.3.0.tar.bz2",
+        "name": "PHP 8.3.0 (tar.bz2)",
+        "sha256": "de67d0833d42b196e5a66fa1a332f45e296cbe8e9472e9256b2a071c34dc5ed6",
+        "date": "23 Nov 2023"
+      },
+      {
+        "filename": "php-8.3.0.tar.xz",
+        "name": "PHP 8.3.0 (tar.xz)",
+        "sha256": "1db84fec57125aa93638b51bb2b15103e12ac196e2f960f0d124275b2687ea54",
+        "date": "23 Nov 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.30": {
+    "announcement": {
+      "English": "/releases/8_0_30.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "03 Aug 2023",
+    "source": [
+      {
+        "filename": "php-8.0.30.tar.gz",
+        "name": "PHP 8.0.30 (tar.gz)",
+        "sha256": "449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.0.30.tar.bz2",
+        "name": "PHP 8.0.30 (tar.bz2)",
+        "sha256": "98a9cb6a0e27a6950cdf4b26dcac48f2be2d936d5224a502f066cf3d4cf19b92",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.0.30.tar.xz",
+        "name": "PHP 8.0.30 (tar.xz)",
+        "sha256": "216ab305737a5d392107112d618a755dc5df42058226f1670e9db90e77d777d9",
+        "date": "03 Aug 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.25": {
+    "announcement": {
+      "English": "/releases/8_1_25.php"
+    },
+    "tags": [],
+    "date": "26 Oct 2023",
+    "source": [
+      {
+        "filename": "php-8.1.25.tar.gz",
+        "name": "PHP 8.1.25 (tar.gz)",
+        "sha256": "1a8c59d6b3eccb404c229e947558d2bf1220c3dec0b0036690fadc07f39934ab",
+        "date": "26 Oct 2023"
+      },
+      {
+        "filename": "php-8.1.25.tar.bz2",
+        "name": "PHP 8.1.25 (tar.bz2)",
+        "sha256": "a86a88c1840c1bc832bcfd2fbec3b8a1942c8314da5dff53f09f9c98d0c12e8a",
+        "date": "26 Oct 2023"
+      },
+      {
+        "filename": "php-8.1.25.tar.xz",
+        "name": "PHP 8.1.25 (tar.xz)",
+        "sha256": "66fdba064aa119b1463a7969571d42f4642690275d8605ab5149bcc5107e2484",
+        "date": "26 Oct 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.12": {
+    "announcement": {
+      "English": "/releases/8_2_12.php"
+    },
+    "tags": [],
+    "date": "26 Oct 2023",
+    "source": [
+      {
+        "filename": "php-8.2.12.tar.gz",
+        "name": "PHP 8.2.12 (tar.gz)",
+        "sha256": "b2b74a91f5fac14ce10ece0ac210f6f5d72f4367a3cb638e80d117d183750a21",
+        "date": "26 Oct 2023"
+      },
+      {
+        "filename": "php-8.2.12.tar.bz2",
+        "name": "PHP 8.2.12 (tar.bz2)",
+        "sha256": "704325f56b1b4c17f9f951e1ffef5c64e148896053f34e2626152cbaa2f05893",
+        "date": "26 Oct 2023"
+      },
+      {
+        "filename": "php-8.2.12.tar.xz",
+        "name": "PHP 8.2.12 (tar.xz)",
+        "sha256": "e1526e400bce9f9f9f774603cfac6b72b5e8f89fa66971ebc3cc4e5964083132",
+        "date": "26 Oct 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.24": {
+    "announcement": {
+      "English": "/releases/8_1_24.php"
+    },
+    "tags": [],
+    "date": "28 Sep 2023",
+    "source": [
+      {
+        "filename": "php-8.1.24.tar.gz",
+        "name": "PHP 8.1.24 (tar.gz)",
+        "sha256": "d6001a5c16765cd1897609fc71ff083e35db9a28c8874a1ff191cdebe80a6460",
+        "date": "28 Sep 2023"
+      },
+      {
+        "filename": "php-8.1.24.tar.bz2",
+        "name": "PHP 8.1.24 (tar.bz2)",
+        "sha256": "b0ae5804a9ad53a7e28d0a32629495f816f935b10830c71f4ec15827185a73c9",
+        "date": "28 Sep 2023"
+      },
+      {
+        "filename": "php-8.1.24.tar.xz",
+        "name": "PHP 8.1.24 (tar.xz)",
+        "sha256": "ee61f6232bb29bd2e785daf325d2177f2272bf80d086c295a724594e710bce3d",
+        "date": "28 Sep 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.11": {
+    "announcement": {
+      "English": "/releases/8_2_11.php"
+    },
+    "tags": [],
+    "date": "28 Sep 2023",
+    "source": [
+      {
+        "filename": "php-8.2.11.tar.gz",
+        "name": "PHP 8.2.11 (tar.gz)",
+        "sha256": "48b1b41279a678a4d4afcd0b256ed921ebf2a91febb0634fdc4449b91c75799f",
+        "date": "28 Sep 2023"
+      },
+      {
+        "filename": "php-8.2.11.tar.bz2",
+        "name": "PHP 8.2.11 (tar.bz2)",
+        "sha256": "38192daeffabf4af6c427bf17ac1f82565d9c7522e0dbd32215162944434b28b",
+        "date": "28 Sep 2023"
+      },
+      {
+        "filename": "php-8.2.11.tar.xz",
+        "name": "PHP 8.2.11 (tar.xz)",
+        "sha256": "29af82e4f7509831490552918aad502697453f0869a579ee1b80b08f9112c5b8",
+        "date": "28 Sep 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.23": {
+    "announcement": {
+      "English": "/releases/8_1_23.php"
+    },
+    "tags": [],
+    "date": "31 Aug 2023",
+    "source": [
+      {
+        "filename": "php-8.1.23.tar.gz",
+        "name": "PHP 8.1.23 (tar.gz)",
+        "sha256": "ec5330b3978edc8fe2f78830720505bf69d12542622b5cddccee63ae3a0e5b58",
+        "date": "31 Aug 2023"
+      },
+      {
+        "filename": "php-8.1.23.tar.bz2",
+        "name": "PHP 8.1.23 (tar.bz2)",
+        "sha256": "929a62785177da892ddffca074bab2f1ff578473a0d4adb915c12f5f3e34ec1b",
+        "date": "31 Aug 2023"
+      },
+      {
+        "filename": "php-8.1.23.tar.xz",
+        "name": "PHP 8.1.23 (tar.xz)",
+        "sha256": "fc48422fa7e75bb45916fc192a9f9728cb38bb2b5858572c51ea15825326360c",
+        "date": "31 Aug 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.10": {
+    "announcement": {
+      "English": "/releases/8_2_10.php"
+    },
+    "tags": [],
+    "date": "31 Aug 2023",
+    "source": [
+      {
+        "filename": "php-8.2.10.tar.gz",
+        "name": "PHP 8.2.10 (tar.gz)",
+        "sha256": "7e3e277d6eab652616f90bc7c75991179c0512953933ceba27496fb5514f7e78",
+        "date": "31 Aug 2023"
+      },
+      {
+        "filename": "php-8.2.10.tar.bz2",
+        "name": "PHP 8.2.10 (tar.bz2)",
+        "sha256": "cc9834e8f1b613d7677af8843c3651e9829abca8ebfe9079251d0d85d9a0aa3e",
+        "date": "31 Aug 2023"
+      },
+      {
+        "filename": "php-8.2.10.tar.xz",
+        "name": "PHP 8.2.10 (tar.xz)",
+        "sha256": "561dc4acd5386e47f25be76f2c8df6ae854756469159248313bcf276e282fbb3",
+        "date": "31 Aug 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.22": {
+    "announcement": {
+      "English": "/releases/8_1_22.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "03 Aug 2023",
+    "source": [
+      {
+        "filename": "php-8.1.22.tar.gz",
+        "name": "PHP 8.1.22 (tar.gz)",
+        "sha256": "f5140e94b139b4adec4b29c337537b7b6f1ef023197eb32be909e724e3da157a",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.1.22.tar.bz2",
+        "name": "PHP 8.1.22 (tar.bz2)",
+        "sha256": "992354e382c6c618d01ed4be06beea8dec3178b14153df64d3c8c48b85e9fbc2",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.1.22.tar.xz",
+        "name": "PHP 8.1.22 (tar.xz)",
+        "sha256": "9ea4f4cfe775cb5866c057323d6b320f3a6e0adb1be41a068ff7bfec6f83e71d",
+        "date": "03 Aug 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.9": {
+    "announcement": {
+      "English": "/releases/8_2_9.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "03 Aug 2023",
+    "source": [
+      {
+        "filename": "php-8.2.9.tar.gz",
+        "name": "PHP 8.2.9 (tar.gz)",
+        "sha256": "5fac52041335cacfb5845aeff2303f92403925338a0285f2e160feebcb840f04",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.2.9.tar.bz2",
+        "name": "PHP 8.2.9 (tar.bz2)",
+        "sha256": "48460b994ae7eb5096a310f44d13e865de1771104d4a550d53072be58a6f176c",
+        "date": "03 Aug 2023"
+      },
+      {
+        "filename": "php-8.2.9.tar.xz",
+        "name": "PHP 8.2.9 (tar.xz)",
+        "sha256": "1e6cb77f997613864ab3127fbfc6a8c7fdaa89a95e8ed6167617b913b4de4765",
+        "date": "03 Aug 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.8": {
+    "announcement": {
+      "English": "/releases/8_2_8.php"
+    },
+    "tags": [],
+    "date": "06 Jul 2023",
+    "source": [
+      {
+        "filename": "php-8.2.8.tar.gz",
+        "name": "PHP 8.2.8 (tar.gz)",
+        "sha256": "6419b74e9b675c8d5a1afd2788c4d7996a19bbe2be409716ccb2067897af9df1",
+        "date": "06 Jul 2023"
+      },
+      {
+        "filename": "php-8.2.8.tar.bz2",
+        "name": "PHP 8.2.8 (tar.bz2)",
+        "sha256": "995ed4009c7917c962d31837a1a3658f36d4af4f357b673c97ffdbe6403f8517",
+        "date": "06 Jul 2023"
+      },
+      {
+        "filename": "php-8.2.8.tar.xz",
+        "name": "PHP 8.2.8 (tar.xz)",
+        "sha256": "cfe1055fbcd486de7d3312da6146949aae577365808790af6018205567609801",
+        "date": "06 Jul 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.29": {
+    "announcement": {
+      "English": "/releases/8_0_29.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "08 Jun 2023",
+    "source": [
+      {
+        "filename": "php-8.0.29.tar.gz",
+        "name": "PHP 8.0.29 (tar.gz)",
+        "sha256": "db6ee08df5706365f624cde1cffb20ad6de1effe59d7e886337213a09f2e2684",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.0.29.tar.bz2",
+        "name": "PHP 8.0.29 (tar.bz2)",
+        "sha256": "4801a1f0e17170286723ab54acd045ac78a9656021d56f104a64543eec922e12",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.0.29.tar.xz",
+        "name": "PHP 8.0.29 (tar.xz)",
+        "sha256": "14db2fbf26c07d0eb2c9fab25dbde7e27726a3e88452cca671f0896bbb683ca9",
+        "date": "08 Jun 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.21": {
+    "announcement": {
+      "English": "/releases/8_1_21.php"
+    },
+    "tags": [],
+    "date": "06 Jul 2023",
+    "source": [
+      {
+        "filename": "php-8.1.21.tar.gz",
+        "name": "PHP 8.1.21 (tar.gz)",
+        "sha256": "a95f8d35924aa5705ad07a70dc994bf41b5d45126ecdec7aaad6edfbe5e1c37f",
+        "date": "06 Jul 2023"
+      },
+      {
+        "filename": "php-8.1.21.tar.bz2",
+        "name": "PHP 8.1.21 (tar.bz2)",
+        "sha256": "6ea49e8335d632177f56b507160aa151c7b020185789a9c14859fce5d4a0776d",
+        "date": "06 Jul 2023"
+      },
+      {
+        "filename": "php-8.1.21.tar.xz",
+        "name": "PHP 8.1.21 (tar.xz)",
+        "sha256": "e634a00b0c6a8cd39e840e9fb30b5227b820b7a9ace95b7b001053c1411c4821",
+        "date": "06 Jul 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.20": {
+    "announcement": {
+      "English": "/releases/8_1_20.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "08 Jun 2023",
+    "source": [
+      {
+        "filename": "php-8.1.20.tar.gz",
+        "name": "PHP 8.1.20 (tar.gz)",
+        "sha256": "b7d3e2a0c5bed37bb39e4627550d0ee5a4a600042b83c63037b0f5f84793cbe6",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.1.20.tar.bz2",
+        "name": "PHP 8.1.20 (tar.bz2)",
+        "sha256": "55578587514a2707500f85319e57c0d4df9b8803cdb26566595ac4bf459dc4dd",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.1.20.tar.xz",
+        "name": "PHP 8.1.20 (tar.xz)",
+        "sha256": "4c9973f599e93ed5e8ce2b45ce1d41bb8fb54ce642824fd23e56b52fd75029a6",
+        "date": "08 Jun 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.7": {
+    "announcement": {
+      "English": "/releases/8_2_7.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "08 Jun 2023",
+    "source": [
+      {
+        "filename": "php-8.2.7.tar.gz",
+        "name": "PHP 8.2.7 (tar.gz)",
+        "sha256": "7046f939f0e5116285341d55c06af1d50907e107ac2c70defc32ef880f88cde4",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.2.7.tar.bz2",
+        "name": "PHP 8.2.7 (tar.bz2)",
+        "sha256": "5bfb2a35c67921bdcadd5c90cb290ad7537d24da113a5e8bc2d646b02de7488f",
+        "date": "08 Jun 2023"
+      },
+      {
+        "filename": "php-8.2.7.tar.xz",
+        "name": "PHP 8.2.7 (tar.xz)",
+        "sha256": "4b9fb3dcd7184fe7582d7e44544ec7c5153852a2528de3b6754791258ffbdfa0",
+        "date": "08 Jun 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.19": {
+    "announcement": {
+      "English": "/releases/8_1_19.php"
+    },
+    "tags": [],
+    "date": "11 May 2023",
+    "source": [
+      {
+        "filename": "php-8.1.19.tar.gz",
+        "name": "PHP 8.1.19 (tar.gz)",
+        "sha256": "0ebb6b0ecf5d8e355c2f1362807f9b73c6e803d496c5ad3e4fb00be989988372",
+        "date": "11 May 2023"
+      },
+      {
+        "filename": "php-8.1.19.tar.bz2",
+        "name": "PHP 8.1.19 (tar.bz2)",
+        "sha256": "64207207fda30be926a2ef1f66ff266bf1fdc7e03339bc99fbba0a1245e4279b",
+        "date": "11 May 2023"
+      },
+      {
+        "filename": "php-8.1.19.tar.xz",
+        "name": "PHP 8.1.19 (tar.xz)",
+        "sha256": "f42f0e93467415b2d30aa5b7ac825f0079a74207e0033010383cdc1e13657379",
+        "date": "11 May 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.6": {
+    "announcement": {
+      "English": "/releases/8_2_6.php"
+    },
+    "tags": [],
+    "date": "11 May 2023",
+    "source": [
+      {
+        "filename": "php-8.2.6.tar.gz",
+        "name": "PHP 8.2.6 (tar.gz)",
+        "sha256": "1b8463df1f180ed39475cfcded1ff106242ccb823f99c9fc1a407c0b76afa2c8",
+        "date": "11 May 2023"
+      },
+      {
+        "filename": "php-8.2.6.tar.bz2",
+        "name": "PHP 8.2.6 (tar.bz2)",
+        "sha256": "44a70c52f537662c10d91eedbf51fd765c9961be6ba2508ed63bf7a26cdd3100",
+        "date": "11 May 2023"
+      },
+      {
+        "filename": "php-8.2.6.tar.xz",
+        "name": "PHP 8.2.6 (tar.xz)",
+        "sha256": "10b796f0ed45574229851212b30a596a76e70ae365322bcaaaf9c00fa7d58cca",
+        "date": "11 May 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.28": {
+    "announcement": {
+      "English": "/releases/8_0_28.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 Feb 2023",
+    "source": [
+      {
+        "filename": "php-8.0.28.tar.gz",
+        "name": "PHP 8.0.28 (tar.gz)",
+        "sha256": "7432184eae01e4e8e39f03f80e8ec0ca2c8bfebc56e9a7b983541ca8805df22f",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.0.28.tar.bz2",
+        "name": "PHP 8.0.28 (tar.bz2)",
+        "sha256": "9d5e74935c900e3b9c7b6bc740596b71933630eb9f63717c0c4923d8c788c62e",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.0.28.tar.xz",
+        "name": "PHP 8.0.28 (tar.xz)",
+        "sha256": "5e07278a1f315a67d36a676c01343ca2d4da5ec5bdb15d018e4248b3012bc0cd",
+        "date": "14 Feb 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.18": {
+    "announcement": {
+      "English": "/releases/8_1_18.php"
+    },
+    "tags": [],
+    "date": "13 Apr 2023",
+    "source": [
+      {
+        "filename": "php-8.1.18.tar.gz",
+        "name": "PHP 8.1.18 (tar.gz)",
+        "sha256": "8b6b12902e7d6bdf68668acc067b4d75a3c504722f768098c5f80c7d7bfd2563",
+        "date": "13 Apr 2023"
+      },
+      {
+        "filename": "php-8.1.18.tar.bz2",
+        "name": "PHP 8.1.18 (tar.bz2)",
+        "sha256": "d2ac30d6b574fca594fe0cc01c0693e23585b27443e342b0aab07274cde4416e",
+        "date": "13 Apr 2023"
+      },
+      {
+        "filename": "php-8.1.18.tar.xz",
+        "name": "PHP 8.1.18 (tar.xz)",
+        "sha256": "f3553370f8ba42729a9ce75eed17a2111d32433a43b615694f6a571b8bad0e39",
+        "date": "13 Apr 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.5": {
+    "announcement": {
+      "English": "/releases/8_2_5.php"
+    },
+    "tags": [],
+    "date": "13 Apr 2023",
+    "source": [
+      {
+        "filename": "php-8.2.5.tar.gz",
+        "name": "PHP 8.2.5 (tar.gz)",
+        "sha256": "8974dea2507155471660b13a0bcbdc165ac778eeb845a7dbd65d5ffb92738c0a",
+        "date": "13 Apr 2023"
+      },
+      {
+        "filename": "php-8.2.5.tar.bz2",
+        "name": "PHP 8.2.5 (tar.bz2)",
+        "sha256": "e5a80663cca4f6044ad86a489798147c7af037eca96f6cd357ab36d28cb63757",
+        "date": "13 Apr 2023"
+      },
+      {
+        "filename": "php-8.2.5.tar.xz",
+        "name": "PHP 8.2.5 (tar.xz)",
+        "sha256": "800738c359b7f1e67e40c22713d2d90276bc85ba1c21b43d99edd43c254c5f76",
+        "date": "13 Apr 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.17": {
+    "announcement": {
+      "English": "/releases/8_1_17.php"
+    },
+    "tags": [],
+    "date": "16 Mar 2023",
+    "source": [
+      {
+        "filename": "php-8.1.17.tar.gz",
+        "name": "PHP 8.1.17 (tar.gz)",
+        "sha256": "ef270156291d90a80ce83d68eee812f301cf5e48836a0ff6fd2931913f8e25c5",
+        "date": "16 Mar 2023"
+      },
+      {
+        "filename": "php-8.1.17.tar.bz2",
+        "name": "PHP 8.1.17 (tar.bz2)",
+        "sha256": "f4fb298a0eb091f944ecebac57b76daae768a970c2f51610a5ab24f34d8c0caf",
+        "date": "16 Mar 2023"
+      },
+      {
+        "filename": "php-8.1.17.tar.xz",
+        "name": "PHP 8.1.17 (tar.xz)",
+        "sha256": "b5c48f95b8e1d8624dd05fc2eab7be13277f9a203ccba97bdca5a1a0fb4a1460",
+        "date": "16 Mar 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.4": {
+    "announcement": {
+      "English": "/releases/8_2_4.php"
+    },
+    "tags": [],
+    "date": "16 Mar 2023",
+    "source": [
+      {
+        "filename": "php-8.2.4.tar.gz",
+        "name": "PHP 8.2.4 (tar.gz)",
+        "sha256": "cee7748015a2ddef1739d448b980b095dccd09ed589cf1b6c6ee2d16f5e73c50",
+        "date": "16 Mar 2023"
+      },
+      {
+        "filename": "php-8.2.4.tar.bz2",
+        "name": "PHP 8.2.4 (tar.bz2)",
+        "sha256": "79186f94bd510db86e31e535dd448277a1eb92a87878303a1ead44602d8b1197",
+        "date": "16 Mar 2023"
+      },
+      {
+        "filename": "php-8.2.4.tar.xz",
+        "name": "PHP 8.2.4 (tar.xz)",
+        "sha256": "bc7bf4ca7ed0dd17647e3ea870b6f062fcb56b243bfdef3f59ff7f94e96176a8",
+        "date": "16 Mar 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.3": {
+    "announcement": {
+      "English": "/releases/8_2_3.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 Feb 2023",
+    "source": [
+      {
+        "filename": "php-8.2.3.tar.gz",
+        "name": "PHP 8.2.3 (tar.gz)",
+        "sha256": "7c475bcbe61d28b6878604b1b6f387f39d1a63b5f21fa8156fd7aa615d43e259",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.2.3.tar.bz2",
+        "name": "PHP 8.2.3 (tar.bz2)",
+        "sha256": "87bb58865f38f5e2941813029152cea2102fe2961bb4d68b88f831ddd0548d0f",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.2.3.tar.xz",
+        "name": "PHP 8.2.3 (tar.xz)",
+        "sha256": "b9b566686e351125d67568a33291650eb8dfa26614d205d70d82e6e92613d457",
+        "date": "14 Feb 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.16": {
+    "announcement": {
+      "English": "/releases/8_1_16.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "14 Feb 2023",
+    "source": [
+      {
+        "filename": "php-8.1.16.tar.gz",
+        "name": "PHP 8.1.16 (tar.gz)",
+        "sha256": "a929fb9ed3bc364a5dea4f64954e8aaaa3408b87df04d7c6f743a190f5594e84",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.1.16.tar.bz2",
+        "name": "PHP 8.1.16 (tar.bz2)",
+        "sha256": "cd9f0ea14d82d9455587a49a0b6c802a7b8d8ff79703f9f48b17db010fb633ce",
+        "date": "14 Feb 2023"
+      },
+      {
+        "filename": "php-8.1.16.tar.xz",
+        "name": "PHP 8.1.16 (tar.xz)",
+        "sha256": "d61f13d96a58b93c39672b58f25e1ee4ce88500f4acb1430cb01a514875c1258",
+        "date": "14 Feb 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.15": {
+    "announcement": {
+      "English": "/releases/8_1_15.php"
+    },
+    "tags": [],
+    "date": "02 Feb 2023",
+    "source": [
+      {
+        "filename": "php-8.1.15.tar.gz",
+        "name": "PHP 8.1.15 (tar.gz)",
+        "sha256": "4035236180efac535ff4f22db9ef3195672f31e3e0aa88f89c38ac0715beca3b",
+        "date": "02 Feb 2023"
+      },
+      {
+        "filename": "php-8.1.15.tar.bz2",
+        "name": "PHP 8.1.15 (tar.bz2)",
+        "sha256": "18da0a94228f4207f8b9e3e23e881f2b74d0d6caefb908bdb5863d4a01035cc6",
+        "date": "02 Feb 2023"
+      },
+      {
+        "filename": "php-8.1.15.tar.xz",
+        "name": "PHP 8.1.15 (tar.xz)",
+        "sha256": "cd450fb4ee50488c5bf5f08851f514e5a1cac18c9512234d9e16c3a1d35781a6",
+        "date": "02 Feb 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.2": {
+    "announcement": {
+      "English": "/releases/8_2_2.php"
+    },
+    "tags": [],
+    "date": "02 Feb 2023",
+    "source": [
+      {
+        "filename": "php-8.2.2.tar.gz",
+        "name": "PHP 8.2.2 (tar.gz)",
+        "sha256": "d82dda50356cebf6b6e14dbb576b14bc8b85f0f4476a787f0f50611f11eb37d2",
+        "date": "02 Feb 2023"
+      },
+      {
+        "filename": "php-8.2.2.tar.bz2",
+        "name": "PHP 8.2.2 (tar.bz2)",
+        "sha256": "f5223a5274eda8b40c19e47de0de4678c65d64401ccf710e2464962eb8136804",
+        "date": "02 Feb 2023"
+      },
+      {
+        "filename": "php-8.2.2.tar.xz",
+        "name": "PHP 8.2.2 (tar.xz)",
+        "sha256": "bdc4aa38e652bac86039601840bae01c0c3653972eaa6f9f93d5f71953a7ee33",
+        "date": "02 Feb 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.27": {
+    "announcement": {
+      "English": "/releases/8_0_27.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "05 Jan 2023",
+    "source": [
+      {
+        "filename": "php-8.0.27.tar.gz",
+        "name": "PHP 8.0.27 (tar.gz)",
+        "sha256": "fe2376faaf91c28ead89a36e118c177f4a8c9a7280a189b97265da1af1f4d305",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.0.27.tar.bz2",
+        "name": "PHP 8.0.27 (tar.bz2)",
+        "sha256": "5fd882b14377c158c1b55cc6ace91fb8c19b77c596d5831ad124fbbbc902dbc8",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.0.27.tar.xz",
+        "name": "PHP 8.0.27 (tar.xz)",
+        "sha256": "f942cbfe2f7bacbb8039fb79bbec41c76ea779ac5c8157f21e1e0c1b28a5fc3a",
+        "date": "05 Jan 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.14": {
+    "announcement": {
+      "English": "/releases/8_1_14.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "05 Jan 2023",
+    "source": [
+      {
+        "filename": "php-8.1.14.tar.gz",
+        "name": "PHP 8.1.14 (tar.gz)",
+        "sha256": "4755af2563ad187ceaf4a3632359c55e3f3be4050e0299e0f713bbb5e0531965",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.1.14.tar.bz2",
+        "name": "PHP 8.1.14 (tar.bz2)",
+        "sha256": "14ca99333dd604a504a2368946485ac35d379c4da96d28dc515d7eb502dffa32",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.1.14.tar.xz",
+        "name": "PHP 8.1.14 (tar.xz)",
+        "sha256": "e16e47a872d58685913ac848ce92ec49f42c1828110c98c65fb6265a08724a1a",
+        "date": "05 Jan 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.1": {
+    "announcement": {
+      "English": "/releases/8_2_1.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "05 Jan 2023",
+    "source": [
+      {
+        "filename": "php-8.2.1.tar.gz",
+        "name": "PHP 8.2.1 (tar.gz)",
+        "sha256": "6d7b1b8feb14fd1c65a2bc9d0f72c75589a61a946566cf9c3bf9536a5530b635",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.2.1.tar.bz2",
+        "name": "PHP 8.2.1 (tar.bz2)",
+        "sha256": "75d6f8f365993ec0d1d9c6281d4557e6feec5a26194a468b8b01459d177efb29",
+        "date": "05 Jan 2023"
+      },
+      {
+        "filename": "php-8.2.1.tar.xz",
+        "name": "PHP 8.2.1 (tar.xz)",
+        "sha256": "650d3bd7a056cabf07f6a0f6f1dd8ba45cd369574bbeaa36de7d1ece212c17af",
+        "date": "05 Jan 2023"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.26": {
+    "announcement": {
+      "English": "/releases/8_0_26.php"
+    },
+    "tags": [],
+    "date": "24 Nov 2022",
+    "source": [
+      {
+        "filename": "php-8.0.26.tar.gz",
+        "name": "PHP 8.0.26 (tar.gz)",
+        "sha256": "3c83a7355a640b2ba436b8202e8597df8f9daadee1ec9241729ece8e578d21cd",
+        "date": "24 Nov 2022"
+      },
+      {
+        "filename": "php-8.0.26.tar.bz2",
+        "name": "PHP 8.0.26 (tar.bz2)",
+        "sha256": "6df87af96f275a75889ece6e3fe4a13abd93a767a9992863bdc0e90f1e887ee7",
+        "date": "24 Nov 2022"
+      },
+      {
+        "filename": "php-8.0.26.tar.xz",
+        "name": "PHP 8.0.26 (tar.xz)",
+        "sha256": "0765bfbe640dba37ccc36d2bc7c7b7ba3d2c3381c9cd4305f66eca83e82a40b3",
+        "date": "24 Nov 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.2.0": {
+    "announcement": {
+      "English": "/releases/8_2_0.php"
+    },
+    "tags": [],
+    "date": "08 Dec 2022",
+    "source": [
+      {
+        "filename": "php-8.2.0.tar.gz",
+        "name": "PHP 8.2.0 (tar.gz)",
+        "sha256": "435c4c2439db648cdf34236f7cd459f93f943fb788b66723a033610d4a059fc6",
+        "date": "08 Dec 2022"
+      },
+      {
+        "filename": "php-8.2.0.tar.bz2",
+        "name": "PHP 8.2.0 (tar.bz2)",
+        "sha256": "1bf4fca663f93d9e0b4909bd6eae0583a1ce383e7f05df126f28f272fa1fd51a",
+        "date": "08 Dec 2022"
+      },
+      {
+        "filename": "php-8.2.0.tar.xz",
+        "name": "PHP 8.2.0 (tar.xz)",
+        "sha256": "6ea4c2dfb532950fd712aa2a08c1412a6a81cd1334dd0b0bf88a8e44c2b3a943",
+        "date": "08 Dec 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.13": {
+    "announcement": {
+      "English": "/releases/8_1_13.php"
+    },
+    "tags": [],
+    "date": "24 Nov 2022",
+    "source": [
+      {
+        "filename": "php-8.1.13.tar.gz",
+        "name": "PHP 8.1.13 (tar.gz)",
+        "sha256": "eed1981ce9999d807cb139a9d463ae54bbeda2a57a9a28ad513badf5b99b0073",
+        "date": "24 Nov 2022"
+      },
+      {
+        "filename": "php-8.1.13.tar.bz2",
+        "name": "PHP 8.1.13 (tar.bz2)",
+        "sha256": "93fcfdfaaa3d094a0fdb18ce08d20f20d526ee3f07a146a8a8ec82ce00b237ca",
+        "date": "24 Nov 2022"
+      },
+      {
+        "filename": "php-8.1.13.tar.xz",
+        "name": "PHP 8.1.13 (tar.xz)",
+        "sha256": "b15ef0ccdd6760825604b3c4e3e73558dcf87c75ef1d68ef4289d8fd261ac856",
+        "date": "24 Nov 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.25": {
+    "announcement": {
+      "English": "/releases/8_0_25.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "27 Oct 2022",
+    "source": [
+      {
+        "filename": "php-8.0.25.tar.gz",
+        "name": "PHP 8.0.25 (tar.gz)",
+        "sha256": "349a2b5a01bfccbc9af8afdf183e57bed3349706a084f3c4694aa4c7ff7cb2e9",
+        "date": "27 Oct 2022"
+      },
+      {
+        "filename": "php-8.0.25.tar.bz2",
+        "name": "PHP 8.0.25 (tar.bz2)",
+        "sha256": "09d716bceb5b3db76d9023b10c1681ebbe040e51f4c18dfd35f9ff8b73bbcf8c",
+        "date": "27 Oct 2022"
+      },
+      {
+        "filename": "php-8.0.25.tar.xz",
+        "name": "PHP 8.0.25 (tar.xz)",
+        "sha256": "a291b71d0498707fc5514eb5b9513e88f0f1d4890bcdefd67282ded8a2bfb941",
+        "date": "27 Oct 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.12": {
+    "announcement": {
+      "English": "/releases/8_1_12.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "27 Oct 2022",
+    "source": [
+      {
+        "filename": "php-8.1.12.tar.gz",
+        "name": "PHP 8.1.12 (tar.gz)",
+        "sha256": "e0e7c823c9f9aa4c021f5e34ae1a7acafc2a9f3056ca60eb70a8af8f33da3fdf",
+        "date": "27 Oct 2022"
+      },
+      {
+        "filename": "php-8.1.12.tar.bz2",
+        "name": "PHP 8.1.12 (tar.bz2)",
+        "sha256": "f87d73e917facf78de7bcde53fc2faa4d4dbe0487a9406e1ab68c8ae8f33eb03",
+        "date": "27 Oct 2022"
+      },
+      {
+        "filename": "php-8.1.12.tar.xz",
+        "name": "PHP 8.1.12 (tar.xz)",
+        "sha256": "08243359e2204d842082269eedc15f08d2eca726d0e65b93fb11f4bfc51bbbab",
+        "date": "27 Oct 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.11": {
+    "announcement": {
+      "English": "/releases/8_1_11.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Sep 2022",
+    "source": [
+      {
+        "filename": "php-8.1.11.tar.gz",
+        "name": "PHP 8.1.11 (tar.gz)",
+        "sha256": "3660e8408321149f5d382bb8eeb9ea7b12ea8dd7ea66069da33f6f7383750ab2",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-8.1.11.tar.bz2",
+        "name": "PHP 8.1.11 (tar.bz2)",
+        "sha256": "af6250b18b4403b6eeff9b4a02786ac86a12a208141f6f65478f79256f47f246",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-8.1.11.tar.xz",
+        "name": "PHP 8.1.11 (tar.xz)",
+        "sha256": "3005198d7303f87ab31bc30695de76e8ad62783f806b6ab9744da59fe41cc5bd",
+        "date": "29 Sep 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.24": {
+    "announcement": {
+      "English": "/releases/8_0_24.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "29 Sep 2022",
+    "source": [
+      {
+        "filename": "php-8.0.24.tar.gz",
+        "name": "PHP 8.0.24 (tar.gz)",
+        "sha256": "6020843a2f1ce36745d958b3ca17f3fdc42e78a43899f552ab5dbc509ff19232",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-8.0.24.tar.bz2",
+        "name": "PHP 8.0.24 (tar.bz2)",
+        "sha256": "908e17cea331d5abb8506b4a89c6392b962e127c391327777c7485eb4b415d43",
+        "date": "29 Sep 2022"
+      },
+      {
+        "filename": "php-8.0.24.tar.xz",
+        "name": "PHP 8.0.24 (tar.xz)",
+        "sha256": "8e6a63ac9cdabe4c345b32a54b18f348d9e50a1decda217faf2d61278d22f08b",
+        "date": "29 Sep 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.23": {
+    "announcement": {
+      "English": "/releases/8_0_23.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "01 Sep 2022",
+    "source": [
+      {
+        "filename": "php-8.0.23.tar.gz",
+        "name": "PHP 8.0.23 (tar.gz)",
+        "sha256": "a2dd50e9c4a0328d921b6bc914e8b4e6572f94f09867318f88acca5ac4fa76c7",
+        "date": "01 Sep 2022"
+      },
+      {
+        "filename": "php-8.0.23.tar.bz2",
+        "name": "PHP 8.0.23 (tar.bz2)",
+        "sha256": "1412db46800a45ced377c2892ec6261b3c412f13dc133bfc998cfb2f147b40cf",
+        "date": "01 Sep 2022"
+      },
+      {
+        "filename": "php-8.0.23.tar.xz",
+        "name": "PHP 8.0.23 (tar.xz)",
+        "sha256": "65e474b6bd8cfc9d4a8a56268a755e2f9d3e7499e1687e6401a9f2b047600f87",
+        "date": "01 Sep 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.10": {
+    "announcement": {
+      "English": "/releases/8_1_10.php"
+    },
+    "tags": [],
+    "date": "01 Sep 2022",
+    "source": [
+      {
+        "filename": "php-8.1.10.tar.gz",
+        "name": "PHP 8.1.10 (tar.gz)",
+        "sha256": "3ea4f323109dfbc8d2631d08aa0e08602c1f713678e9dc6c750f081ef49eab0f",
+        "date": "01 Sep 2022"
+      },
+      {
+        "filename": "php-8.1.10.tar.bz2",
+        "name": "PHP 8.1.10 (tar.bz2)",
+        "sha256": "2de8e0402285f7c56887defe651922308aded58ba60befcf3b77720209e31f10",
+        "date": "01 Sep 2022"
+      },
+      {
+        "filename": "php-8.1.10.tar.xz",
+        "name": "PHP 8.1.10 (tar.xz)",
+        "sha256": "90e7120c77ee83630e6ac928d23bc6396603d62d83a3cf5df8a450d2e3070162",
+        "date": "01 Sep 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.22": {
+    "announcement": {
+      "English": "/releases/8_0_22.php"
+    },
+    "tags": [],
+    "date": "04 Aug 2022",
+    "source": [
+      {
+        "filename": "php-8.0.22.tar.gz",
+        "name": "PHP 8.0.22 (tar.gz)",
+        "sha256": "56fce7529a9798fd0895bca3539d2a65b9cac5d23ffbdf6338419c62ed083519",
+        "date": "04 Aug 2022"
+      },
+      {
+        "filename": "php-8.0.22.tar.bz2",
+        "name": "PHP 8.0.22 (tar.bz2)",
+        "sha256": "e342918d3ecd422f10032df0ac3ffb0e17f568fad6cf8e232b6f7a6a1fdc3c9c",
+        "date": "04 Aug 2022"
+      },
+      {
+        "filename": "php-8.0.22.tar.xz",
+        "name": "PHP 8.0.22 (tar.xz)",
+        "sha256": "130937c0fa3050cd33d6c415402f6ccbf0682ae83eb8d39c91164224ddfe57f1",
+        "date": "04 Aug 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.9": {
+    "announcement": {
+      "English": "/releases/8_1_9.php"
+    },
+    "tags": [],
+    "date": "04 Aug 2022",
+    "source": [
+      {
+        "filename": "php-8.1.9.tar.gz",
+        "name": "PHP 8.1.9 (tar.gz)",
+        "sha256": "954cf77f7e0a70dc765e7639acdfdccd164be5cd1bce3dbe9d10c58dca631e76",
+        "date": "04 Aug 2022"
+      },
+      {
+        "filename": "php-8.1.9.tar.bz2",
+        "name": "PHP 8.1.9 (tar.bz2)",
+        "sha256": "9ebb0e2e571db6fd5930428dcb2d19ed3e050338ec1f1347c282cae92fc086ff",
+        "date": "04 Aug 2022"
+      },
+      {
+        "filename": "php-8.1.9.tar.xz",
+        "name": "PHP 8.1.9 (tar.xz)",
+        "sha256": "53477e73e6254dc942b68913a58d815ffdbf6946baf61a1f8ef854de524c27bf",
+        "date": "04 Aug 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.8": {
+    "announcement": {
+      "English": "/releases/8_1_8.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "07 Jul 2022",
+    "source": [
+      {
+        "filename": "php-8.1.8.tar.gz",
+        "name": "PHP 8.1.8 (tar.gz)",
+        "sha256": "889d910558d2492f7f2236921b9bcde620674c8b684ec02d126060f8ca45dc8d",
+        "date": "07 Jul 2022"
+      },
+      {
+        "filename": "php-8.1.8.tar.bz2",
+        "name": "PHP 8.1.8 (tar.bz2)",
+        "sha256": "b8815a5a02431453d4261e3598bd1f28516e4c0354f328c12890f257870e4c01",
+        "date": "07 Jul 2022"
+      },
+      {
+        "filename": "php-8.1.8.tar.xz",
+        "name": "PHP 8.1.8 (tar.xz)",
+        "sha256": "04c065515bc347bc68e0bb1ac7182669a98a731e4a17727e5731650ad3d8de4c",
+        "date": "07 Jul 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.21": {
+    "announcement": {
+      "English": "/releases/8_0_21.php"
+    },
+    "tags": [],
+    "date": "07 Jul 2022",
+    "source": [
+      {
+        "filename": "php-8.0.21.tar.gz",
+        "name": "PHP 8.0.21 (tar.gz)",
+        "sha256": "2f51f6e90e2e8efd3a20db08f0dd61d7f8d5a9362f8c7325f1ad28ccea5be0ac",
+        "date": "07 Jul 2022"
+      },
+      {
+        "filename": "php-8.0.21.tar.bz2",
+        "name": "PHP 8.0.21 (tar.bz2)",
+        "sha256": "1cb7762d1ffecceaeebafb9f6e24132ca23fb1443cb5630d0fccf53f04cfa126",
+        "date": "07 Jul 2022"
+      },
+      {
+        "filename": "php-8.0.21.tar.xz",
+        "name": "PHP 8.0.21 (tar.xz)",
+        "sha256": "e87a598f157e0cf0606e64382bb91c8b30c47d4a0fc96b2c17ad547a27869b3b",
+        "date": "07 Jul 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.7": {
+    "announcement": {
+      "English": "/releases/8_1_7.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jun 2022",
+    "source": [
+      {
+        "filename": "php-8.1.7.tar.gz",
+        "name": "PHP 8.1.7 (tar.gz)",
+        "sha256": "5f0b422a117633c86d48d028934b8dc078309d4247e7565ea34b2686189abdd8",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-8.1.7.tar.bz2",
+        "name": "PHP 8.1.7 (tar.bz2)",
+        "sha256": "b816753eb005511e695d90945c27093c3236cc73db1262656d9fadd73ead7e9d",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-8.1.7.tar.xz",
+        "name": "PHP 8.1.7 (tar.xz)",
+        "sha256": "f042322f1b5a9f7c2decb84b7086ef676896c2f7178739b9672afafa964ed0e5",
+        "date": "09 Jun 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.20": {
+    "announcement": {
+      "English": "/releases/8_0_20.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "09 Jun 2022",
+    "source": [
+      {
+        "filename": "php-8.0.20.tar.gz",
+        "name": "PHP 8.0.20 (tar.gz)",
+        "sha256": "7e21fd985966264194cde63503b57fd0f0170b32a39bd7af2384c1071b50f164",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-8.0.20.tar.bz2",
+        "name": "PHP 8.0.20 (tar.bz2)",
+        "sha256": "cb7666bf67ed9f6c987d4836caf03d4b364537e6a75e56cd5c986760ecc2fdd8",
+        "date": "09 Jun 2022"
+      },
+      {
+        "filename": "php-8.0.20.tar.xz",
+        "name": "PHP 8.0.20 (tar.xz)",
+        "sha256": "973fec765336ee01f47536a5db1c2eee98df9d34a41522b7b6c760159bf0a77b",
+        "date": "09 Jun 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.19": {
+    "announcement": {
+      "English": "/releases/8_0_19.php"
+    },
+    "tags": [],
+    "date": "12 May 2022",
+    "source": [
+      {
+        "filename": "php-8.0.19.tar.gz",
+        "name": "PHP 8.0.19 (tar.gz)",
+        "sha256": "48e57634d350bcab4745d25d9d94ffa474649bf4f7e879fad163226c0d107bb5",
+        "date": "12 May 2022"
+      },
+      {
+        "filename": "php-8.0.19.tar.bz2",
+        "name": "PHP 8.0.19 (tar.bz2)",
+        "sha256": "eba0e67fdaf6904b2e4b84e064be0a0d61b2cb64a23f81a0ca9b1a51bc3a8330",
+        "date": "12 May 2022"
+      },
+      {
+        "filename": "php-8.0.19.tar.xz",
+        "name": "PHP 8.0.19 (tar.xz)",
+        "sha256": "ba62219c4b0486cbb2a04f0796749a46b0ee1f5a142ed454212b4e2460cb0fab",
+        "date": "12 May 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.6": {
+    "announcement": {
+      "English": "/releases/8_1_6.php"
+    },
+    "tags": [],
+    "date": "12 May 2022",
+    "source": [
+      {
+        "filename": "php-8.1.6.tar.gz",
+        "name": "PHP 8.1.6 (tar.gz)",
+        "sha256": "e847745fd66fc8c57fac993a609fefcded93fddccd225f0620a26bb5ae5753c3",
+        "date": "12 May 2022"
+      },
+      {
+        "filename": "php-8.1.6.tar.bz2",
+        "name": "PHP 8.1.6 (tar.bz2)",
+        "sha256": "7b353304b7407554f70d3e101a226a1fc22decae5c4c42ed270c4e389bfa1b66",
+        "date": "12 May 2022"
+      },
+      {
+        "filename": "php-8.1.6.tar.xz",
+        "name": "PHP 8.1.6 (tar.xz)",
+        "sha256": "da38d65bb0d5dd56f711cd478204f2b62a74a2c2b0d2d523a78d6eb865b2364c",
+        "date": "12 May 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.5": {
+    "announcement": {
+      "English": "/releases/8_1_5.php"
+    },
+    "tags": [],
+    "date": "14 Apr 2022",
+    "source": [
+      {
+        "filename": "php-8.1.5.tar.gz",
+        "name": "PHP 8.1.5 (tar.gz)",
+        "sha256": "44d637627746082395d5d3d3d6ae7d71e780b82a8d55a0228887158c4316bf11",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-8.1.5.tar.bz2",
+        "name": "PHP 8.1.5 (tar.bz2)",
+        "sha256": "827de56771c3ab8313a069812f15f6ec49989d510aebd0dce180839c6d8d6ff3",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-8.1.5.tar.xz",
+        "name": "PHP 8.1.5 (tar.xz)",
+        "sha256": "7647734b4dcecd56b7e4bd0bc55e54322fa3518299abcdc68eb557a7464a2e8a",
+        "date": "14 Apr 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.18": {
+    "announcement": {
+      "English": "/releases/8_0_18.php"
+    },
+    "tags": [],
+    "date": "14 Apr 2022",
+    "source": [
+      {
+        "filename": "php-8.0.18.tar.gz",
+        "name": "PHP 8.0.18 (tar.gz)",
+        "sha256": "cd980f5a2f422362f8c52d314ed25140c6f472877c5442c4f3304205f54e192a",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-8.0.18.tar.bz2",
+        "name": "PHP 8.0.18 (tar.bz2)",
+        "sha256": "826ee34881a1c349678d4f7cc55ff9141fa1411344e4bb8f95d0f9223bceb55a",
+        "date": "14 Apr 2022"
+      },
+      {
+        "filename": "php-8.0.18.tar.xz",
+        "name": "PHP 8.0.18 (tar.xz)",
+        "sha256": "db161652cacae4b31c347fbf2e17b80656473cb365f2bb3460c4552f5647e2e7",
+        "date": "14 Apr 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.17": {
+    "announcement": {
+      "English": "/releases/8_0_17.php"
+    },
+    "tags": [],
+    "date": "17 Mar 2022",
+    "source": [
+      {
+        "filename": "php-8.0.17.tar.gz",
+        "name": "PHP 8.0.17 (tar.gz)",
+        "sha256": "bdbd792901c156c4d1710c9d266732d3c17f6ff63850d6660b9d8d3411188424",
+        "date": "17 Mar 2022"
+      },
+      {
+        "filename": "php-8.0.17.tar.bz2",
+        "name": "PHP 8.0.17 (tar.bz2)",
+        "sha256": "52811ee2dde71660ca32737a4ac696c24591eb22e846dd8e09ee77122660283f",
+        "date": "17 Mar 2022"
+      },
+      {
+        "filename": "php-8.0.17.tar.xz",
+        "name": "PHP 8.0.17 (tar.xz)",
+        "sha256": "4e7d94bb3d144412cb8b2adeb599fb1c6c1d7b357b0d0d0478dc5ef53532ebc5",
+        "date": "17 Mar 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.4": {
+    "announcement": {
+      "English": "/releases/8_1_4.php"
+    },
+    "tags": [],
+    "date": "17 Mar 2022",
+    "source": [
+      {
+        "filename": "php-8.1.4.tar.gz",
+        "name": "PHP 8.1.4 (tar.gz)",
+        "sha256": "a9951c1c8fd5d2eefde28de0f646c344eb61d751319d220713a6da26f986abde",
+        "date": "17 Mar 2022"
+      },
+      {
+        "filename": "php-8.1.4.tar.bz2",
+        "name": "PHP 8.1.4 (tar.bz2)",
+        "sha256": "b3f688cb69758523838b8e7f509aaef0152133d9b84a84a0b7cf68eeafc1df76",
+        "date": "17 Mar 2022"
+      },
+      {
+        "filename": "php-8.1.4.tar.xz",
+        "name": "PHP 8.1.4 (tar.xz)",
+        "sha256": "05a8c0ac30008154fb38a305560543fc172ba79fb957084a99b8d3b10d5bdb4b",
+        "date": "17 Mar 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.3": {
+    "announcement": {
+      "English": "/releases/8_1_3.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "17 Feb 2022",
+    "source": [
+      {
+        "filename": "php-8.1.3.tar.gz",
+        "name": "PHP 8.1.3 (tar.gz)",
+        "sha256": "92d74f5a4af7de90cef6cda65bd0c341dc9a1027b32f70e7b8861f6f68a38bb2",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-8.1.3.tar.bz2",
+        "name": "PHP 8.1.3 (tar.bz2)",
+        "sha256": "354c4e2c506046eca812d1fc2526884a2f54b5e3d20ef0ede919a69eb232d0be",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-8.1.3.tar.xz",
+        "name": "PHP 8.1.3 (tar.xz)",
+        "sha256": "5d65a11071b47669c17452fb336c290b67c101efb745c1dbe7525b5caf546ec6",
+        "date": "17 Feb 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.16": {
+    "announcement": {
+      "English": "/releases/8_0_16.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "17 Feb 2022",
+    "source": [
+      {
+        "filename": "php-8.0.16.tar.gz",
+        "name": "PHP 8.0.16 (tar.gz)",
+        "sha256": "ce0ea32ff9c5af18cfb70197b40caf55824400dc8d5b4258a783ec9168baa5b1",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-8.0.16.tar.bz2",
+        "name": "PHP 8.0.16 (tar.bz2)",
+        "sha256": "f49f8181ee29463a0d23a0c65969e92d58fee8ac564df917cff58e48d65e1849",
+        "date": "17 Feb 2022"
+      },
+      {
+        "filename": "php-8.0.16.tar.xz",
+        "name": "PHP 8.0.16 (tar.xz)",
+        "sha256": "f27a2f25259e8c51e42dfd74e24a546ee521438ad7d9f6c6e794aa91f38bab0a",
+        "date": "17 Feb 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.2": {
+    "announcement": {
+      "English": "/releases/8_1_2.php"
+    },
+    "tags": [],
+    "date": "20 Jan 2022",
+    "source": [
+      {
+        "filename": "php-8.1.2.tar.gz",
+        "name": "PHP 8.1.2 (tar.gz)",
+        "sha256": "9992409c0543e0c8e89914f7307e1485a08c057091146e4731565b59065f8bde",
+        "date": "20 Jan 2022"
+      },
+      {
+        "filename": "php-8.1.2.tar.bz2",
+        "name": "PHP 8.1.2 (tar.bz2)",
+        "sha256": "913dc7dd4388427fa33ea4ac89834e856ff5394f4218eace260a3a279f5b53a9",
+        "date": "20 Jan 2022"
+      },
+      {
+        "filename": "php-8.1.2.tar.xz",
+        "name": "PHP 8.1.2 (tar.xz)",
+        "sha256": "6b448242fd360c1a9f265b7263abf3da25d28f2b2b0f5465533b69be51a391dd",
+        "date": "20 Jan 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.15": {
+    "announcement": {
+      "English": "/releases/8_0_15.php"
+    },
+    "tags": [],
+    "date": "20 Jan 2022",
+    "source": [
+      {
+        "filename": "php-8.0.15.tar.gz",
+        "name": "PHP 8.0.15 (tar.gz)",
+        "sha256": "47f0be6188b05390bb457eb1968ea19463acada79650afc35ec763348d5c2370",
+        "date": "20 Jan 2022"
+      },
+      {
+        "filename": "php-8.0.15.tar.bz2",
+        "name": "PHP 8.0.15 (tar.bz2)",
+        "sha256": "881171c90aba746d28df768f3d99fa3261999e506415be4c7352078a64fe59dc",
+        "date": "20 Jan 2022"
+      },
+      {
+        "filename": "php-8.0.15.tar.xz",
+        "name": "PHP 8.0.15 (tar.xz)",
+        "sha256": "5f33544061d37d805a2a9ce791f081ef08a7155bd7ba2362e69bba2d06b0f8b2",
+        "date": "20 Jan 2022"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.1": {
+    "announcement": {
+      "English": "/releases/8_1_1.php"
+    },
+    "tags": [],
+    "date": "16 Dec 2021",
+    "source": [
+      {
+        "filename": "php-8.1.1.tar.gz",
+        "name": "PHP 8.1.1 (tar.gz)",
+        "sha256": "4e4cf3f843a5111f6c55cd21de8f26834ea3cd4a5be77c88357cbcec4a2d671d",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-8.1.1.tar.bz2",
+        "name": "PHP 8.1.1 (tar.bz2)",
+        "sha256": "8f8bc9cad6cd124edc111f7db0a109745e2f638770a101b3c22a2953f7a9b40e",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-8.1.1.tar.xz",
+        "name": "PHP 8.1.1 (tar.xz)",
+        "sha256": "33c09d76d0a8bbb5dd930d9dd32e6bfd44e9efcf867563759eb5492c3aff8856",
+        "date": "16 Dec 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.14": {
+    "announcement": {
+      "English": "/releases/8_0_14.php"
+    },
+    "tags": [],
+    "date": "16 Dec 2021",
+    "source": [
+      {
+        "filename": "php-8.0.14.tar.gz",
+        "name": "PHP 8.0.14 (tar.gz)",
+        "sha256": "e67ebd8c4c77247ad1fa88829e5b95d51a19edf3d87814434de261e20a63ea20",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-8.0.14.tar.bz2",
+        "name": "PHP 8.0.14 (tar.bz2)",
+        "sha256": "bb381fdf4817ad7c24c23ea7f77cad68dceb86eb3ac1a37acedadf8ad0a0cd4b",
+        "date": "16 Dec 2021"
+      },
+      {
+        "filename": "php-8.0.14.tar.xz",
+        "name": "PHP 8.0.14 (tar.xz)",
+        "sha256": "fbde8247ac200e4de73449d9fefc8b495d323b5be9c10cdb645fb431c91156e3",
+        "date": "16 Dec 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.1.0": {
+    "announcement": {
+      "English": "/releases/8_1_0.php"
+    },
+    "tags": [],
+    "date": "25 Nov 2021",
+    "source": [
+      {
+        "filename": "php-8.1.0.tar.gz",
+        "name": "PHP 8.1.0 (tar.gz)",
+        "sha256": "848705043ea4a6e022246ae12a1bff6afcf5c73ea98c6ac4d2108d6028c5c125",
+        "date": "25 Nov 2021"
+      },
+      {
+        "filename": "php-8.1.0.tar.bz2",
+        "name": "PHP 8.1.0 (tar.bz2)",
+        "sha256": "0725ed2baea125496a898455d501a77460218b2a0cfad773fa9322f491b82b61",
+        "date": "25 Nov 2021"
+      },
+      {
+        "filename": "php-8.1.0.tar.xz",
+        "name": "PHP 8.1.0 (tar.xz)",
+        "sha256": "a1317eff0723a2b3d3122bbfe107a1158570ea2822dc35a5fb360086db0f6bbc",
+        "date": "25 Nov 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.13": {
+    "announcement": {
+      "English": "/releases/8_0_13.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "18 Nov 2021",
+    "source": [
+      {
+        "filename": "php-8.0.13.tar.gz",
+        "name": "PHP 8.0.13 (tar.gz)",
+        "sha256": "b4c2d27c954e1b0d84fd4bfef4d252e154ba479e7db11abd89358f2164ee7cc8",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-8.0.13.tar.bz2",
+        "name": "PHP 8.0.13 (tar.bz2)",
+        "sha256": "c2419d7ba4395f44747043f4e6f5b47fa08125705fb9f88377e453068a815836",
+        "date": "18 Nov 2021"
+      },
+      {
+        "filename": "php-8.0.13.tar.xz",
+        "name": "PHP 8.0.13 (tar.xz)",
+        "sha256": "cd976805ec2e9198417651027dfe16854ba2c2c388151ab9d4d268513d52ed52",
+        "date": "18 Nov 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.12": {
+    "announcement": {
+      "English": "/releases/8_0_12.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "21 Oct 2021",
+    "source": [
+      {
+        "filename": "php-8.0.12.tar.gz",
+        "name": "PHP 8.0.12 (tar.gz)",
+        "sha256": "a5b78f04a89d3b401465febf449c7ea9de48681f92803dd8dc2bf922812d572b",
+        "date": "21 Oct 2021"
+      },
+      {
+        "filename": "php-8.0.12.tar.bz2",
+        "name": "PHP 8.0.12 (tar.bz2)",
+        "sha256": "b4886db1df322dc8fb128d8b34ae7e94f6fc682ecb29ff4f5a591d4de9feadbf",
+        "date": "21 Oct 2021"
+      },
+      {
+        "filename": "php-8.0.12.tar.xz",
+        "name": "PHP 8.0.12 (tar.xz)",
+        "sha256": "a501017b3b0fd3023223ea25d98e87369b782f8a82310c4033d7ea6a989fea0a",
+        "date": "21 Oct 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.11": {
+    "announcement": {
+      "English": "/releases/8_0_11.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "23 Sep 2021",
+    "source": [
+      {
+        "filename": "php-8.0.11.tar.gz",
+        "name": "PHP 8.0.11 (tar.gz)",
+        "sha256": "c6a461f57b4bcb46cd4dec443253b1e2e8e981466f1280093322b7864afe8be7",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-8.0.11.tar.bz2",
+        "name": "PHP 8.0.11 (tar.bz2)",
+        "sha256": "70ed874285e4010c1e2e8937bfb56b13b9ed1b3789dcaf274b793b00c1f4403a",
+        "date": "23 Sep 2021"
+      },
+      {
+        "filename": "php-8.0.11.tar.xz",
+        "name": "PHP 8.0.11 (tar.xz)",
+        "sha256": "e3e5f764ae57b31eb65244a45512f0b22d7bef05f2052b23989c053901552e16",
+        "date": "23 Sep 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.10": {
+    "announcement": {
+      "English": "/releases/8_0_10.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "26 Aug 2021",
+    "source": [
+      {
+        "filename": "php-8.0.10.tar.gz",
+        "name": "PHP 8.0.10 (tar.gz)",
+        "sha256": "4612dca9afe8148801648839175ab588097ace66658c6859e9f283ecdeaf84b3",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-8.0.10.tar.bz2",
+        "name": "PHP 8.0.10 (tar.bz2)",
+        "sha256": "c94547271410900845b084ec2bcb3466af363eeca92cb24bd611dcbdc26f1587",
+        "date": "26 Aug 2021"
+      },
+      {
+        "filename": "php-8.0.10.tar.xz",
+        "name": "PHP 8.0.10 (tar.xz)",
+        "sha256": "66dc4d1bc86d9c1bc255b51b79d337ed1a7a035cf71230daabbf9a4ca35795eb",
+        "date": "26 Aug 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.9": {
+    "announcement": {
+      "English": "/releases/8_0_9.php"
+    },
+    "tags": [],
+    "date": "29 Jul 2021",
+    "source": [
+      {
+        "filename": "php-8.0.9.tar.gz",
+        "name": "PHP 8.0.9 (tar.gz)",
+        "sha256": "1f0d72e90ab6ad0ae13329a96b281f71bc592563ce4e3a4c816b8da4b5854fb4",
+        "date": "29 Jul 2021"
+      },
+      {
+        "filename": "php-8.0.9.tar.bz2",
+        "name": "PHP 8.0.9 (tar.bz2)",
+        "sha256": "6ac8edebd295ddc43fb010653c43ccf203cd7cdc40981b210ed5275994040806",
+        "date": "29 Jul 2021"
+      },
+      {
+        "filename": "php-8.0.9.tar.xz",
+        "name": "PHP 8.0.9 (tar.xz)",
+        "sha256": "71a01b2b56544e20e28696ad5b366e431a0984eaa39aa5e35426a4843e172010",
+        "date": "29 Jul 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.8": {
+    "announcement": {
+      "English": "/releases/8_0_8.php"
+    },
+    "tags": [],
+    "date": "01 Jul 2021",
+    "source": [
+      {
+        "filename": "php-8.0.8.tar.gz",
+        "name": "PHP 8.0.8 (tar.gz)",
+        "sha256": "084a1e8020e86fb99b663d195fd9ac98a9f37dfcb9ecb5c159054cdb8f388945",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-8.0.8.tar.bz2",
+        "name": "PHP 8.0.8 (tar.bz2)",
+        "sha256": "14bd77d71a98943e14b324da83e31b572781df583cda9650a184fae3214cd16f",
+        "date": "01 Jul 2021"
+      },
+      {
+        "filename": "php-8.0.8.tar.xz",
+        "name": "PHP 8.0.8 (tar.xz)",
+        "sha256": "dc1668d324232dec1d05175ec752dade92d29bb3004275118bc3f7fc7cbfbb1c",
+        "date": "01 Jul 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.7": {
+    "announcement": {
+      "English": "/releases/8_0_7.php"
+    },
+    "tags": [],
+    "date": "03 Jun 2021",
+    "source": [
+      {
+        "filename": "php-8.0.7.tar.gz",
+        "name": "PHP 8.0.7 (tar.gz)",
+        "sha256": "1e7462455bec8062ef3fc7c74f1f496417cb80aa374ce11edb35015de248c3c1",
+        "date": "03 Jun 2021"
+      },
+      {
+        "filename": "php-8.0.7.tar.bz2",
+        "name": "PHP 8.0.7 (tar.bz2)",
+        "sha256": "72b2f2c96f35748b1d6e8a71af4ead439b17129aefe611eb0baf1bd313635f79",
+        "date": "03 Jun 2021"
+      },
+      {
+        "filename": "php-8.0.7.tar.xz",
+        "name": "PHP 8.0.7 (tar.xz)",
+        "sha256": "d5fc2e4fc780a32404d88c360e3e0009bc725d936459668e9c2ac992f2d83654",
+        "date": "03 Jun 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.6": {
+    "announcement": {
+      "English": "/releases/8_0_6.php"
+    },
+    "tags": [],
+    "date": "06 May 2021",
+    "source": [
+      {
+        "filename": "php-8.0.6.tar.gz",
+        "name": "PHP 8.0.6 (tar.gz)",
+        "sha256": "51a3dcea6deb8ab82ad035d15baa7f5398980f576ac1968313ef149f7cf20100",
+        "date": "06 May 2021"
+      },
+      {
+        "filename": "php-8.0.6.tar.bz2",
+        "name": "PHP 8.0.6 (tar.bz2)",
+        "sha256": "26a8a9dad66012039deb0bcf151c6e22ab1e4b6a91508383ff705da41289526e",
+        "date": "06 May 2021"
+      },
+      {
+        "filename": "php-8.0.6.tar.xz",
+        "name": "PHP 8.0.6 (tar.xz)",
+        "sha256": "e9871d3b6c391fe9e89f86f6334852dcc10eeaaa8d5565beb8436e7f0cf30e20",
+        "date": "06 May 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.5": {
+    "announcement": {
+      "English": "/releases/8_0_5.php"
+    },
+    "tags": [],
+    "date": "29 Apr 2021",
+    "source": [
+      {
+        "filename": "php-8.0.5.tar.gz",
+        "name": "PHP 8.0.5 (tar.gz)",
+        "sha256": "50aeac6fe9c2b5577d534369392ebb89c3e7a342b20ef538832b1df996cccb2a",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-8.0.5.tar.bz2",
+        "name": "PHP 8.0.5 (tar.bz2)",
+        "sha256": "195d934febefaac3b19ac586679149759324a434411ae8aca6f7d87553ef08e0",
+        "date": "29 Apr 2021"
+      },
+      {
+        "filename": "php-8.0.5.tar.xz",
+        "name": "PHP 8.0.5 (tar.xz)",
+        "sha256": "5dd358b35ecd5890a4f09fb68035a72fe6b45d3ead6999ea95981a107fd1f2ab",
+        "date": "29 Apr 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.3": {
+    "announcement": {
+      "English": "/releases/8_0_3.php"
+    },
+    "tags": [],
+    "date": "4 Mar 2021",
+    "source": [
+      {
+        "filename": "php-8.0.3.tar.gz",
+        "name": "PHP 8.0.3 (tar.gz)",
+        "sha256": "e7ecfee901e0843377b64b2d8124132eae75bdb71a2675ba7c5c038d6592383d",
+        "date": "4 Mar 2021"
+      },
+      {
+        "filename": "php-8.0.3.tar.bz2",
+        "name": "PHP 8.0.3 (tar.bz2)",
+        "sha256": "95f8621d9e34f822d2583564c358598dff7346241f839bfa319bbf65bf2eb012",
+        "date": "4 Mar 2021"
+      },
+      {
+        "filename": "php-8.0.3.tar.xz",
+        "name": "PHP 8.0.3 (tar.xz)",
+        "sha256": "c9816aa9745a9695672951eaff3a35ca5eddcb9cacf87a4f04b9fb1169010251",
+        "date": "4 Mar 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.2": {
+    "announcement": {
+      "English": "/releases/8_0_2.php"
+    },
+    "tags": [],
+    "date": "04 Feb 2021",
+    "source": [
+      {
+        "filename": "php-8.0.2.tar.gz",
+        "name": "PHP 8.0.2 (tar.gz)",
+        "sha256": "cc17a32f76beb5f405da39a548218b3b6736710884fcd761838098553df149da",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-8.0.2.tar.bz2",
+        "name": "PHP 8.0.2 (tar.bz2)",
+        "sha256": "000fa89e3eae317c0b17ee048229cd68a38a3b0fef72c558681fd004057ba3e6",
+        "date": "04 Feb 2021"
+      },
+      {
+        "filename": "php-8.0.2.tar.xz",
+        "name": "PHP 8.0.2 (tar.xz)",
+        "sha256": "84dd6e36f48c3a71ff5dceba375c1f6b34b71d4fa9e06b720780127176468ccc",
+        "date": "04 Feb 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.1": {
+    "announcement": {
+      "English": "/releases/8_0_1.php"
+    },
+    "tags": [],
+    "date": "07 Jan 2021",
+    "source": [
+      {
+        "filename": "php-8.0.1.tar.gz",
+        "name": "PHP 8.0.1 (tar.gz)",
+        "sha256": "f1fee0429aa2cce6bc5df5d7e65386e266b0aab8a5fad7882d10eb833d2f5376",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-8.0.1.tar.bz2",
+        "name": "PHP 8.0.1 (tar.bz2)",
+        "sha256": "c44e76af40d133de64564f9caf5daec52bbe84c1ccb4e4500a62233d614ebdee",
+        "date": "07 Jan 2021"
+      },
+      {
+        "filename": "php-8.0.1.tar.xz",
+        "name": "PHP 8.0.1 (tar.xz)",
+        "sha256": "208b3330af881b44a6a8c6858d569c72db78dab97810332978cc65206b0ec2dc",
+        "date": "07 Jan 2021"
+      }
+    ],
+    "museum": false
+  },
+  "8.0.0": {
+    "announcement": {
+      "English": "/releases/8_0_0.php"
+    },
+    "tags": [],
+    "date": "26 Nov 2020",
+    "source": [
+      {
+        "filename": "php-8.0.0.tar.gz",
+        "name": "PHP 8.0.0 (tar.gz)",
+        "sha256": "3ed7b48d64357d3e8fa9e828dbe7416228f84105b8290c2f9779cd66be31ea71",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-8.0.0.tar.bz2",
+        "name": "PHP 8.0.0 (tar.bz2)",
+        "sha256": "5e832dc37eabf444410b4ea6fb3d66b72e44e7407a3b49caa5746edcf71b9d09",
+        "date": "26 Nov 2020"
+      },
+      {
+        "filename": "php-8.0.0.tar.xz",
+        "name": "PHP 8.0.0 (tar.xz)",
+        "sha256": "b5278b3eef584f0c075d15666da4e952fa3859ee509d6b0cc2ed13df13f65ebb",
+        "date": "26 Nov 2020"
+      }
+    ],
+    "museum": false
+  }
+}

--- a/php-releases/releases.json
+++ b/php-releases/releases.json
@@ -1,0 +1,145 @@
+{
+  "8": {
+    "announcement": true,
+    "tags": [],
+    "date": "09 May 2024",
+    "source": [
+      {
+        "filename": "php-8.3.7.tar.gz",
+        "name": "PHP 8.3.7 (tar.gz)",
+        "sha256": "2e11d10b651459a8767401e66b5d70e3b048e446579fcdeb0b69bcba789af8c4",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.3.7.tar.bz2",
+        "name": "PHP 8.3.7 (tar.bz2)",
+        "sha256": "01c20cde1c5a5696651875ed22f507849679fba740f8c421616b7d43d7f797da",
+        "date": "09 May 2024"
+      },
+      {
+        "filename": "php-8.3.7.tar.xz",
+        "name": "PHP 8.3.7 (tar.xz)",
+        "sha256": "d53433c1ca6b2c8741afa7c524272e6806c1e895e5912a058494fea89988570a",
+        "date": "09 May 2024"
+      }
+    ],
+    "version": "8.3.7",
+    "supported_versions": [
+      "8.1",
+      "8.2",
+      "8.3"
+    ]
+  },
+  "7": {
+    "announcement": {
+      "English": "/releases/7_4_33.php"
+    },
+    "tags": [
+      "security"
+    ],
+    "date": "03 Nov 2022",
+    "source": [
+      {
+        "filename": "php-7.4.33.tar.gz",
+        "name": "PHP 7.4.33 (tar.gz)",
+        "sha256": "5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e",
+        "date": "03 Nov 2022"
+      },
+      {
+        "filename": "php-7.4.33.tar.bz2",
+        "name": "PHP 7.4.33 (tar.bz2)",
+        "sha256": "4e8117458fe5a475bf203128726b71bcbba61c42ad463dffadee5667a198a98a",
+        "date": "03 Nov 2022"
+      },
+      {
+        "filename": "php-7.4.33.tar.xz",
+        "name": "PHP 7.4.33 (tar.xz)",
+        "sha256": "924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927",
+        "date": "03 Nov 2022"
+      }
+    ],
+    "museum": false,
+    "version": "7.4.33",
+    "supported_versions": []
+  },
+  "5": {
+    "announcement": {
+      "English": "/releases/5_6_40.php"
+    },
+    "source": [
+      {
+        "filename": "php-5.6.40.tar.bz2",
+        "name": "PHP 5.6.40 (tar.bz2)",
+        "sha256": "ffd025d34623553ab2f7fd8fb21d0c9e6f9fa30dc565ca03a1d7b763023fba00",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-5.6.40.tar.gz",
+        "name": "PHP 5.6.40 (tar.gz)",
+        "sha256": "56fb9878d12fdd921f6a0897e919f4e980d930160e154cbde2cc6d9206a27cac",
+        "date": "10 Jan 2019"
+      },
+      {
+        "filename": "php-5.6.40.tar.xz",
+        "name": "PHP 5.6.40 (tar.xz)",
+        "sha256": "1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c",
+        "date": "10 Jan 2019"
+      }
+    ],
+    "date": "10 Jan 2019",
+    "museum": false,
+    "version": "5.6.40",
+    "supported_versions": []
+  },
+  "4": {
+    "announcement": {
+      "English": "/releases/4_4_9.php"
+    },
+    "source": [
+      {
+        "filename": "php-4.4.9.tar.bz2",
+        "name": "PHP 4.4.9 (tar.bz2)",
+        "md5": "2e3b2a0e27f10cb84fd00e5ecd7a1880",
+        "date": "07 August 2008"
+      },
+      {
+        "filename": "php-4.4.9.tar.gz",
+        "name": "PHP 4.4.9 (tar.gz)",
+        "md5": "9bcc1aba50be0dfeeea551d018375548",
+        "date": "07 August 2008"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-4.4.9-Win32.zip",
+        "name": "PHP 4.4.9 zip package",
+        "md5": "7395068d5489a9f8abf50c6e4b48622f",
+        "date": "07 August 2008"
+      }
+    ],
+    "date": "07 August 2008",
+    "museum": true,
+    "version": "4.4.9",
+    "supported_versions": []
+  },
+  "3": {
+    "date": "20 Oct 2000",
+    "source": [
+      {
+        "filename": "php-3.0.18.tar.gz",
+        "name": "PHP 3.0.18 Source Code",
+        "md5": "b4b8f7f1151ce66d5f3910a066651133"
+      }
+    ],
+    "windows": [
+      {
+        "filename": "php-3.0.17-win32.zip",
+        "name": "PHP 3.0.17 Windows binary",
+        "md5": "29029ac1c3c2075dce38bbd804c42f72"
+      }
+    ],
+    "museum": true,
+    "version": "3.0.x (latest)",
+    "supported_versions": []
+  }
+}


### PR DESCRIPTION
# Context

Some years ago, for Paketo's PHP Dist, we encountered the challenge of parsing the PHP release information from upstream. To address this, I developed a solution that involved creating a repository mimicking the behavior of Depwatcher. This repository facilitates general fetches to obtain branches (e.g., 8, 7, 6) and specific fetches for a particular branch (e.g., 8.x, 7.x).

In the context-sharing process that I'm working on, moving the functionalities from my persona account to this CI repo ensures that everyone on the team has access to and can contribute to modifying or updating the logic as needed. You can find the original repository [here](https://github.com/brayanhenao/php-releases-information).
