### PR TITLE
Update to gcc-11 and use latest available python for fs3

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -41,8 +41,8 @@ module DependencyBuild
       Runner.run('apt', 'install', '-y', 'software-properties-common')
       Runner.run('add-apt-repository', '-y', 'ppa:ubuntu-toolchain-r/test')
       Runner.run('apt', 'update')
-      Runner.run('apt', 'install', '-y', 'gcc-8', 'g++-8')
-      Runner.run('update-alternatives', '--install', '/usr/bin/gcc', 'gcc', '/usr/bin/gcc-8', '60', '--slave', '/usr/bin/g++', 'g++', '/usr/bin/g++-8')
+      Runner.run('apt', 'install', '-y', 'gcc-11', 'g++-11')
+      Runner.run('update-alternatives', '--install', '/usr/bin/gcc', 'gcc', '/usr/bin/gcc-11', '60', '--slave', '/usr/bin/g++', 'g++', '/usr/bin/g++-11')
     end
 
     def bundle_pip_dependencies(source_input)
@@ -683,6 +683,7 @@ class Builder
       )
 
     when 'node', 'httpd'
+      DependencyBuild.setup_python
       DependencyBuild.setup_gcc11
 
       source_input.version = source_input.version.delete_prefix('v') if source_input.name == 'node'


### PR DESCRIPTION
# Context

After investigating the errors encountered while building Node.js `22.x` in cflinuxfs3, I discovered that the latest version has specific [prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#unix-prerequisites) we currently do not meet.

Specifically, it requires `gcc` and `g++` versions greater than or equal to 10.1 or newer. Additionally, the required Python version should exceed or equal to 3.8. Although we already have a function that installs the corresponding Python version, we were not using this function in the Node.js building process.

NOTE: Do not merge until https://github.com/cloudfoundry/binary-builder/pull/79 is merged.