### PR TITLE
remove build/test on windows2016 stack

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -4,7 +4,7 @@
 
 supported_languages:
 - name: binary
-  stacks: #@ default_stacks + ["cflinuxfs4", "windows2016", "windows"]
+  stacks: #@ default_stacks + ["cflinuxfs4", "windows"]
 - name: dotnet-core
   stacks: #@ default_stacks + ["cflinuxfs4"]
 - name: go
@@ -27,7 +27,7 @@ supported_languages:
   stacks: #@ default_stacks + ["cflinuxfs4"]
 supported_languages_without_java:
 - name: binary
-  stacks: #@ default_stacks + ["cflinuxfs4", "windows2016", "windows"]
+  stacks: #@ default_stacks + ["cflinuxfs4", "windows"]
 - name: dotnet-core
   stacks: #@ default_stacks + ["cflinuxfs4"]
 - name: go

--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -364,7 +364,7 @@ cflinuxfs4_build_dependencies: [ 'libunwind', 'libgdiplus', 'node', 'pipenv', 'p
 cflinuxfs4_dependencies: [ 'bower', 'libunwind', 'libgdiplus', 'node', 'dotnet-sdk', 'dotnet-runtime', 'dotnet-aspnetcore', 'pipenv', 'python', 'yarn', 'pip', 'setuptools', 'miniconda3-py39', 'go', 'godep', 'glide', 'dep', 'ruby', 'jruby', 'bundler', 'rubygems', 'nginx', 'nginx-static', 'openresty', 'r', 'appdynamics', 'composer', 'httpd', 'php' ]
 cflinuxfs4_buildpacks: [ 'dotnet-core' , 'nodejs', 'python', 'go', 'ruby', 'nginx', 'r', 'php', 'staticfile' ]
 build_stacks: [ 'cflinuxfs4' , 'cflinuxfs3' ]
-windows_stacks: [ 'windows2016', 'windows' ]
+windows_stacks: [ 'windows' ]
 
 #! only check deprecation dates for dotnet-runtime as they are redundant for sdk and aspnetcore
 skip_deprecation_check:

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -4,7 +4,7 @@
     'non_lts' => true,
   },
   'binary' => {
-    'stacks' => %w(cflinuxfs3 cflinuxfs4 windows2016 windows),
+    'stacks' => %w(cflinuxfs3 cflinuxfs4 windows),
     'product_slug' => 'binary-buildpack',
     'skip_docker_start' => true,
   },
@@ -19,7 +19,7 @@
     'compute_instance_count' => 3
   },
   'hwc' => {
-    'stacks' => %w(windows2016 windows),
+    'stacks' => %w(windows),
     'skip_brats' => true,
     'product_slug' => 'hwc-buildpack',
     'non_lts' => true,

--- a/tasks/cf/redeploy/operations/add-cflinuxfs3-to-current.yml
+++ b/tasks/cf/redeploy/operations/add-cflinuxfs3-to-current.yml
@@ -17,16 +17,12 @@
     cflinuxfs4: /home/vcap
     cflinuxfs3: /home/vcap
     windows: /Users/vcap
-    windows2012R2: /
-    windows2016: /Users/vcap
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/lifecycle_bundles
   value:
     buildpack/cflinuxfs4: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
     buildpack/cflinuxfs3: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
     buildpack/windows: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
-    buildpack/windows2012R2: windows_app_lifecycle/windows_app_lifecycle.tgz
-    buildpack/windows2016: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
     docker: docker_app_lifecycle/docker_app_lifecycle.tgz
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/rep/preloaded_rootfses


### PR DESCRIPTION
Cf-d removed support for stack[1]. windows2016 is just an alias for windows stack kept for legacy reasons. The CF docs already state[2] windows2016 as an unsupported stack, and I believe we have warned users to switch for years.

1. https://github.com/cloudfoundry/cf-deployment/pull/1156
2. https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html#-available-stacks