### PR TITLE
retry for httpd dependency build pipeline

### DIFF
--- a/dockerfiles/depwatcher/src/depwatcher/httpd.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/httpd.cr
@@ -25,9 +25,33 @@ module Depwatcher
     end
 
     def in(ref : String) : Release
-      sha_response = HTTP::Client.get("https://archive.apache.org/dist/httpd/httpd-#{ref}.tar.bz2.sha256").body
-      sha256 = sha_response.split(" ")[0]
-      Release.new(ref, "https://dlcdn.apache.org/httpd/httpd-#{ref}.tar.bz2", sha256)
+      sha_response = nil
+      max_retries = 3
+      retries = 0
+
+      while retries < max_retries
+        begin
+          sha_response = HTTP::Client.get("https://archive.apache.org/dist/httpd/httpd-#{ref}.tar.bz2.sha256")
+          if sha_response.status_code != 200
+            puts "Attempt #{retries + 1}: Received status #{sha_response.status_code}, retrying..."
+            retries += 1
+            sleep(5)
+          else
+            puts "Success: Received status 200"
+            break
+          end
+        rescue ex
+          puts "Failed with error: #{ex.message}, retrying..."
+        end
+      end
+
+      unless sha_response.nil?
+        sha256 = sha_response.body.split(" ")[0]
+        puts sha256
+        Release.new(ref, "https://dlcdn.apache.org/httpd/httpd-#{ref}.tar.bz2", sha256)
+      else
+        raise "Could not retreive the page after #{max_retries} attempts"
+      end
     end
   end
 end


### PR DESCRIPTION
It seems like the httpd dependency build pipeline[1] fails for 2 reasons:
1. The dep watcher watches the github repo but downloads from archive.apache.org. There's a time lag between maintainers create a new tag in the GH repo, AND they upload the artifacts to the download portal.
2. The download portal isn't 100% available. So instead of getting the checksum page, we sometimes get a 404 html page.

This PR only addresses reason2 by implementing a retry for the sha retrieval. As of date, they released a patch yesterday and a patch today contributing to multiple CI failures.

1: https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-httpd-latest