### PR TITLE
Fix errors with node 22.x in cflinuxfs3 (skip this version line)

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -220,6 +220,7 @@ dependencies:
             link: https://github.com/nodejs/Release
     source_type: node
     versions_to_keep: 2
+    skip_lines_cflinuxfs3: [ '22.X.X' ]
   php:
     buildpacks:
       php:

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -223,7 +223,8 @@ private_key = '((cf-buildpacks-eng-github-ssh-key.private_key))'
 jobs:
 <% dependencies.each do |dep_name, dep| %>
 <%
-skipped_version_lines = dep['skip_lines_cflinuxfs4'] ? dep['skip_lines_cflinuxfs4'] : []
+skipped_version_lines_fs4 = dep['skip_lines_cflinuxfs4'] ? dep['skip_lines_cflinuxfs4'] : []
+skipped_version_lines_fs3 = dep['skip_lines_cflinuxfs3'] ? dep['skip_lines_cflinuxfs3'] : []
 version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version_lines(bp['lines'], ['latest'])}
 %>
 <% if is_multiline?(dep) %>
@@ -365,7 +366,8 @@ version_lines = dep['buildpacks'].values.reduce([]) {|sum, bp| sum | get_version
   - in_parallel:
   <%
   build_stacks = dep['any_stack'] ? ['any-stack'] : specific_stack
-  build_stacks = build_stacks - ['cflinuxfs4'] if skipped_version_lines.map(&:downcase).include?(line.downcase)
+  build_stacks = build_stacks - ['cflinuxfs4'] if skipped_version_lines_fs4.map(&:downcase).include?(line.downcase)
+  build_stacks = build_stacks - ['cflinuxfs3'] if skipped_version_lines_fs3.map(&:downcase).include?(line.downcase)
   %>
   <% build_stacks.each do |stack| %>
     - do:

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -36,13 +36,13 @@ module DependencyBuild
       Runner.run('rm', '-f', 'get-pip.py')
     end
 
-    def setup_gcc11
+    def setup_gcc
       Runner.run('apt', 'update')
       Runner.run('apt', 'install', '-y', 'software-properties-common')
       Runner.run('add-apt-repository', '-y', 'ppa:ubuntu-toolchain-r/test')
       Runner.run('apt', 'update')
-      Runner.run('apt', 'install', '-y', 'gcc-11', 'g++-11')
-      Runner.run('update-alternatives', '--install', '/usr/bin/gcc', 'gcc', '/usr/bin/gcc-11', '60', '--slave', '/usr/bin/g++', 'g++', '/usr/bin/g++-11')
+      Runner.run('apt', 'install', '-y', 'gcc-8', 'g++-8')
+      Runner.run('update-alternatives', '--install', '/usr/bin/gcc', 'gcc', '/usr/bin/gcc-8', '60', '--slave', '/usr/bin/g++', 'g++', '/usr/bin/g++-8')
     end
 
     def bundle_pip_dependencies(source_input)
@@ -683,8 +683,7 @@ class Builder
       )
 
     when 'node', 'httpd'
-      DependencyBuild.setup_python
-      DependencyBuild.setup_gcc11
+      DependencyBuild.setup_gcc
 
       source_input.version = source_input.version.delete_prefix('v') if source_input.name == 'node'
       binary_builder.build(source_input)

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -95,6 +95,12 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
     stacks = stacks - ['cflinuxfs4']
   end
 
+  # Logic to skip certain version lines that are not supported in cflinuxfs3
+  skip_lines_cflinuxfs3 = config['dependencies'][source_name].key?('skip_lines_cflinuxfs3') ? config['dependencies'][source_name]['skip_lines_cflinuxfs3'].map(&:downcase) : []
+  if skip_lines_cflinuxfs3.include?(version_line.downcase)
+    stacks = stacks - ['cflinuxfs3']
+  end
+
   stacks = WINDOWS_STACKS if source_name == 'hwc'
   total_stacks = total_stacks | stacks
 


### PR DESCRIPTION
# Context

- We decided not to ship Node version `22.x` for `cflinuxfs3`. I am just rolling back the changes made before (including the GCC bump, that doesn't work in `cflinuxfs3`
- We already have logic for skipping lines for `cflinuxfs4` but not for `cflinuxfs3`, so this PR addresses this new change.