### PR TITLE
Revert "retry for httpd dependency build pipeline"

### DIFF
--- a/dockerfiles/depwatcher/src/depwatcher/httpd.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/httpd.cr
@@ -25,33 +25,9 @@ module Depwatcher
     end
 
     def in(ref : String) : Release
-      sha_response = nil
-      max_retries = 3
-      retries = 0
-
-      while retries < max_retries
-        begin
-          sha_response = HTTP::Client.get("https://archive.apache.org/dist/httpd/httpd-#{ref}.tar.bz2.sha256")
-          if sha_response.status_code != 200
-            puts "Attempt #{retries + 1}: Received status #{sha_response.status_code}, retrying..."
-            retries += 1
-            sleep(5)
-          else
-            puts "Success: Received status 200"
-            break
-          end
-        rescue ex
-          puts "Failed with error: #{ex.message}, retrying..."
-        end
-      end
-
-      unless sha_response.nil?
-        sha256 = sha_response.body.split(" ")[0]
-        puts sha256
-        Release.new(ref, "https://dlcdn.apache.org/httpd/httpd-#{ref}.tar.bz2", sha256)
-      else
-        raise "Could not retreive the page after #{max_retries} attempts"
-      end
+      sha_response = HTTP::Client.get("https://archive.apache.org/dist/httpd/httpd-#{ref}.tar.bz2.sha256").body
+      sha256 = sha_response.split(" ")[0]
+      Release.new(ref, "https://dlcdn.apache.org/httpd/httpd-#{ref}.tar.bz2", sha256)
     end
   end
 end


### PR DESCRIPTION
This reverts commit a8194d08db9a9d2f8f0e03730f279aea32f673c8.

due to https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/build-httpd-latest/builds/65