### PR TITLE
R: back to devtools, but provide gcc9 support on fs3

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -232,16 +232,16 @@ module DependencyBuildHelper
             Runner.run('make')
             Runner.run('make install')
 
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "install.packages('remotes', repos='https://cran.r-project.org')")
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "install.packages('devtools', repos='https://cran.r-project.org')")
 
             rserve_version = rserve_input.split(".")[0..1].join(".") + "-" + rserve_input.split(".")[2..-1].join(".")
 
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('remotes'); remotes::install_version('Rserve', '#{rserve_version}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('remotes'); remotes::install_version('forecast', '#{forecast_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('remotes'); remotes::install_version('shiny', '#{shiny_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('remotes'); remotes::install_version('plumber', '#{plumber_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('devtools'); devtools::install_version('Rserve', '#{rserve_version}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('devtools'); devtools::install_version('forecast', '#{forecast_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('devtools'); devtools::install_version('shiny', '#{shiny_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', "require('devtools'); devtools::install_version('plumber', '#{plumber_input}', repos='https://cran.r-project.org', type='source', dependencies=TRUE)")
 
-            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', 'remove.packages("remotes")')
+            Runner.run('/usr/local/lib/R/bin/R', '--vanilla', '-e', 'remove.packages("devtools")')
 
             Dir.chdir('/usr/local/lib/R') do
               Runner.run('cp', '-L', '/usr/bin/x86_64-linux-gnu-gfortran-11', './bin/gfortran')


### PR DESCRIPTION
This reverts https://github.com/cloudfoundry/buildpacks-ci/pull/430 and adds gcc9 support for cflinuxfs3.

background:
We ship R dependency with a few modules pre-installed (Rserve, shiny etc.). There are 2 major toolchains to install these dependencies - devtools (heavy footprint) and remote (light). We traditionally used devtools, but a few months ago it stopped working for fs3 and so in #430 we switched to remote. However installing with devtools seemed to have added some freebie modules like stringr. Therefore, our tests started breaking with apps that didn't explicitly ask for modules like stringr (Not sure why this wasn't an issue for R 4.3, but started with 4.4). In this PR, we revert that change and fix building on cflinuxfs3 by updating gcc to build C++17 components of devtools