### PR TITLE
Do not replace with OpenSSL_1_1_0g w building python

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -642,12 +642,6 @@ class DependencyBuild
             Runner.run("dpkg -x #{path} #{destdir}")
           end
 
-          # replace openssl if needed
-          major, minor, _ = @source_input.version.split('.')
-          if @stack == 'cflinuxfs3' && major == '3' && minor.to_i < 10
-            DependencyBuild.replace_openssl
-          end
-
           Runner.run("make")
           Runner.run("make install")
           # create python symlink

--- a/tasks/build-binary-new/builder.rb
+++ b/tasks/build-binary-new/builder.rb
@@ -297,12 +297,6 @@ module DependencyBuild
               Runner.run("dpkg -x #{path} #{destdir}")
             end
 
-            # replace openssl if needed
-            # major, minor, _ = source_input.version.split('.')
-            # if stack == 'cflinuxfs3' && major == '3' && minor.to_i < 10
-            #   DependencyBuild.replace_openssl
-            # end
-
             Runner.run("make")
             Runner.run("make install")
             # create python symlink


### PR DESCRIPTION
Continuation of #417.

This was attempted when the brats tests kept failing with SSL errors for python < 3.10 ONLY on cflinuxfs3. See
https://buildpacks.ci.cf-app.com/teams/main/pipelines/python-buildpack/jobs/specs-edge-integration-develop-cflinuxfs3/builds/174. Should have been triggered by upstream change https://github.com/python/cpython/pull/118109.

The change in #417 fixed the brats test

The original change seems to have been intended for cflinuxfs2 as seen from this story: https://www.pivotaltracker.com/n/projects/1042066/stories/158871862 (also
https://github.com/cloudfoundry/binary-builder/commit/78323c46171c9b68a1e90d0bb657bf5608319fe2 and
https://github.com/cloudfoundry/binary-builder/commit/ccff965e1dae41105116a78e0068ade6e4b7ed46#diff-2183fca5c37f210ec00d4741797bd856666332eff7d11b7e10aeefb5001f40cdR12)

It looks like this replace_openssl magic also happens for nginx, but this PR doesn't deal with that.