### PR TITLE
Update bucket creds for CF BP Bosh releases

### DIFF
--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -170,9 +170,8 @@ jobs:
   - task: create-buildpack-dev-release
     file: buildpacks-ci/tasks/cf-release/create-buildpack-dev-release/task.yml
     params:
-      AWS_ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
-      AWS_SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
-      AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
+      AWS_ACCESS_KEY_ID: ((buildpacks-cloudfoundry-org-aws-access-key-id))
+      AWS_SECRET_ACCESS_KEY: ((buildpacks-cloudfoundry-org-aws-secret-access-key))
   - put: #@ language.name + "-buildpack-release"
     params:
       repository: release
@@ -411,9 +410,8 @@ jobs:
   - task: finalize-release
     file: buildpacks-ci/tasks/cf-release/finalize-buildpack-release/task.yml
     params:
-      AWS_ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
-      AWS_SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
-      AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
+      AWS_ACCESS_KEY_ID: ((buildpacks-cloudfoundry-org-aws-access-key-id))
+      AWS_SECRET_ACCESS_KEY: ((buildpacks-cloudfoundry-org-aws-secret-access-key))
   - put: #@ language.name + "-buildpack-release"
     params:
       repository: release

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -710,9 +710,8 @@ jobs: ##########################################################################
         - task: create-bosh-release
           file: buildpacks-ci/tasks/create-bosh-release/task.yml
           params:
-            ACCESS_KEY_ID: ((svc-buildpacks-aws-team-access-key))
-            SECRET_ACCESS_KEY: ((svc-buildpacks-aws-team-secret-key))
-            AWS_ASSUME_ROLE_ARN: ((svc-buildpacks-aws-team-assume-role-arn))
+            ACCESS_KEY_ID: ((buildpacks-cloudfoundry-org-aws-access-key-id))
+            SECRET_ACCESS_KEY: ((buildpacks-cloudfoundry-org-aws-secret-access-key))
             LANGUAGE: "hwc"
             RELEASE_NAME: hwc-buildpack
             RELEASE_DIR: release


### PR DESCRIPTION
We are moving from the defunct bucket "pivotal-buildpacks" to "buildpacks.cloudfoundry.org"

See e.g. https://github.com/cloudfoundry/dotnet-core-buildpack-release/pull/3

Also see related change with dependencies for more context: https://github.com/cloudfoundry/buildpacks-ci/pull/403

Also related: https://github.com/cloudfoundry/go-buildpack-release/pull/3 etc.