### PR TITLE
Switch to using buildpacks.cloudfoundry.org bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ fly intercept -c $RESOURCE_NAME rm -rf /tmp/git-resource-repo-cache
 
 Build should automatically kick off at
 https://buildpacks.ci.cf-app.com/pipelines/binary-builder and silently
-upload a binary to the `pivotal-buildpacks` bucket under
+upload a binary to the `buildpacks.cloudfoundry.org` bucket under
 `dependencies/`,
-e.g. https://pivotal-buildpacks.s3.amazonaws.com/dependencies/ruby/ruby-2.2.2-linux-x64.tgz
+e.g. https://buildpacks.cloudfoundry.org.s3.amazonaws.com/dependencies/ruby/ruby-2.2.2-linux-x64.tgz
 
 Note that the array is a stack, which will be emptied as the build
 succeeds in packaging successive versions.

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -146,20 +146,18 @@ resources:
 - name: stack-s3
   type: s3
   source:
-    bucket: pivotal-buildpacks
+    bucket: buildpacks.cloudfoundry.org
     regexp: rootfs/cflinuxfs4-(.*).tar.gz
-    access_key_id: ((svc-buildpacks-aws-team-access-key))
-    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
-    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
+    access_key_id: ((buildpacks.cloudfoundry.org-aws-access-key-id))
+    secret_access_key: ((buildpacks.cloudfoundry.org-aws-secret-access-key))
 
 - name: receipt-s3
   type: s3
   source:
-    bucket: pivotal-buildpacks
+    bucket: buildpacks.cloudfoundry.org
     regexp: rootfs/receipt.cflinuxfs4.x86_64-(.*)
-    access_key_id: ((svc-buildpacks-aws-team-access-key))
-    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
-    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
+    access_key_id: ((buildpacks.cloudfoundry.org-aws-access-key-id))
+    secret_access_key: ((buildpacks.cloudfoundry.org-aws-secret-access-key))
 
 - name: cflinuxfs4-cf-deployment
   type: bosh-deployment
@@ -205,11 +203,10 @@ resources:
 - name: version
   type: semver-latest
   source:
-    bucket: pivotal-buildpacks
+    bucket: buildpacks.cloudfoundry.org
     key: versions/stack-cflinuxfs4
-    access_key_id: ((svc-buildpacks-aws-team-access-key))
-    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
-    assume_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
+    access_key_id: ((buildpacks.cloudfoundry.org-aws-access-key-id))
+    secret_access_key: ((buildpacks.cloudfoundry.org-aws-secret-access-key))
 
 - name: check-interval
   type: cron

--- a/pipelines/dependency-builds.yml.erb
+++ b/pipelines/dependency-builds.yml.erb
@@ -206,10 +206,9 @@ private_key = '((cf-buildpacks-eng-github-ssh-key.private_key))'
 - name: buildpacks-bucket-<%= dep_name %>
   type: s3
   source:
-    bucket: {{buildpacks-binaries-s3-bucket}}
-    access_key_id: ((svc-buildpacks-aws-team-access-key))
-    secret_access_key: ((svc-buildpacks-aws-team-secret-key))
-    aws_role_arn: ((svc-buildpacks-aws-team-assume-role-arn))
+    bucket: buildpacks.cloudfoundry.org
+    access_key_id: ((buildpacks.cloudfoundry.org-aws-access-key-id))
+    secret_access_key: ((buildpacks.cloudfoundry.org-aws-secret-access-key))
     # pip, go and libgdiplus have some versions of the form 'v1.2'; everyone else uses 'v1.2.3'
     regexp: dependencies/<%=dep_name%>/<%=dep_name == 'nginx-static' ? 'nginx' : dep_name %>.*?<%= (dep_name == 'pip' || dep_name == 'go' || dep_name == 'libgdiplus') ? '(\d+\.\d+(?:\.\d+)?)' : '(\d+\.\d+\.\d+)' %>(.*)
 <% end %>

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -360,7 +360,7 @@ jobs: ##########################################################################
       - in_parallel:
         - get: buildpacks-ci
         <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
-        - get: pivotal-buildpacks-stack<%= ndx.to_s %>
+        - get: uncached-buildpack-for-stack<%= ndx.to_s %>
           resource: pivotal-buildpack-<%= stack %>
           passed: [ ship-it ]
         <% end %>

--- a/public-config.yml
+++ b/public-config.yml
@@ -6,7 +6,6 @@ buildpack-packager-git-uri-public: https://github.com/cloudfoundry/buildpack-pac
 buildpack-packager-git-uri: git@github.com:cloudfoundry/buildpack-packager.git
 buildpack-release-candidates-bucket: buildpack-release-candidates
 buildpackapplifecycle-git-branch: develop
-buildpacks-binaries-s3-bucket: pivotal-buildpacks
 buildpacks-ci-git-uri-public-branch: master
 buildpacks-ci-git-uri-public-develop-branch: develop
 buildpacks-ci-git-uri-public: https://github.com/cloudfoundry/buildpacks-ci

--- a/tasks/finalize-buildpack/run.rb
+++ b/tasks/finalize-buildpack/run.rb
@@ -6,7 +6,7 @@ artifact_dir = File.join(Dir.pwd, 'buildpack-artifacts')
 version = File.read('buildpack/VERSION').strip
 
 buildpack_repo_dir = 'buildpack'
-uncached_buildpack_dirs = Dir.glob('pivotal-buildpacks*')
+uncached_buildpack_dirs = Dir.glob('uncached-buildpack-for-stack*')
 
 ENV['GOBIN']="#{File.expand_path(buildpack_repo_dir)}/.bin"
 ENV['PATH']="#{ENV['GOBIN']}:#{ENV['PATH']}"

--- a/tasks/finalize-buildpack/task.yml
+++ b/tasks/finalize-buildpack/task.yml
@@ -7,14 +7,14 @@ image_resource:
 inputs:
   - name: buildpacks-ci
   - name: buildpack
-  - name: pivotal-buildpacks-stack0
-  - name: pivotal-buildpacks-stack1
+  - name: uncached-buildpack-for-stack0
+  - name: uncached-buildpack-for-stack1
     optional: true
-  - name: pivotal-buildpacks-stack2
+  - name: uncached-buildpack-for-stack2
     optional: true
-  - name: pivotal-buildpacks-stack3
+  - name: uncached-buildpack-for-stack3
     optional: true
-  - name: pivotal-buildpacks-stack4
+  - name: uncached-buildpack-for-stack4
     optional: true
 caches:
   - path: buildpack/vendor


### PR DESCRIPTION
- this is necessary for the CFF to take over the CDN that sits in front of this namespace.
- there is a lot of specific nuance, but the summary is that the CDN must now point to a bucket that has the same name
- this does not affect consumers because they were already downloading dependencies from the CDN under the buildpacks.cloudfoundry.org host

Changes have already been fly'd