### PR TITLE
update go dep to 1.23, drop 1.21

### DIFF
--- a/pipelines/config/dependency-builds.yml
+++ b/pipelines/config/dependency-builds.yml
@@ -90,10 +90,10 @@ dependencies:
         lines:
           #! go version lines lose support the day that the version line 2 minor bumps ahead is released
           #! for example, 1.17.X reaches EOS whenever 1.19 releases. This gap is roughly 12 months.
-          - line: 1.21.X
+          - line: 1.22.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html
-          - line: 1.22.X
+          - line: 1.23.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html
         removal_strategy: remove_all


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/buildpacks-github-config/issues/95