### PR TITLE
Fix nginx default update in PHP BP

### DIFF
--- a/tasks/update-buildpack-dependency/php_manifest.rb
+++ b/tasks/update-buildpack-dependency/php_manifest.rb
@@ -1,8 +1,16 @@
 class PHPManifest
-  def self.update_defaults(manifest, source_name, resource_version)
+  def self.update_defaults(manifest, target_name, resource_version)
     manifest['default_versions'].map do |default|
-      if default['name'] == source_name
-        default['version'] = resource_version
+      if default['name'] == target_name
+        if default['name'] == 'nginx'
+          # For nginx, we update defaults only when a mainline version updates.
+          # Mainline versions are identified by having an odd number as the minor (e.g. 1.27.2)
+          if Gem::Version.new(resource_version).segments[1].odd?
+            default['version'] = resource_version
+          end
+        else
+          default['version'] = resource_version
+        end
       end
       default
     end

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -194,7 +194,7 @@ end
 # Updates default versions for PHP dependencies
 # manifest_name will be the name of the dependency, not PHP
 if !rebuilt && manifest_name != 'php' && buildpack_name == 'php' && manifest['default_versions']
-  manifest['default_versions'] = PHPManifest.update_defaults(manifest, source_name, resource_version)
+  manifest['default_versions'] = PHPManifest.update_defaults(manifest, manifest_name, resource_version)
 end
 
 #


### PR DESCRIPTION
- We need to look at `manifest_name` (e.g. nginx), not `source_name` (e.g. nginx-static) when updating the manifest as the former refers to the name of the dependency in the manifest.
- Only update the default value when the bump is for an NGINX mainline version.