### PR TITLE
depwatcher: immediately remove github_token from input

### DIFF
--- a/dockerfiles/depwatcher/src/check.cr
+++ b/dockerfiles/depwatcher/src/check.cr
@@ -2,13 +2,15 @@ require "./depwatcher/*"
 require "json"
 
 data = JSON.parse(STDIN)
-STDERR.puts data.to_json
 source = data["source"]
 
 if source.as_h.has_key?("github_token")
   token = source["github_token"].to_s
   ENV["OAUTH_AUTHORIZATION_TOKEN"] = token
+  # To avoid leaking the credential, immediately remove it from the data struct
+  source.as_h.delete("github_token")
 end
+STDERR.puts data.to_json
 
 case type = source["type"].to_s
 when "github_releases"

--- a/dockerfiles/depwatcher/src/in.cr
+++ b/dockerfiles/depwatcher/src/in.cr
@@ -3,14 +3,16 @@ require "json"
 
 dir = ARGV[0]
 data = JSON.parse(STDIN)
-STDERR.puts data.to_json
 source = data["source"]
 version = data["version"]
 
 if source.as_h.has_key?("github_token")
   token = source["github_token"].to_s
   ENV["OAUTH_AUTHORIZATION_TOKEN"] = token
+  # To avoid leaking the credential, immediately remove it from the data struct
+  source.as_h.delete("github_token")
 end
+STDERR.puts data.to_json
 
 case type = source["type"].to_s
 when "github_releases"


### PR DESCRIPTION
for cred safety.
This resource prints and returns the input into the output, which is unsafe if the input has creds. But, without printing the input/ouptut, it makes it difficult to understand what's happening from the UI.

So, immediately take the token out before anything else.