### PR TITLE
tasks: add docker auth to ALL tasks

### DIFF
--- a/tasks/add-gcp-parent-dns-record/task.yml
+++ b/tasks/add-gcp-parent-dns-record/task.yml
@@ -5,6 +5,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
 - name: buildpacks-ci

--- a/tasks/build-binary-new-cflinuxfs4/build.yml
+++ b/tasks/build-binary-new-cflinuxfs4/build.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/cflinuxfs4
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: binary-builder
   - name: buildpacks-ci

--- a/tasks/build-binary-new/build.yml
+++ b/tasks/build-binary-new/build.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/cflinuxfs3
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: binary-builder
   - name: buildpacks-ci

--- a/tasks/build-image/task.yml
+++ b/tasks/build-image/task.yml
@@ -5,6 +5,8 @@ image_resource:
   type: registry-image
   source:
     repository: vito/oci-build-task
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
 - name: source

--- a/tasks/buildpack-to-master/task.yml
+++ b/tasks/buildpack-to-master/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: repo

--- a/tasks/cf-release/create-cats-integration-config/task.yml
+++ b/tasks/cf-release/create-cats-integration-config/task.yml
@@ -5,6 +5,8 @@ image_resource:
   source:
     repository: cfbuildpacks/ci
     tag: latest
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: cf-deployment-concourse-tasks

--- a/tasks/cf-release/upload-bosh-release/task.yml
+++ b/tasks/cf-release/upload-bosh-release/task.yml
@@ -5,6 +5,8 @@ image_resource:
   source:
     repository: cfbuildpacks/ci
     tag: latest
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
 - name: buildpacks-ci
 - name: cf-deployment-concourse-tasks

--- a/tasks/cf/create-space/task.yml
+++ b/tasks/cf/create-space/task.yml
@@ -6,6 +6,8 @@ image_resource:
   source:
     repository: cfbuildpacks/ci
     tag: latest
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
 - name: ci

--- a/tasks/cf/redeploy/task.yml
+++ b/tasks/cf/redeploy/task.yml
@@ -6,6 +6,8 @@ image_resource:
   source:
     repository: cfbuildpacks/ci
     tag: latest
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
   - name: ci

--- a/tasks/check-for-binary-builder-integration-spec-presence/task.yml
+++ b/tasks/check-for-binary-builder-integration-spec-presence/task.yml
@@ -3,6 +3,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: binary-builder
   - name: buildpacks-ci

--- a/tasks/check-for-new-rootfs-cves-cflinuxfs4/task.yml
+++ b/tasks/check-for-new-rootfs-cves-cflinuxfs4/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: new-cves
   - name: buildpacks-ci

--- a/tasks/check-for-new-rootfs-cves/task.yml
+++ b/tasks/check-for-new-rootfs-cves/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: new-cves
   - name: buildpacks-ci

--- a/tasks/check-for-rootfs-race-condition/task.yml
+++ b/tasks/check-for-rootfs-race-condition/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: version

--- a/tasks/check-php-modules-in-manifest/task.yml
+++ b/tasks/check-php-modules-in-manifest/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpack
   - name: buildpacks-ci

--- a/tasks/check-tag-not-already-added/task.yml
+++ b/tasks/check-tag-not-already-added/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/configure-pas/task.yml
+++ b/tasks/configure-pas/task.yml
@@ -5,6 +5,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
   - name: buildpacks-ci

--- a/tasks/create-bosh-release/task.yml
+++ b/tasks/create-bosh-release/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: release

--- a/tasks/create-bump-buildpacks-opsfile/task.yml
+++ b/tasks/create-bump-buildpacks-opsfile/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: java-buildpack
   - name: go-buildpack-stack0

--- a/tasks/create-capi-release-with-rootfs/task.yml
+++ b/tasks/create-capi-release-with-rootfs/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/create-cf-space-toolsmiths/task.yml
+++ b/tasks/create-cf-space-toolsmiths/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: environment

--- a/tasks/create-deployment-source-config/task.yml
+++ b/tasks/create-deployment-source-config/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: bbl-state
   - name: buildpacks-ci

--- a/tasks/create-new-version-line-story/create_node_lts.yml
+++ b/tasks/create-new-version-line-story/create_node_lts.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: source

--- a/tasks/create-rootfs-bosh-release-commit/task.yml
+++ b/tasks/create-rootfs-bosh-release-commit/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: release-artifacts
 outputs:

--- a/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
+++ b/tasks/create-rootfs-bosh-release-github-release-notes/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: version

--- a/tasks/delete-cf-space/task.yml
+++ b/tasks/delete-cf-space/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: cf-space

--- a/tasks/detect-and-upload/task.yml
+++ b/tasks/detect-and-upload/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: pivotal-buildpack
     optional: true

--- a/tasks/finalize-buildpack/task.yml
+++ b/tasks/finalize-buildpack/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/generate-buildpacks-json/task.yml
+++ b/tasks/generate-buildpacks-json/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpacks-site

--- a/tasks/generate-dependency-deprecation-github-issue/task.yml
+++ b/tasks/generate-dependency-deprecation-github-issue/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/generate-rootfs-receipt-diff/task.yml
+++ b/tasks/generate-rootfs-receipt-diff/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: previous-rootfs-release

--- a/tasks/generate-rootfs-release-notes/task.yml
+++ b/tasks/generate-rootfs-release-notes/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: previous-rootfs-release
   - name: buildpacks-ci

--- a/tasks/get-buildpack-github-release-notes/task.yml
+++ b/tasks/get-buildpack-github-release-notes/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: registry-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/get-cf-creds/task.yml
+++ b/tasks/get-cf-creds/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: bbl-state

--- a/tasks/make-rootfs/task.yml
+++ b/tasks/make-rootfs/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: rootfs

--- a/tasks/overwrite-rootfs-release/task.yml
+++ b/tasks/overwrite-rootfs-release/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/remove-gcp-parent-dns-record/task.yml
+++ b/tasks/remove-gcp-parent-dns-record/task.yml
@@ -5,6 +5,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 
 inputs:
   - name: buildpacks-ci

--- a/tasks/rename-rootfs-for-docker/task.yml
+++ b/tasks/rename-rootfs-for-docker/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: stack-s3
 outputs:

--- a/tasks/repackage-dependency/task.yml
+++ b/tasks/repackage-dependency/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/cflinuxfs3
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
 - name: buildpacks-ci
 - name: source

--- a/tasks/rootfs/create-bosh-release-commit/task.yml
+++ b/tasks/rootfs/create-bosh-release-commit/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: release-artifacts
 outputs:

--- a/tasks/rootfs/create-bosh-release-github-release-notes/task.yml
+++ b/tasks/rootfs/create-bosh-release-github-release-notes/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: version

--- a/tasks/rootfs/create-release/task.yml
+++ b/tasks/rootfs/create-release/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: blob

--- a/tasks/rootfs/rename-for-docker/task.yml
+++ b/tasks/rootfs/rename-for-docker/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/rootfs/run-rootfs-smoke-test/task.yml
+++ b/tasks/rootfs/run-rootfs-smoke-test/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: bbl-state

--- a/tasks/rootfs/update-filename/task.yml
+++ b/tasks/rootfs/update-filename/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/rootfs/update-receipt/task.yml
+++ b/tasks/rootfs/update-receipt/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: receipt-s3

--- a/tasks/run-bp-brats-jammy/task.yml
+++ b/tasks/run-bp-brats-jammy/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/test-on-jammy
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-bp-brats/task.yml
+++ b/tasks/run-bp-brats/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-buildpack-integration-specs/task.yml
+++ b/tasks/run-buildpack-integration-specs/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-buildpack-unit-specs/task.yml
+++ b/tasks/run-buildpack-unit-specs/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/run-rootfs-smoke-test/task.yml
+++ b/tasks/run-rootfs-smoke-test/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: bbl-state

--- a/tasks/set-status-success/task.yml
+++ b/tasks/set-status-success/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: repo

--- a/tasks/set-test-configuration/task.yml
+++ b/tasks/set-test-configuration/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: repo

--- a/tasks/update-buildpack-dependency/task.yml
+++ b/tasks/update-buildpack-dependency/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpack
   - name: buildpack-latest-released

--- a/tasks/update-compile-extensions/task.yml
+++ b/tasks/update-compile-extensions/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/update-gem-in-gemfile/task.yml
+++ b/tasks/update-gem-in-gemfile/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: gem
   - name: buildpacks-ci

--- a/tasks/update-libbuildpack/task.yml
+++ b/tasks/update-libbuildpack/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: buildpack

--- a/tasks/update-rootfs-filename/task.yml
+++ b/tasks/update-rootfs-filename/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: stack-s3

--- a/tasks/update-rootfs-receipt/task.yml
+++ b/tasks/update-rootfs-receipt/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: receipt-s3

--- a/tasks/upload-bosh-release/task.yml
+++ b/tasks/upload-bosh-release/task.yml
@@ -5,6 +5,8 @@ image_resource:
   source:
     repository: cfbuildpacks/ci
     tag: bbl-6 # TODO cut this back after all pipelines migrate to bbl 6
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: bosh-release

--- a/tasks/use-new-buildpack-bosh-releases/task.yml
+++ b/tasks/use-new-buildpack-bosh-releases/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: java-buildpack-release
   - name: go-buildpack-release

--- a/tasks/verify-buildpack-binaries/task.yml
+++ b/tasks/verify-buildpack-binaries/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: verification-whitelist

--- a/tasks/write-cats-config/task.yml
+++ b/tasks/write-cats-config/task.yml
@@ -4,6 +4,8 @@ image_resource:
   type: docker-image
   source:
     repository: cfbuildpacks/ci
+    username: ((coredeps-dockerhub-user.username))
+    password: ((coredeps-dockerhub-user.password))
 inputs:
   - name: buildpacks-ci
   - name: cf-admin-password


### PR DESCRIPTION
to avoid rate limiting.
We use the same credhub path for the secret in all concourse instances managed by the team. So the task should be reusable by other concourse instances.