### PR TITLE
build openresty with http2

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -788,6 +788,7 @@ class DependencyBuild
             '-j2',
             '--error-log-path=stderr',
             '--with-http_ssl_module',
+            '--with-http_v2_module',
             '--with-http_realip_module',
             '--with-http_gunzip_module',
             '--with-http_gzip_static_module',

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -440,6 +440,7 @@ module DependencyBuild
               '-j2',
               '--error-log-path=stderr',
               '--with-http_ssl_module',
+              '--with-http_v2_module',
               '--with-http_realip_module',
               '--with-http_gunzip_module',
               '--with-http_gzip_static_module',


### PR DESCRIPTION
while nginx is build with the flag `--with-http_v2_module` to enable http2, openresty isn't build with the flag.
To support http2 with openresty, this adds the required build flag.