### PR TITLE
depwatcher: use github-token for githuby deps

### DIFF
--- a/dockerfiles/depwatcher/src/check.cr
+++ b/dockerfiles/depwatcher/src/check.cr
@@ -5,6 +5,11 @@ data = JSON.parse(STDIN)
 STDERR.puts data.to_json
 source = data["source"]
 
+if source.as_h.has_key?("github_token")
+  token = source["github_token"].to_s
+  ENV["OAUTH_AUTHORIZATION_TOKEN"] = token
+end
+
 case type = source["type"].to_s
 when "github_releases"
   allow_prerelease = source["prerelease"]?

--- a/dockerfiles/depwatcher/src/in.cr
+++ b/dockerfiles/depwatcher/src/in.cr
@@ -7,6 +7,11 @@ STDERR.puts data.to_json
 source = data["source"]
 version = data["version"]
 
+if source.as_h.has_key?("github_token")
+  token = source["github_token"].to_s
+  ENV["OAUTH_AUTHORIZATION_TOKEN"] = token
+end
+
 case type = source["type"].to_s
 when "github_releases"
   version = if source["fetch_source"]? == JSON.parse("true")


### PR DESCRIPTION
manually built and pushed to coredeps/depwatcher