### PR TITLE
fix pip: use newer setuptools

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/builder.rb
+++ b/tasks/build-binary-new-cflinuxfs4/builder.rb
@@ -585,7 +585,7 @@ class DependencyBuild
 
         Archive.strip_top_level_directory_from_tar("pip-#{@source_input.version}.tar.gz")
         Runner.run('tar', 'zxf', "pip-#{@source_input.version}.tar.gz")
-        Runner.run('/usr/bin/pip3', 'download', '--no-binary', ':all:', 'setuptools==62.1.0')
+        Runner.run('/usr/bin/pip3', 'download', '--no-binary', ':all:', 'setuptools')
         Runner.run('/usr/bin/pip3', 'download', '--no-binary', ':all:', 'wheel')
         Runner.run('tar', 'zcvf', old_filepath, '.')
       end


### PR DESCRIPTION
Avoid wheel/setuptools mismatch. Recent releases moved the bdist_wheel implementation from wheel into setuptools