### PR TITLE
python 3.9 build: temporarily stop replacing openssl

### DIFF
--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -298,10 +298,10 @@ module DependencyBuild
             end
 
             # replace openssl if needed
-            major, minor, _ = source_input.version.split('.')
-            if stack == 'cflinuxfs3' && major == '3' && minor.to_i < 10
-              DependencyBuild.replace_openssl
-            end
+            # major, minor, _ = source_input.version.split('.')
+            # if stack == 'cflinuxfs3' && major == '3' && minor.to_i < 10
+            #   DependencyBuild.replace_openssl
+            # end
 
             Runner.run("make")
             Runner.run("make install")


### PR DESCRIPTION
To figure out the reason for https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-edge-integration-develop-cflinuxfs3/builds/174