### PR TITLE
Allow empty stack diff release notes section

### DIFF
--- a/lib/release-notes-creator.rb
+++ b/lib/release-notes-creator.rb
@@ -51,7 +51,11 @@ class RootfsReleaseNotesCreator
     diffy = Diffy::Diff.new(@old_receipt_file, @new_receipt_file, source: 'files', diff: '-b') or raise 'Could not create Diffy::Diff'
     receipt_diff_array = parse_diffy_output(diffy)
     receipt_diff = format_diff(receipt_diff_array) unless receipt_diff_array.empty?
-    "```\n#{receipt_diff}```\n" if receipt_diff
+    if receipt_diff
+      "```\n#{receipt_diff}```\n"
+    else
+      ""
+    end
   end
 
   def new_packages?

--- a/tasks/generate-rootfs-receipt-diff/task.yml
+++ b/tasks/generate-rootfs-receipt-diff/task.yml
@@ -13,9 +13,6 @@ outputs:
   - name: public-robots-artifacts
   - name: git-tags
 run:
-  path: bash
-  args:
-    - "-cl"
-    - "buildpacks-ci/tasks/generate-rootfs-receipt-diff/run.rb"
+  path: buildpacks-ci/tasks/generate-rootfs-receipt-diff/run.rb
 params:
   STACK:

--- a/tasks/generate-rootfs-release-notes/task.yml
+++ b/tasks/generate-rootfs-release-notes/task.yml
@@ -14,10 +14,7 @@ outputs:
   - name: release-body
   - name: new-cves-artifacts
 run:
-  path: bash
-  args:
-    - "-cl"
-    - "buildpacks-ci/tasks/generate-rootfs-release-notes/run.rb"
+  path: buildpacks-ci/tasks/generate-rootfs-release-notes/run.rb
 params:
   STACK:
   STACK_REPO:


### PR DESCRIPTION
When re-running a stack build, if there are no receipt diff changes this step fails with the following error:

```
mesg: ttyname failed: Inappropriate ioctl for device
/tmp/build/0f8c0414/buildpacks-ci/lib/release-notes-creator.rb:19:in `+': no implicit conversion of nil into String (TypeError)
```

For the `ioctl` errors - invoke the ruby task directly, as `bash -cl` does not always work on concourse.
