### PR TITLE
Depwatcher refactor to use latest crystal-lang version and fix php 

### DIFF
--- a/dockerfiles/depwatcher/Dockerfile
+++ b/dockerfiles/depwatcher/Dockerfile
@@ -3,13 +3,14 @@ FROM crystallang/crystal:1.17.0
 ADD . /src
 WORKDIR /src
 RUN shards install
+RUN crystal spec --no-debug
 RUN shards build --production
 
-FROM ubuntu:bionic
+FROM ubuntu:noble
 
 RUN \
   apt-get update && \
-  apt-get install -y apt-transport-https libxml2-dev libevent-2.1-6 libyaml-dev ca-certificates curl jq && \
+  apt-get install -y apt-transport-https libxml2-dev libevent-2.1-7 libyaml-dev ca-certificates curl jq && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=0 /src/bin/check /opt/resource/check

--- a/dockerfiles/depwatcher/Dockerfile
+++ b/dockerfiles/depwatcher/Dockerfile
@@ -1,8 +1,8 @@
-FROM crystallang/crystal:0.32.1
+FROM crystallang/crystal:1.17.0
 
 ADD . /src
 WORKDIR /src
-RUN shards && crystal spec --no-debug
+RUN shards install
 RUN shards build --production
 
 FROM ubuntu:bionic

--- a/dockerfiles/depwatcher/shard.yml
+++ b/dockerfiles/depwatcher/shard.yml
@@ -10,11 +10,8 @@ targets:
   in:
     main: src/in.cr
 
-crystal: 0.32.1
+crystal: 1.17.0
 
 license: MIT
 
 dependencies:
-  spec2:
-    github: waterlink/spec2.cr
-    version: ~> 0.11

--- a/dockerfiles/depwatcher/spec/depwatcher/app_dynamics_agent_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/app_dynamics_agent_spec.cr
@@ -1,31 +1,36 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/app_dynamics_agent.cr"
 
-Spec2.describe Depwatcher::AppDynamicsAgent do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://download.run.pivotal.io/appdynamics-php/index.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/appd_agent.yml")))
-
-    client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-2.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-1"))
-    client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-3.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-2"))
-    client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-2.1.1-1.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-3"))
-    client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-4"))
-  end
-
+describe Depwatcher::AppDynamicsAgent do
   describe "#check" do
     it "returns final releases sorted" do
-      expect(subject.check.map(&.ref)).to eq ["1.1.1-2", "1.1.1-3", "2.1.1-1", "3.1.1-14"]
+      client = HTTPClientMock.new
+      subject = Depwatcher::AppDynamicsAgent.new.tap { |s| s.client = client }
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/index.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/appd_agent.yml")))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-2.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-1"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-3.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-2"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-2.1.1-1.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-3"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-4"))
+      
+      subject.check.map(&.ref).should eq ["1.1.1-2", "1.1.1-3", "2.1.1-1", "3.1.1-14"]
     end
   end
 
   describe "#in" do
     it "returns final releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::AppDynamicsAgent.new.tap { |s| s.client = client }
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/index.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/appd_agent.yml")))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-2.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-1"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-3.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-2"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-2.1.1-1.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-3"))
+      client.stub_get("https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2", nil, HTTP::Client::Response.new(200,  "some-content-4"))
+      
       obj = subject.in("3.1.1-14")
-      expect(obj.ref).to eq "3.1.1-14"
-      expect(obj.url).to eq "https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2"
-      expect(obj.sha256).to eq OpenSSL::Digest.new("sha256").update("some-content-4").hexdigest
+      obj.ref.should eq "3.1.1-14"
+      obj.url.should eq "https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2"
+      obj.sha256.should eq OpenSSL::Digest.new("sha256").update("some-content-4").final.hexstring
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/ca_apm_agent_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/ca_apm_agent_spec.cr
@@ -1,27 +1,30 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/ca_apm_agent"
 
-Spec2.describe Depwatcher::CaApmAgent do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/apm_agents.html")))
-    client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/CA-APM-PHPAgent-10.6.0_linux.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::CaApmAgent do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq ["10.6.0", "10.7.0"]
+      client = HTTPClientMock.new
+      subject = Depwatcher::CaApmAgent.new.tap { |s| s.client = client }
+      client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/apm_agents.html")))
+      client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/CA-APM-PHPAgent-10.6.0_linux.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
+      subject.check.map(&.ref).should eq ["10.6.0", "10.7.0"]
     end
   end
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::CaApmAgent.new.tap { |s| s.client = client }
+      client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/apm_agents.html")))
+      client.stub_get("https://packages.broadcom.com/artifactory/apm-agents/CA-APM-PHPAgent-10.6.0_linux.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
       obj = subject.in("10.6.0")
-      expect(obj.ref).to eq "10.6.0"
-      expect(obj.url).to eq "https://packages.broadcom.com/artifactory/apm-agents/CA-APM-PHPAgent-10.6.0_linux.tar.gz"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "10.6.0"
+      obj.url.should eq "https://packages.broadcom.com/artifactory/apm-agents/CA-APM-PHPAgent-10.6.0_linux.tar.gz"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/cran_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/cran_spec.cr
@@ -1,43 +1,48 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/cran"
 
-Spec2.describe Depwatcher::CRAN do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://cran.r-project.org/web/packages/Rserve/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rserve.html")))
-    client.stub_get("https://cran.r-project.org/web/packages/forecast/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/forecast.html")))
-    client.stub_get("https://cran.r-project.org/web/packages/shiny/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/shiny.html")))
-    client.stub_get("https://cran.r-project.org/web/packages/plumber/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/plumber.html")))
-  end
-
+describe Depwatcher::CRAN do
   describe "#check" do
     it "returns the latest release in semver form" do
-      expect(subject.check("Rserve").map(&.ref)).to eq [ "1.7.3" ]
-      expect(subject.check("forecast").map(&.ref)).to eq [ "8.4" ]
-      expect(subject.check("shiny").map(&.ref)).to eq [ "1.2.0" ]
-      expect(subject.check("plumber").map(&.ref)).to eq [ "0.4.6" ]
+      client = HTTPClientMock.new
+      subject = Depwatcher::CRAN.new.tap { |s| s.client = client }
+      client.stub_get("https://cran.r-project.org/web/packages/Rserve/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rserve.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/forecast/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/forecast.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/shiny/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/shiny.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/plumber/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/plumber.html")))
+      
+      subject.check("Rserve").map(&.ref).should eq [ "1.7.3" ]
+      subject.check("forecast").map(&.ref).should eq [ "8.4" ]
+      subject.check("shiny").map(&.ref).should eq [ "1.2.0" ]
+      subject.check("plumber").map(&.ref).should eq [ "0.4.6" ]
     end
   end
 
   describe "#in" do
     it "returns the latest release download url" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::CRAN.new.tap { |s| s.client = client }
+      client.stub_get("https://cran.r-project.org/web/packages/Rserve/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rserve.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/forecast/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/forecast.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/shiny/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/shiny.html")))
+      client.stub_get("https://cran.r-project.org/web/packages/plumber/index.html", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/plumber.html")))
+      
       obj = subject.in("Rserve", "1.7.3")
-      expect(obj.ref).to eq "1.7.3"
-      expect(obj.url).to eq "https://cran.r-project.org/src/contrib/Rserve_1.7-3.tar.gz"
+      obj.ref.should eq "1.7.3"
+      obj.url.should eq "https://cran.r-project.org/src/contrib/Rserve_1.7-3.tar.gz"
 
       obj = subject.in("forecast", "8.4")
-      expect(obj.ref).to eq "8.4"
-      expect(obj.url).to eq "https://cran.r-project.org/src/contrib/forecast_8.4.tar.gz"
+      obj.ref.should eq "8.4"
+      obj.url.should eq "https://cran.r-project.org/src/contrib/forecast_8.4.tar.gz"
 
       obj = subject.in("shiny", "1.2.0")
-      expect(obj.ref).to eq "1.2.0"
-      expect(obj.url).to eq "https://cran.r-project.org/src/contrib/shiny_1.2.0.tar.gz"
+      obj.ref.should eq "1.2.0"
+      obj.url.should eq "https://cran.r-project.org/src/contrib/shiny_1.2.0.tar.gz"
 
       obj = subject.in("plumber", "0.4.6")
-      expect(obj.ref).to eq "0.4.6"
-      expect(obj.url).to eq "https://cran.r-project.org/src/contrib/plumber_0.4.6.tar.gz"
+      obj.ref.should eq "0.4.6"
+      obj.url.should eq "https://cran.r-project.org/src/contrib/plumber_0.4.6.tar.gz"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/dotnet_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/dotnet_spec.cr
@@ -1,225 +1,410 @@
-require "spec2"
+require "spec"
+require "file_utils"
 require "./httpclient_mock"
 require "../../src/depwatcher/dotnet"
 
-Spec2.describe Depwatcher::DotnetBase do
-  let(dirname) { File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64) }
-  let(client) { HTTPClientMock.new }
-
-  before do
-    Dir.mkdir dirname
-    client.stub_get(
-      "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
-      nil,
-      HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
-    )
-  end
-
-  after do
-    FileUtils.rm_rf dirname
-  end
-
+describe Depwatcher::DotnetBase do
   context "DotnetSdk" do
-    subject { Depwatcher::DotnetSdk.new.tap { |s| s.client = client } }
-
     describe "#check" do
       it "returns dotnet sdk release versions sorted" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
+        
         checked_deps = subject.check("2.1.7X")
-        expect(checked_deps.map(&.ref)).to eq ["2.1.700", "2.1.701"]
+        checked_deps.map(&.ref).should eq ["2.1.700", "2.1.701"]
+        
+        FileUtils.rm_rf dirname
       end
 
-      context "when the version is latest" do
-        before do
-          client.stub_get(
-            "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json",
-            nil,
-            HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-releases-index.json"))
-          )
-          client.stub_get(
-            "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/3.0/releases.json",
-            nil,
-            HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-3.0_releases.json"))
-          )
-        end
+      it "uses the latest version" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-releases-index.json"))
+        )
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/3.0/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-3.0_releases.json"))
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
 
-        it "uses the latest version" do
-          checked_deps = subject.check("latest")
-          expect(checked_deps.map(&.ref)).to eq ["3.0.100"]
-        end
+        checked_deps = subject.check("latest")
+        checked_deps.map(&.ref).should eq ["3.0.100"]
+        
+        FileUtils.rm_rf dirname
       end
 
-      context "when the version is latest and the latest version is a preview" do
-        before do
-          client.stub_get(
-            "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json",
-            nil,
-            HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-releases-index-with-preview.json"))
-          )
-          client.stub_get(
-            "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/3.1/releases.json",
-            nil,
-            HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-3.1_releases.json"))
-          )
-        end
+      it "uses the latest version when latest is preview" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-releases-index-with-preview.json"))
+        )
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/3.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-3.1_releases.json"))
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
 
-        it "uses the latest version" do
-          checked_deps = subject.check("latest")
-          expect(checked_deps.map(&.ref)).to eq ["3.1.100", "3.1.101", "3.1.200", "3.1.201"]
-        end
+        checked_deps = subject.check("latest")
+        checked_deps.map(&.ref).should eq ["3.1.100", "3.1.101", "3.1.200", "3.1.201"]
+        
+        FileUtils.rm_rf dirname
       end
     end
 
     describe "#in" do
-      before do
+      it "returns a release object for the version" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
         client.stub_get(
           "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz",
           HTTP::Headers{"Accept" => "application/octet-stream"},
           HTTP::Client::Response.new(200, body: "dummy sdk data")
         )
-      end
-
-      it "returns a release object for the version" do
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.701", dirname).not_nil!
-        expect(obj.ref).to eq "2.1.701"
-        expect(obj.url).to eq "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz"
-        expect(obj.sha512).to eq "238b5049593ae6aa9a5f34473ad890b84487ae1cd2129a9878e074b0217f1ebe7b849d7e3376a437941437b918ab3990cea5fe3fb0305e9e76bc5da0e33aafac"
+        obj.ref.should eq "2.1.701"
+        obj.url.should eq "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz"
+        obj.sha512.should eq "238b5049593ae6aa9a5f34473ad890b84487ae1cd2129a9878e074b0217f1ebe7b849d7e3376a437941437b918ab3990cea5fe3fb0305e9e76bc5da0e33aafac"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "writes the runtime version to a file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy sdk data")
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
+        
         subject.in("2.1.701", dirname)
         runtime_version = File.read(File.join(dirname, "runtime_version"))
-        expect(runtime_version).to eq "2.1.12"
+        runtime_version.should eq "2.1.12"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "downloads the file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy sdk data")
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.701", dirname).not_nil!
         hash = OpenSSL::Digest.new("SHA512")
         hash.update(File.read(File.join(dirname, "dotnet-sdk-2.1.701-linux-x64.tar.gz")))
-        expect(hash.hexdigest).to eq obj.sha512
+        hash.final.hexstring.should eq obj.sha512
+        
+        FileUtils.rm_rf dirname
       end
 
-      context "bad hash" do
-        before do
-          client.stub_get(
-            "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz",
-            HTTP::Headers{"Accept" => "application/octet-stream"},
-            HTTP::Client::Response.new(200, body: "corrupt sdk data")
-          )
-        end
+      it "raises an error on bad hash" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/4609998f-2a88-403e-9273-c0d0529cab86/83bd75418eac15dd751c124ad624f1d7/dotnet-sdk-2.1.701-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "corrupt sdk data")
+        )
+        subject = Depwatcher::DotnetSdk.new.tap { |s| s.client = client }
 
-        it "raises an error" do
-          expect { subject.in("2.1.701", dirname) }.to raise_error(Exception, "Expected hash: 238b5049593ae6aa9a5f34473ad890b84487ae1cd2129a9878e074b0217f1ebe7b849d7e3376a437941437b918ab3990cea5fe3fb0305e9e76bc5da0e33aafac : Got hash: 3b81200d7e61008fbe5ebc62cb88ce65f88efb1fca2b39329d6daec2e7dd213dc516a099f24486dfec32112844ec57d0b2e7a98a146468654233c98b8245956a")
+        expect_raises(Exception, "Expected hash: 238b5049593ae6aa9a5f34473ad890b84487ae1cd2129a9878e074b0217f1ebe7b849d7e3376a437941437b918ab3990cea5fe3fb0305e9e76bc5da0e33aafac : Got hash: 3b81200d7e61008fbe5ebc62cb88ce65f88efb1fca2b39329d6daec2e7dd213dc516a099f24486dfec32112844ec57d0b2e7a98a146468654233c98b8245956a") do
+          subject.in("2.1.701", dirname)
         end
+        
+        FileUtils.rm_rf dirname
       end
     end
   end
 
   context "DotnetRuntime" do
-    subject { Depwatcher::DotnetRuntime.new.tap { |s| s.client = client } }
-
     describe "#check" do
       it "returns dotnet runtime release versions sorted" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        subject = Depwatcher::DotnetRuntime.new.tap { |s| s.client = client }
+        
         checked_deps = subject.check("2.1.X")
-        expect(checked_deps.map(&.ref)).to eq ["2.1.0", "2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7", "2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13"]
+        checked_deps.map(&.ref).should eq ["2.1.0", "2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7", "2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13"]
+        
+        FileUtils.rm_rf dirname
       end
     end
 
     describe "#in" do
-      before do
+      it "returns a release object for the version" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
         client.stub_get(
           "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz",
           HTTP::Headers{"Accept" => "application/octet-stream"},
           HTTP::Client::Response.new(200, body: "dummy dotnet runtime data")
         )
-      end
-
-      it "returns a release object for the version" do
+        subject = Depwatcher::DotnetRuntime.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.12", dirname).not_nil!
-        expect(obj.ref).to eq "2.1.12"
-        expect(obj.url).to eq "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz"
-        expect(obj.sha512).to eq "cbf2e9d45ae7f275e3b75091f36a95411129d703df856c17f9758673e04a6282eae8dfacea5cc55ab718eb63a8f467c9e3c4ca6c6277a1a3bbddf00b63cebb6c"
+        obj.ref.should eq "2.1.12"
+        obj.url.should eq "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz"
+        obj.sha512.should eq "cbf2e9d45ae7f275e3b75091f36a95411129d703df856c17f9758673e04a6282eae8dfacea5cc55ab718eb63a8f467c9e3c4ca6c6277a1a3bbddf00b63cebb6c"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "writes the runtime version to a file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy dotnet runtime data")
+        )
+        subject = Depwatcher::DotnetRuntime.new.tap { |s| s.client = client }
+        
         subject.in("2.1.12", dirname)
         runtime_version = File.read(File.join(dirname, "runtime_version"))
-        expect(runtime_version).to eq "2.1.12"
+        runtime_version.should eq "2.1.12"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "downloads the file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy dotnet runtime data")
+        )
+        subject = Depwatcher::DotnetRuntime.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.12", dirname).not_nil!
         hash = OpenSSL::Digest.new("SHA512")
         hash.update(File.read(File.join(dirname, "dotnet-runtime-2.1.12-linux-x64.tar.gz")))
-        expect(hash.hexdigest).to eq obj.sha512
+        hash.final.hexstring.should eq obj.sha512
+        
+        FileUtils.rm_rf dirname
       end
 
-      context "bad hash" do
-        before do
-          client.stub_get(
-            "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz",
-            HTTP::Headers{"Accept" => "application/octet-stream"},
-            HTTP::Client::Response.new(200, body: "corrupt dotnet runtime data")
-          )
-        end
+      it "raises an error on bad hash" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/2c78594a-dd2c-488e-b201-b7fd9b78ab00/5f2169b20fc704e069c336114ec653c5/dotnet-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "corrupt dotnet runtime data")
+        )
+        subject = Depwatcher::DotnetRuntime.new.tap { |s| s.client = client }
 
-        it "raises an error" do
-          expect { subject.in("2.1.12", dirname) }.to raise_error(Exception, "Expected hash: cbf2e9d45ae7f275e3b75091f36a95411129d703df856c17f9758673e04a6282eae8dfacea5cc55ab718eb63a8f467c9e3c4ca6c6277a1a3bbddf00b63cebb6c : Got hash: 273b7fb6dfa81fbdc46e7509fd69f6c47717f05d91e76da6d7ed857b925a3edafd3df01c21a78aae55336d834d188f1a3103e25d6a75f18d6090c5797409f60e")
+        expect_raises(Exception, "Expected hash: cbf2e9d45ae7f275e3b75091f36a95411129d703df856c17f9758673e04a6282eae8dfacea5cc55ab718eb63a8f467c9e3c4ca6c6277a1a3bbddf00b63cebb6c : Got hash: 273b7fb6dfa81fbdc46e7509fd69f6c47717f05d91e76da6d7ed857b925a3edafd3df01c21a78aae55336d834d188f1a3103e25d6a75f18d6090c5797409f60e") do
+          subject.in("2.1.12", dirname)
         end
+        
+        FileUtils.rm_rf dirname
       end
     end
   end
 
   context "AspnetcoreRuntime" do
-    subject { Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client } }
-
     describe "#check" do
       it "returns dotnet sdk release versions sorted" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        subject = Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client }
+        
         checked_deps = subject.check("2.1.X")
-        expect(checked_deps.map(&.ref)).to eq ["2.1.0", "2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7", "2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13"]
+        checked_deps.map(&.ref).should eq ["2.1.0", "2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7", "2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13"]
+        
+        FileUtils.rm_rf dirname
       end
     end
 
     describe "#in" do
-      before do
+      it "returns a release object for the version" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
         client.stub_get(
           "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz",
           HTTP::Headers{"Accept" => "application/octet-stream"},
           HTTP::Client::Response.new(200, body: "dummy aspnetcore runtime data")
         )
-      end
-
-      it "returns a release object for the version" do
+        subject = Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.12", dirname).not_nil!
-        expect(obj.ref).to eq "2.1.12"
-        expect(obj.url).to eq "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz"
-        expect(obj.sha512).to eq "138bbc69b94303fa2f151b32ef60873917090949a8e70bcf538765bb813fa015aadf7ef8c59f708166bb812e0e05fc64c73a70885a7cae7a0c1182e50c896f9b"
+        obj.ref.should eq "2.1.12"
+        obj.url.should eq "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz"
+        obj.sha512.should eq "138bbc69b94303fa2f151b32ef60873917090949a8e70bcf538765bb813fa015aadf7ef8c59f708166bb812e0e05fc64c73a70885a7cae7a0c1182e50c896f9b"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "writes the runtime version to a file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy aspnetcore runtime data")
+        )
+        subject = Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client }
+        
         subject.in("2.1.12", dirname)
         runtime_version = File.read(File.join(dirname, "runtime_version"))
-        expect(runtime_version).to eq "2.1.12"
+        runtime_version.should eq "2.1.12"
+        
+        FileUtils.rm_rf dirname
       end
 
       it "downloads the file" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "dummy aspnetcore runtime data")
+        )
+        subject = Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client }
+        
         obj = subject.in("2.1.12", dirname).not_nil!
         hash = OpenSSL::Digest.new("SHA512")
         hash.update(File.read(File.join(dirname, "aspnetcore-runtime-2.1.12-linux-x64.tar.gz")))
-        expect(hash.hexdigest).to eq obj.sha512
+        hash.final.hexstring.should eq obj.sha512
+        
+        FileUtils.rm_rf dirname
       end
 
-      context "bad hash" do
-        before do
-          client.stub_get(
-            "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz",
-            HTTP::Headers{"Accept" => "application/octet-stream"},
-            HTTP::Client::Response.new(200, body: "corrupt aspnetcore runtime data")
-          )
-        end
+      it "raises an error on bad hash" do
+        dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new.urlsafe_base64)
+        client = HTTPClientMock.new
+        Dir.mkdir dirname
+        client.stub_get(
+          "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/2.1/releases.json",
+          nil,
+          HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/dotnet-2.1_releases.json"))
+        )
+        client.stub_get(
+          "https://download.visualstudio.microsoft.com/download/pr/c1b620fe-7d8e-4685-b6ae-82b444dbc7a7/3d5610f0607da49ee014c61c6cd4e9af/aspnetcore-runtime-2.1.12-linux-x64.tar.gz",
+          HTTP::Headers{"Accept" => "application/octet-stream"},
+          HTTP::Client::Response.new(200, body: "corrupt aspnetcore runtime data")
+        )
+        subject = Depwatcher::AspnetcoreRuntime.new.tap { |s| s.client = client }
 
-        it "raises an error" do
-          expect { subject.in("2.1.12", dirname) }.to raise_error(Exception, "Expected hash: 138bbc69b94303fa2f151b32ef60873917090949a8e70bcf538765bb813fa015aadf7ef8c59f708166bb812e0e05fc64c73a70885a7cae7a0c1182e50c896f9b : Got hash: 1a10e26187fee5a2c30a8a6d93c392f1ca8e0b6e954dcea2deefe51e6f16f75480f830aeb645590b9f83442e2f2843a7c5febf43357d484a55c777f6e232e532")
+        expect_raises(Exception, "Expected hash: 138bbc69b94303fa2f151b32ef60873917090949a8e70bcf538765bb813fa015aadf7ef8c59f708166bb812e0e05fc64c73a70885a7cae7a0c1182e50c896f9b : Got hash: 1a10e26187fee5a2c30a8a6d93c392f1ca8e0b6e954dcea2deefe51e6f16f75480f830aeb645590b9f83442e2f2843a7c5febf43357d484a55c777f6e232e532") do
+          subject.in("2.1.12", dirname)
         end
+        
+        FileUtils.rm_rf dirname
       end
     end
   end

--- a/dockerfiles/depwatcher/spec/depwatcher/github_releases_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/github_releases_spec.cr
@@ -1,74 +1,115 @@
-require "spec2"
+require "spec"
 require "file_utils"
 require "./httpclient_mock"
 require "../../src/depwatcher/github_releases"
 
-Spec2.describe Depwatcher::GithubReleases do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
-    client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
-    client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
-    client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
-  end
-
+describe Depwatcher::GithubReleases do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check("yarnpkg/yarn", false).map(&.ref)).to eq ["1.5.1", "1.6.0"]
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      subject.check("yarnpkg/yarn", false).map(&.ref).should eq ["1.5.1", "1.6.0"]
     end
 
     it "returns pre-releases and real releases sorted" do
-      expect(subject.check("yarnpkg/yarn", true).map(&.ref)).to eq ["0.0.1", "1.5.1", "1.6.0"]
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      subject.check("yarnpkg/yarn", true).map(&.ref).should eq ["0.0.1", "1.5.1", "1.6.0"]
     end
 
     it "doesn't return alpha and rc releases" do
-      expect(subject.check("composer/composer", true).map(&.ref)).to eq ["1.10.6", "1.10.7", "1.10.8"]
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      subject.check("composer/composer", true).map(&.ref).should eq ["1.10.6", "1.10.7", "1.10.8"]
     end
   end
 
   describe "#in" do
-    let(dirname) {
-      File.join(Dir.tempdir, "github_releases_spec-" + Random.new().urlsafe_base64())
-    }
-    before do
+    it "returns a release object for the version with binary" do
+      dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new().urlsafe_base64())
       Dir.mkdir dirname
-    end
-
-    after do
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      obj = subject.in("yarnpkg/yarn", "tar.gz", "1.5.1", dirname)
+      obj.ref.should eq "1.5.1"
+      obj.url.should eq "https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz"
+      obj.sha256.should eq "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
+      
       FileUtils.rm_rf dirname
     end
 
-    context "when fetching a binary" do
-      it "returns a release object for the version" do
-        obj = subject.in("yarnpkg/yarn", "tar.gz", "1.5.1", dirname)
-        expect(obj.ref).to eq "1.5.1"
-        expect(obj.url).to eq "https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz"
-        expect(obj.sha256).to eq "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
-      end
-
-      it "downloads the file" do
-        obj = subject.in("yarnpkg/yarn", "tar.gz", "1.5.1", dirname)
-        hash = OpenSSL::Digest.new("SHA256")
-        hash.update(File.read(File.join(dirname, "yarn-v1.5.1.tar.gz")))
-        expect(hash.hexdigest).to eq obj.sha256
-      end
+    it "downloads the file with binary" do
+      dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new().urlsafe_base64())
+      Dir.mkdir dirname
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      obj = subject.in("yarnpkg/yarn", "tar.gz", "1.5.1", dirname)
+      hash = OpenSSL::Digest.new("SHA256")
+      hash.update(File.read(File.join(dirname, "yarn-v1.5.1.tar.gz")))
+      hash.final.hexstring.should eq obj.sha256
+      
+      FileUtils.rm_rf dirname
     end
 
-    context "when fetching raw source code" do
-      it "returns a release object for the version" do
-        obj = subject.in("yarnpkg/yarn", "1.5.1", dirname)
-        expect(obj.ref).to eq "1.5.1"
-        expect(obj.url).to eq "https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz"
-        expect(obj.sha256).to eq "04d4ca87acce59d80d59e00e850e4bbc3a996aa8761fec218bcba0beab2412bd"
-      end
+    it "returns a release object for the version with source code" do
+      dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new().urlsafe_base64())
+      Dir.mkdir dirname
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      obj = subject.in("yarnpkg/yarn", "1.5.1", dirname)
+      obj.ref.should eq "1.5.1"
+      obj.url.should eq "https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz"
+      obj.sha256.should eq "04d4ca87acce59d80d59e00e850e4bbc3a996aa8761fec218bcba0beab2412bd"
+      
+      FileUtils.rm_rf dirname
+    end
 
-      it "downloads the file" do
-        obj = subject.in("yarnpkg/yarn", "1.5.1", dirname)
-        hash = OpenSSL::Digest.new("SHA256")
-        hash.update(File.read(File.join(dirname, "v1.5.1.tar.gz")))
-        expect(hash.hexdigest).to eq obj.sha256
-      end
+    it "downloads the file with source code" do
+      dirname = File.join(Dir.tempdir, "github_releases_spec-" + Random.new().urlsafe_base64())
+      Dir.mkdir dirname
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/yarnpkg/yarn/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_yarn.json")))
+      client.stub_get("https://api.github.com/repos/composer/composer/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_composer.json")))
+      client.stub_get("https://github.com/yarnpkg/yarn/releases/download/v1.5.1/yarn-v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      client.stub_get("https://github.com/yarnpkg/yarn/archive/v1.5.1.tar.gz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "different dummy data"))
+      subject = Depwatcher::GithubReleases.new.tap { |s| s.client = client }
+      
+      obj = subject.in("yarnpkg/yarn", "1.5.1", dirname)
+      hash = OpenSSL::Digest.new("SHA256")
+      hash.update(File.read(File.join(dirname, "v1.5.1.tar.gz")))
+      hash.final.hexstring.should eq obj.sha256
+      
+      FileUtils.rm_rf dirname
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/github_tags_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/github_tags_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/github_tags"
 
-Spec2.describe Depwatcher::GithubTags do
-  let(client) {HTTPClientMock.new}
-  subject {described_class.new.tap {|s| s.client = client}}
-  before do
-    client.stub_get("https://api.github.com/repos/dotnet/cli/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_tags.json")))
-    client.stub_get("https://github.com/dotnet/cli/archive/2edba8d7f10739031100193636112628263f669c.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::GithubTags do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check("dotnet/cli", "^v[0-9]").map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/dotnet/cli/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_tags.json")))
+      client.stub_get("https://github.com/dotnet/cli/archive/2edba8d7f10739031100193636112628263f669c.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::GithubTags.new.tap {|s| s.client = client}
+      
+      subject.check("dotnet/cli", "^v[0-9]").map(&.ref).should eq [
         "v1.0.4", "v1.1.0", "v1.1.0-preview1-005051", "v1.1.0-preview1-005077", "v1.1.3",
         "v1.1.4", "v1.1.5", "v1.1.6", "v1.1.7", "v1.1.8", "v1.1.9", "v2.0.0", "v2.0.0-preview1",
         "v2.0.0-preview2", "v2.0.2", "v2.0.3", "v2.1.1-preview-007183", "v2.1.2", "v2.1.3",
@@ -24,11 +22,16 @@ Spec2.describe Depwatcher::GithubTags do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/dotnet/cli/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_tags.json")))
+      client.stub_get("https://github.com/dotnet/cli/archive/2edba8d7f10739031100193636112628263f669c.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::GithubTags.new.tap {|s| s.client = client}
+      
       obj = subject.in("dotnet/cli", "v2.1.200")
-      expect(obj.ref).to eq "v2.1.200"
-      expect(obj.url).to eq "https://github.com/dotnet/cli/archive/2edba8d7f10739031100193636112628263f669c.tar.gz"
-      expect(obj.git_commit_sha).to eq "2edba8d7f10739031100193636112628263f669c"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "v2.1.200"
+      obj.url.should eq "https://github.com/dotnet/cli/archive/2edba8d7f10739031100193636112628263f669c.tar.gz"
+      obj.git_commit_sha.should eq "2edba8d7f10739031100193636112628263f669c"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/go_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/go_spec.cr
@@ -1,17 +1,15 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/go"
 
-Spec2.describe Depwatcher::Go do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://go.dev/dl/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/golang.html")))
-  end
-
+describe Depwatcher::Go do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Go.new.tap { |s| s.client = client }
+      client.stub_get("https://go.dev/dl/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/golang.html")))
+      
+      subject.check.map(&.ref).should eq [
         "1.2.2", "1.3", "1.3.1", "1.3.2", "1.3.3", "1.4", "1.4.1", "1.4.2",
         "1.4.3", "1.5", "1.5.1", "1.5.2", "1.5.3", "1.5.4", "1.6", "1.6.1",
         "1.6.2", "1.6.3", "1.6.4", "1.7", "1.7.1", "1.7.3", "1.7.4", "1.7.5",
@@ -39,10 +37,14 @@ Spec2.describe Depwatcher::Go do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Go.new.tap { |s| s.client = client }
+      client.stub_get("https://go.dev/dl/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/golang.html")))
+      
       obj = subject.in("1.8.4")
-      expect(obj.ref).to eq "1.8.4"
-      expect(obj.url).to eq "https://dl.google.com/go/go1.8.4.src.tar.gz"
-      expect(obj.sha256).to eq "abf1b2e5ae2a4845f3d2eac00c7382ff209e2c132dc35b7ce753da9b4f52e59f"
+      obj.ref.should eq "1.8.4"
+      obj.url.should eq "https://dl.google.com/go/go1.8.4.src.tar.gz"
+      obj.sha256.should eq "abf1b2e5ae2a4845f3d2eac00c7382ff209e2c132dc35b7ce753da9b4f52e59f"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/httpd_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/httpd_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/httpd"
 
-Spec2.describe Depwatcher::Httpd do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://api.github.com/repos/apache/httpd/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd_tags.json")))
-    client.stub_get("https://archive.apache.org/dist/httpd-.*tar/.bz2.*tar\.bz2\.sha256", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd.sha256")))
-  end
-
+describe Depwatcher::Httpd do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq ["2.4.40", "2.4.41", "2.4.42", "2.4.43", "2.4.44", 
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/apache/httpd/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd_tags.json")))
+      client.stub_get("https://archive.apache.org/dist/httpd-.*tar/.bz2.*tar\.bz2\.sha256", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd.sha256")))
+      subject = Depwatcher::Httpd.new.tap { |s| s.client = client }
+      
+      subject.check.map(&.ref).should eq ["2.4.40", "2.4.41", "2.4.42", "2.4.43", "2.4.44", 
       "2.4.45", "2.4.46", "2.4.47", "2.4.48", "2.4.49", "2.4.50", "2.4.51", "2.4.52", "2.4.53", 
       "2.4.54", "2.4.55", "2.4.56", "2.4.57", "2.4.58", "2.4.59"]
     end
@@ -20,10 +18,15 @@ Spec2.describe Depwatcher::Httpd do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/apache/httpd/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd_tags.json")))
+      client.stub_get("https://archive.apache.org/dist/httpd-.*tar/.bz2.*tar\.bz2\.sha256", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/httpd.sha256")))
+      subject = Depwatcher::Httpd.new.tap { |s| s.client = client }
+      
       obj = subject.in("2.4.29")
-      expect(obj.ref).to eq "2.4.29"
-      expect(obj.url).to eq "https://dlcdn.apache.org/httpd/httpd-2.4.29.tar.bz2"
-      expect(obj.sha256).to eq "777753a5a25568a2a27428b2214980564bc1c38c1abf9ccc7630b639991f7f00"
+      obj.ref.should eq "2.4.29"
+      obj.url.should eq "https://dlcdn.apache.org/httpd/httpd-2.4.29.tar.bz2"
+      obj.sha256.should eq "777753a5a25568a2a27428b2214980564bc1c38c1abf9ccc7630b639991f7f00"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/icu_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/icu_spec.cr
@@ -1,46 +1,51 @@
-require "spec2"
+require "spec"
 require "file_utils"
 require "./httpclient_mock"
 require "../../src/depwatcher/icu"
 
-Spec2.describe Depwatcher::Icu do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://api.github.com/repos/unicode-org/icu/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_icu.json")))
-    client.stub_get("https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
-  end
-
+describe Depwatcher::Icu do
   describe "#check" do
     it "returns sorted versions as valid semvers" do
-      expect(subject.check().map(&.ref)).to eq ["4.8.2", "64.2.0", "65.1.0"]
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/unicode-org/icu/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_icu.json")))
+      client.stub_get("https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      subject = Depwatcher::Icu.new.tap { |s| s.client = client }
+      
+      subject.check().map(&.ref).should eq ["4.8.2", "64.2.0", "65.1.0"]
     end
   end
 
   describe "#in" do
-    let(dirname) {
-      File.join(Dir.tempdir, "icu_spec-" + Random.new().urlsafe_base64())
-    }
-    before do
+    it "returns a release object for the version" do
+      dirname = File.join(Dir.tempdir, "icu_spec-" + Random.new().urlsafe_base64())
       Dir.mkdir dirname
-    end
-
-    after do
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/unicode-org/icu/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_icu.json")))
+      client.stub_get("https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      subject = Depwatcher::Icu.new.tap { |s| s.client = client }
+      
+      obj = subject.in("65.1.0", dirname)
+      obj.ref.should eq "65.1.0"
+      obj.url.should eq "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
+      obj.sha256.should eq "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
+      
       FileUtils.rm_rf dirname
     end
 
-    it "returns a release object for the version" do
-      obj = subject.in("65.1.0", dirname)
-      expect(obj.ref).to eq "65.1.0"
-      expect(obj.url).to eq "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
-      expect(obj.sha256).to eq "797bb0abff798d7200af7685dca7901edffc52bf26500d5bd97282658ee24152"
-    end
-
     it "downloads the file" do
+      dirname = File.join(Dir.tempdir, "icu_spec-" + Random.new().urlsafe_base64())
+      Dir.mkdir dirname
+      client = HTTPClientMock.new
+      client.stub_get("https://api.github.com/repos/unicode-org/icu/releases", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/gh_icu.json")))
+      client.stub_get("https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz", HTTP::Headers{"Accept" => "application/octet-stream"}, HTTP::Client::Response.new(200, body: "dummy data"))
+      subject = Depwatcher::Icu.new.tap { |s| s.client = client }
+      
       obj = subject.in("65.1.0", dirname)
       hash = OpenSSL::Digest.new("SHA256")
       hash.update(File.read(File.join(dirname, "icu4c-65_1-src.tgz")))
-      expect(hash.hexdigest).to eq obj.sha256
+      hash.final.hexstring.should eq obj.sha256
+      
+      FileUtils.rm_rf dirname
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/jruby_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/jruby_spec.cr
@@ -1,27 +1,30 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/jruby"
 
-Spec2.describe Depwatcher::JRuby do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.0.0/jruby-dist-9.2.0.0-src.zip.sha256", nil, HTTP::Client::Response.new(200, "3d59bde1639c69965664ee46a07be230141ee8e99d2e7f43b574a6a8298c887c\n"))
-    client.stub_get("https://www.jruby.org/download", nil, HTTP::Client::Response.new(200, File.read(File.join(__DIR__,"..", "fixtures", "jruby.html"))))
-  end
-
+describe Depwatcher::JRuby do
   describe "#check" do
     it "returns releases sorted" do
-      expect(subject.check().map(&.ref)).to eq ["9.1.17.0", "9.2.0.0"]
+      client = HTTPClientMock.new
+      client.stub_get("https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.0.0/jruby-dist-9.2.0.0-src.zip.sha256", nil, HTTP::Client::Response.new(200, "3d59bde1639c69965664ee46a07be230141ee8e99d2e7f43b574a6a8298c887c\n"))
+      client.stub_get("https://www.jruby.org/download", nil, HTTP::Client::Response.new(200, File.read(File.join(__DIR__,"..", "fixtures", "jruby.html"))))
+      subject = Depwatcher::JRuby.new.tap { |s| s.client = client }
+      
+      subject.check().map(&.ref).should eq ["9.1.17.0", "9.2.0.0"]
     end
   end
 
   describe "#in" do
     it "returns the release version, url, sha256" do
-     obj = subject.in("9.2.0.0")
-     expect(obj.ref).to eq "9.2.0.0"
-     expect(obj.url).to eq "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.0.0/jruby-dist-9.2.0.0-src.zip"
-     expect(obj.sha256).to eq "3d59bde1639c69965664ee46a07be230141ee8e99d2e7f43b574a6a8298c887c"
-   end
- end
+      client = HTTPClientMock.new
+      client.stub_get("https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.0.0/jruby-dist-9.2.0.0-src.zip.sha256", nil, HTTP::Client::Response.new(200, "3d59bde1639c69965664ee46a07be230141ee8e99d2e7f43b574a6a8298c887c\n"))
+      client.stub_get("https://www.jruby.org/download", nil, HTTP::Client::Response.new(200, File.read(File.join(__DIR__,"..", "fixtures", "jruby.html"))))
+      subject = Depwatcher::JRuby.new.tap { |s| s.client = client }
+      
+      obj = subject.in("9.2.0.0")
+      obj.ref.should eq "9.2.0.0"
+      obj.url.should eq "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.0.0/jruby-dist-9.2.0.0-src.zip"
+      obj.sha256.should eq "3d59bde1639c69965664ee46a07be230141ee8e99d2e7f43b574a6a8298c887c"
+    end
+  end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/miniconda_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/miniconda_spec.cr
@@ -1,39 +1,57 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/miniconda"
 
-Spec2.describe Depwatcher::Miniconda do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
-    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
-    client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::Miniconda do
   describe "#check" do
     it "returns real linux releases for miniconda3-py39 sorted" do
-      expect(subject.check("3.9").map(&.ref)).to eq ["22.11.1", "23.1.0",
+      client = HTTPClientMock.new
+      client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::Miniconda.new.tap { |s| s.client = client }
+      
+      subject.check("3.9").map(&.ref).should eq ["22.11.1", "23.1.0",
       "23.3.1", "23.5.0", "23.5.1", "23.5.2"]
     end
+    
     it "returns real linux releases for miniconda3-py38 sorted" do
-      expect(subject.check("3.8").map(&.ref)).to eq ["22.11.1", "23.1.0",
+      client = HTTPClientMock.new
+      client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::Miniconda.new.tap { |s| s.client = client }
+      
+      subject.check("3.8").map(&.ref).should eq ["22.11.1", "23.1.0",
       "23.3.1", "23.5.0", "23.5.1", "23.5.2"]
     end
   end
 
   describe "#in" do
     it "returns the release version, url, sha256 for miniconda39" do
+      client = HTTPClientMock.new
+      client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::Miniconda.new.tap { |s| s.client = client }
+      
       obj = subject.in("3.9", "23.1.0")
-      expect(obj.ref).to eq "23.1.0"
-      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh"
-      expect(obj.sha256).to eq "5dc619babc1d19d6688617966251a38d245cb93d69066ccde9a013e1ebb5bf18"
+      obj.ref.should eq "23.1.0"
+      obj.url.should eq "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh"
+      obj.sha256.should eq "5dc619babc1d19d6688617966251a38d245cb93d69066ccde9a013e1ebb5bf18"
     end
+    
     it "returns the release version, url, sha256 for miniconda38" do
+      client = HTTPClientMock.new
+      client.stub_get("https://repo.anaconda.com/miniconda/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/miniconda.html")))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      client.stub_get("https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh", nil, HTTP::Client::Response.new(200, "hello"))
+      subject = Depwatcher::Miniconda.new.tap { |s| s.client = client }
+      
       obj = subject.in("3.8", "23.1.0")
-      expect(obj.ref).to eq "23.1.0"
-      expect(obj.url).to eq "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh"
-      expect(obj.sha256).to eq "640b7dceee6fad10cb7e7b54667b2945c4d6f57625d062b2b0952b7f3a908ab7"
-   end
+      obj.ref.should eq "23.1.0"
+      obj.url.should eq "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh"
+      obj.sha256.should eq "640b7dceee6fad10cb7e7b54667b2945c4d6f57625d062b2b0952b7f3a908ab7"
+    end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/nginx_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/nginx_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/nginx"
 
-Spec2.describe Depwatcher::Nginx do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://api.github.com/repos/nginx/nginx/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_nginx.json")))
-    client.stub_get("http://nginx.org/download/nginx-1.12.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::Nginx do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Nginx.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/nginx/nginx/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_nginx.json")))
+      client.stub_get("http://nginx.org/download/nginx-1.12.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
+      subject.check.map(&.ref).should eq [
        "1.10.1", "1.10.2", "1.10.3", "1.11.0", "1.11.1", "1.11.2", "1.11.3",
        "1.11.4", "1.11.5", "1.11.6", "1.11.7", "1.11.8", "1.11.9", "1.11.10",
        "1.11.11", "1.11.12", "1.11.13", "1.12.0", "1.12.1", "1.12.2", "1.13.0",
@@ -23,11 +21,16 @@ Spec2.describe Depwatcher::Nginx do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Nginx.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/nginx/nginx/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_nginx.json")))
+      client.stub_get("http://nginx.org/download/nginx-1.12.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
       obj = subject.in("1.12.2")
-      expect(obj.ref).to eq "1.12.2"
-      expect(obj.url).to eq "http://nginx.org/download/nginx-1.12.2.tar.gz"
-      expect(obj.pgp).to eq "http://nginx.org/download/nginx-1.12.2.tar.gz.asc"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "1.12.2"
+      obj.url.should eq "http://nginx.org/download/nginx-1.12.2.tar.gz"
+      obj.pgp.should eq "http://nginx.org/download/nginx-1.12.2.tar.gz.asc"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/node_lts_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/node_lts_spec.cr
@@ -1,34 +1,45 @@
-require "spec2"
+require "spec"
+require "./httpclient_mock"
 require "../../src/depwatcher/node_lts"
 
-Spec2.describe Depwatcher::NodeLTS do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-
+describe Depwatcher::NodeLTS do
   describe "#check" do
-    before do
+    it "returns the right number of releases" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::NodeLTS.new.tap { |s| s.client = client }
       client.stub_get("https://raw.githubusercontent.com/nodejs/Release/main/schedule.json",
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_lts_releases.json"))
       )
-
       client.stub_get("https://nodejs.org/dist/",
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
       )
-    end
-    it "returns the right number of releases" do
-      expect(subject.check.size).to eq 3
+      
+      subject.check.size.should eq 3
     end
 
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq  ["22.0.0", "22.1.0", "22.2.0"]
+      client = HTTPClientMock.new
+      subject = Depwatcher::NodeLTS.new.tap { |s| s.client = client }
+      client.stub_get("https://raw.githubusercontent.com/nodejs/Release/main/schedule.json",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_lts_releases.json"))
+      )
+      client.stub_get("https://nodejs.org/dist/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
+      )
+      
+      subject.check.map(&.ref).should eq ["22.0.0", "22.1.0", "22.2.0"]
     end
   end
 
   describe "#in" do
-    let(version) { "6.1.0" }
-    before do
+    it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::NodeLTS.new.tap { |s| s.client = client }
+      version = "6.1.0"
       client.stub_get("https://nodejs.org/dist/v#{version}/",
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_v6.1.0.html"))
@@ -37,12 +48,11 @@ Spec2.describe Depwatcher::NodeLTS do
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_shasum256.txt"))
       )
-    end
-    it "returns real releases sorted" do
+      
       obj = subject.in("6.1.0")
-      expect(obj.ref).to eq "6.1.0"
-      expect(obj.url).to eq "https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz"
-      expect(obj.sha256).to eq "9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3"
+      obj.ref.should eq "6.1.0"
+      obj.url.should eq "https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz"
+      obj.sha256.should eq "9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/node_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/node_spec.cr
@@ -1,36 +1,51 @@
-require "spec2"
+require "spec"
+require "./httpclient_mock"
 require "../../src/depwatcher/node"
 
-Spec2.describe Depwatcher::Node do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-
+describe Depwatcher::Node do
   describe "#check" do
-    before do
+    it "returns the right number of releases" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Node.new.tap { |s| s.client = client }
       client.stub_get("https://nodejs.org/dist/",
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
       )
-    end
-    it "returns the right number of releases" do
-      expect(subject.check.size).to eq 14
+      
+      subject.check.size.should eq 14
     end
 
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq ["14.0.0", "14.5.0", "16.0.0", "16.5.0", "16.9.0", "18.0.0", "18.5.0", "18.9.0", "20.0.0", "20.8.0", "20.9.0", "22.0.0", "22.1.0", "22.2.0"]
+      client = HTTPClientMock.new
+      subject = Depwatcher::Node.new.tap { |s| s.client = client }
+      client.stub_get("https://nodejs.org/dist/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
+      )
+      
+      subject.check.map(&.ref).should eq ["14.0.0", "14.5.0", "16.0.0", "16.5.0", "16.9.0", "18.0.0", "18.5.0", "18.9.0", "20.0.0", "20.8.0", "20.9.0", "22.0.0", "22.1.0", "22.2.0"]
     end
 
     it "returns only non-LTS versions" do
-      expect(subject.check.map(&.ref).select { |v|
+      client = HTTPClientMock.new
+      subject = Depwatcher::Node.new.tap { |s| s.client = client }
+      client.stub_get("https://nodejs.org/dist/",
+        nil,
+        HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_dist.html"))
+      )
+      
+      subject.check.map(&.ref).select { |v|
         semver = Semver.new(v)
         semver.major % 2 != 0
-      }).to eq [] of String
+      }.should eq [] of String
     end
   end
 
   describe "#in" do
-    let(version) { "6.1.0" }
-    before do
+    it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Node.new.tap { |s| s.client = client }
+      version = "6.1.0"
       client.stub_get("https://nodejs.org/dist/v#{version}/",
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_v6.1.0.html"))
@@ -39,12 +54,11 @@ Spec2.describe Depwatcher::Node do
         nil,
         HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/node_shasum256.txt"))
       )
-    end
-    it "returns real releases sorted" do
+      
       obj = subject.in("6.1.0")
-      expect(obj.ref).to eq "6.1.0"
-      expect(obj.url).to eq "https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz"
-      expect(obj.sha256).to eq "9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3"
+      obj.ref.should eq "6.1.0"
+      obj.url.should eq "https://nodejs.org/dist/v6.1.0/node-v6.1.0.tar.gz"
+      obj.sha256.should eq "9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/npm_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/npm_spec.cr
@@ -1,17 +1,15 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/npm"
 
-Spec2.describe Depwatcher::Npm do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://registry.npmjs.com/yarn/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/npm_yarn.json")))
-  end
-
+describe Depwatcher::Npm do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check("yarn").map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      client.stub_get("https://registry.npmjs.com/yarn/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/npm_yarn.json")))
+      subject = Depwatcher::Npm.new.tap { |s| s.client = client }
+      
+      subject.check("yarn").map(&.ref).should eq [
         "1.0.2", "1.1.0", "1.2.0", "1.2.1", "1.3.1", "1.3.2", "1.4.0", "1.5.0", "1.5.1", "1.6.0"
       ]
     end
@@ -19,10 +17,14 @@ Spec2.describe Depwatcher::Npm do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      client.stub_get("https://registry.npmjs.com/yarn/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/npm_yarn.json")))
+      subject = Depwatcher::Npm.new.tap { |s| s.client = client }
+      
       obj = subject.in("yarn", "1.2.1")
-      expect(obj.ref).to eq "1.2.1"
-      expect(obj.url).to eq "https://registry.npmjs.org/yarn/-/yarn-1.2.1.tgz"
-      expect(obj.sha1).to eq "0d628dc01438881a1663a6f83cbf7ac5db7a75fc"
+      obj.ref.should eq "1.2.1"
+      obj.url.should eq "https://registry.npmjs.org/yarn/-/yarn-1.2.1.tgz"
+      obj.sha1.should eq "0d628dc01438881a1663a6f83cbf7ac5db7a75fc"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/openresty_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/openresty_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/openresty"
 
-Spec2.describe Depwatcher::Openresty do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-     client.stub_get("https://api.github.com/repos/openresty/openresty/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_openresty.json")))
-    client.stub_get("http://openresty.org/download/openresty-1.13.6.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::Openresty do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Openresty.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/openresty/openresty/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_openresty.json")))
+      client.stub_get("http://openresty.org/download/openresty-1.13.6.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
+      subject.check.map(&.ref).should eq [
         "1.15.8.3", "1.21.4.2",
       ]
     end
@@ -20,11 +18,16 @@ Spec2.describe Depwatcher::Openresty do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Openresty.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/openresty/openresty/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/github_openresty.json")))
+      client.stub_get("http://openresty.org/download/openresty-1.13.6.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
       obj = subject.in("1.13.6.2")
-      expect(obj.ref).to eq "1.13.6.2"
-      expect(obj.url).to eq "http://openresty.org/download/openresty-1.13.6.2.tar.gz"
-      expect(obj.pgp).to eq "http://openresty.org/download/openresty-1.13.6.2.tar.gz.asc"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "1.13.6.2"
+      obj.url.should eq "http://openresty.org/download/openresty-1.13.6.2.tar.gz"
+      obj.pgp.should eq "http://openresty.org/download/openresty-1.13.6.2.tar.gz.asc"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/php_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/php_spec.cr
@@ -67,6 +67,7 @@ describe Depwatcher::Php do
       client = HTTPClientMock.new
       subject = Depwatcher::Php.new.tap { |s| s.client = client }
       client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      client.stub_get("https://php.net/distributions/php-8.0.1.tar.gz", nil, HTTP::Client::Response.new(200, "mock-tarball-content-for-sha256"))
       
       obj = subject.in("8.0.1")
       obj.ref.should eq "8.0.1"
@@ -78,6 +79,7 @@ describe Depwatcher::Php do
       client = HTTPClientMock.new
       subject = Depwatcher::Php.new.tap { |s| s.client = client }
       client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      client.stub_get("https://php.net/distributions/php-7.4.0.tar.gz", nil, HTTP::Client::Response.new(200, "mock-tarball-content-for-sha256"))
       
       obj = subject.in("7.4.0")
       obj.ref.should eq "7.4.0"

--- a/dockerfiles/depwatcher/spec/depwatcher/php_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/php_spec.cr
@@ -1,219 +1,121 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/php"
+require "../../src/depwatcher/semver"
 
-Spec2.describe Depwatcher::Php do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  
-  before do
-    client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
-  end
-
+describe Depwatcher::Php do
   describe "#check" do
-    context "with version filter" do
-      it "returns filtered releases sorted for PHP 8.0" do
-        # Test with specific version filter using fallback method (since we can't easily mock external commands)
-        results = subject.check("8.0")
-        expect(results).to_not be_empty
-        expect(results.first.ref).to match(/^8\.0\./)
-        
-        # Verify they are sorted
-        refs = results.map(&.ref)
-        sorted_refs = refs.sort_by { |r| Depwatcher::Semver.new(r) }
-        expect(refs).to eq(sorted_refs)
-      end
+    it "returns filtered releases sorted for PHP 8.0" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
       
-      it "returns filtered releases sorted for PHP 7.4" do
-        results = subject.check("7.4")
-        expect(results).to_not be_empty
-        expect(results.first.ref).to match(/^7\.4\./)
-        
-        # Verify they are sorted
-        refs = results.map(&.ref)
-        sorted_refs = refs.sort_by { |r| Depwatcher::Semver.new(r) }
-        expect(refs).to eq(sorted_refs)
-      end
+      results = subject.check("8.0")
+      results.should_not be_empty
+      results.first.ref.should match(/^8\.0\./)
+      
+      refs = results.map(&.ref)
+      sorted_refs = refs.sort_by { |r| Semver.new(r) }
+      refs.should eq(sorted_refs)
     end
     
-    context "HTML fallback method" do
-      it "returns all release versions from HTML when phpwatch unavailable" do
-        # This tests the old_versions() method through fallback
-        results = subject.check("8.1")
-        
-        # Should contain PHP 8.1.x versions from the fixture
-        php81_versions = results.select { |r| r.ref.starts_with?("8.1.") }
-        expect(php81_versions).to_not be_empty
-        php81_refs = php81_versions.map(&.ref)
-        expect(php81_refs.includes?("8.1.0")).to be_true
-        expect(php81_refs.includes?("8.1.1")).to be_true
-      end
+    it "returns filtered releases sorted for PHP 7.4" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
       
-      it "handles versions that were never released" do
-        # Test that missing versions like 7.4.17 and 8.0.4 are not included
-        results = subject.check("7.4")
-        refs = results.map(&.ref)
-        expect(refs).to_not include("7.4.17")
-        
-        results_80 = subject.check("8.0")
-        refs_80 = results_80.map(&.ref)
-        expect(refs_80).to_not include("8.0.4")
-      end
+      results = subject.check("7.4")
+      results.should_not be_empty
+      results.first.ref.should match(/^7\.4\./)
+      
+      refs = results.map(&.ref)
+      sorted_refs = refs.sort_by { |r| Semver.new(r) }
+      refs.should eq(sorted_refs)
+    end
+
+    it "returns all release versions from HTML when phpwatch unavailable" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
+      results = subject.check("8.1")
+      
+      php81_versions = results.select { |r| r.ref.starts_with?("8.1.") }
+      php81_versions.should_not be_empty
+      php81_refs = php81_versions.map(&.ref)
+      php81_refs.includes?("8.1.0").should be_true
+      php81_refs.includes?("8.1.1").should be_true
+    end
+    
+    it "handles versions that were never released" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
+      results = subject.check("7.4")
+      refs = results.map(&.ref)
+      refs.includes?("7.4.17").should be_false
+      
+      results_80 = subject.check("8.0")
+      refs_80 = results_80.map(&.ref)
+      refs_80.includes?("8.0.4").should be_false
     end
   end
 
   describe "#in" do
     it "returns the release version, url, sha256 for a valid version" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
       obj = subject.in("8.0.1")
-      expect(obj.ref).to eq "8.0.1"
-      expect(obj.url).to eq "https://php.net/distributions/php-8.0.1.tar.gz"
-      expect(obj.sha256).to_not be_empty
+      obj.ref.should eq "8.0.1"
+      obj.url.should eq "https://php.net/distributions/php-8.0.1.tar.gz"
+      obj.sha256.should_not be_empty
     end
     
     it "returns the release version, url, sha256 for older versions" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
       obj = subject.in("7.4.0")
-      expect(obj.ref).to eq "7.4.0"
-      expect(obj.url).to eq "https://php.net/distributions/php-7.4.0.tar.gz"
-      expect(obj.sha256).to_not be_empty
+      obj.ref.should eq "7.4.0"
+      obj.url.should eq "https://php.net/distributions/php-7.4.0.tar.gz"
+      obj.sha256.should_not be_empty
     end
   end
   
   describe "#old_versions" do
     it "extracts PHP versions from HTML releases page" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
       results = subject.old_versions()
-      expect(results).to_not be_empty
+      results.should_not be_empty
       
-      # Should contain versions from the fixture
       refs = results.map(&.ref)
-       expect(refs).to include("8.1.1")
-       expect(refs).to include("8.0.14")
-       expect(refs).to include("7.4.26")
-       expect(refs).to include("7.3.33")
+      refs.includes?("8.1.1").should be_true
+      refs.includes?("8.0.14").should be_true
+      refs.includes?("7.4.26").should be_true
+      refs.includes?("7.3.33").should be_true
       
-      # Should only contain PHP 7.x and 8.x versions
       refs.each do |ref|
-        expect(ref).to match(/^[78]\.\d+\.\d+$/)
+        ref.should match(/^[78]\.\d+\.\d+$/)
       end
     end
   end
   
   describe "#get_latest_supported_version" do
     it "returns a version string in major.minor format" do
-      # This will use the fallback method since we can't mock curl commands easily
+      client = HTTPClientMock.new
+      subject = Depwatcher::Php.new.tap { |s| s.client = client }
+      client.stub_get("https://secure.php.net/releases/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/php_releases.php")))
+      
       version = subject.get_latest_supported_version()
-      expect(version).to match(/^\d+\.\d+$/)
-      expect(version.split('.').size).to eq(2)
-    end
-  end
-  
-  describe "XML feed functionality (integration tests)" do
-    # Note: These tests use real external commands and may fail if php.watch is unavailable
-    # They test the actual XML parsing and QA filtering logic
-    
-    context "when php.watch XML feed is available" do
-      it "can parse XML feed and extract stable versions only" do
-        # This test verifies that the XML parsing logic works correctly
-        # and filters out QA releases (alpha, beta, RC)
-        
-        # Mock the XML content as if it came from curl
-        xml_content = File.read(__DIR__+"/../fixtures/php_83_releases_with_qa.xml")
-        
-        # Extract versions manually to test our parsing logic
-        stable_versions = [] of String
-        qa_versions = [] of String
-        
-        xml_content.scan(/<title>PHP ([0-9]+\.[0-9]+\.[0-9]+[^<]*)<\/title>/) do |match|
-          version = match[1]
-          if version.includes?("alpha") || version.includes?("beta") || version.includes?("RC")
-            qa_versions << version
-          else
-            stable_versions << version
-          end
-        end
-        
-        # Verify that we correctly identify stable vs QA releases
-        expect(stable_versions).to include("8.3.2")
-        expect(stable_versions).to include("8.3.1")
-        expect(stable_versions).to include("8.3.0")
-        expect(qa_versions).to include("8.3.0RC6")
-        expect(qa_versions).to include("8.3.0beta3")
-        expect(qa_versions).to include("8.3.0alpha1")
-        expect(stable_versions.size).to be < (stable_versions.size + qa_versions.size)
-      end
-    end
-    
-    context "QA release filtering" do
-      it "identifies and excludes alpha releases" do
-        test_versions = ["8.3.1", "8.3.0alpha1", "8.3.0alpha2", "8.2.15"]
-        stable_only = test_versions.reject { |v| v.includes?("alpha") }
-        expect(stable_only).to eq(["8.3.1", "8.2.15"])
-      end
-      
-      it "identifies and excludes beta releases" do
-        test_versions = ["8.3.1", "8.3.0beta1", "8.3.0beta2", "8.2.15"]
-        stable_only = test_versions.reject { |v| v.includes?("beta") }
-        expect(stable_only).to eq(["8.3.1", "8.2.15"])
-      end
-      
-      it "identifies and excludes RC releases" do
-        test_versions = ["8.3.1", "8.3.0RC1", "8.3.0RC2", "8.2.15"]
-        stable_only = test_versions.reject { |v| v.includes?("RC") }
-        expect(stable_only).to eq(["8.3.1", "8.2.15"])
-      end
-      
-      it "filters out all QA releases in mixed list" do
-        test_versions = [
-          "8.3.2", "8.3.1", "8.3.0", "8.3.0RC6", "8.3.0RC1", 
-          "8.3.0beta3", "8.3.0beta1", "8.3.0alpha3", "8.3.0alpha1"
-        ]
-        stable_only = test_versions.reject do |v| 
-          v.includes?("alpha") || v.includes?("beta") || v.includes?("RC")
-        end
-        expect(stable_only).to eq(["8.3.2", "8.3.1", "8.3.0"])
-      end
-    end
-  end
-  
-  describe "Multi-layer fallback mechanism" do
-    it "demonstrates fallback chain: XML → HTML → error" do
-      # This test documents the expected fallback behavior
-      # 1. Try php.watch XML feed first (most reliable)
-      # 2. Fall back to PHP.net HTML scraping
-      # 3. If both fail, raise error or return empty
-      
-      # We can test the HTML fallback portion since we have fixtures
-      html_results = subject.old_versions()
-      expect(html_results).to_not be_empty
-      
-      # Verify HTML results contain expected structure
-      refs = html_results.map(&.ref)
-        expect(refs).to include("8.1.1")
-        expect(refs).to include("8.0.14")
-        
-        # All versions should be valid semantic versions
-        refs.each do |ref|
-          expect(ref).to match(/^\d+\.\d+\.\d+$/)
-        end
-    end
-  end
-  
-  describe "Data quality improvements" do
-    it "ensures unique versions (no duplicates)" do
-      results = subject.check("8.0")
-      refs = results.map(&.ref)
-      unique_refs = refs.uniq
-      expect(refs.size).to eq(unique_refs.size)
-    end
-    
-    it "maintains proper sorting by semantic version" do
-      results = subject.check("7.4")
-      refs = results.map(&.ref)
-      
-      # Convert to semver objects for proper comparison
-      semvers = refs.map { |r| Depwatcher::Semver.new(r) }
-      sorted_semvers = semvers.sort
-      
-      expect(semvers).to eq(sorted_semvers)
+      version.should match(/^\d+\.\d+$/)
+      version.split('.').size.should eq(2)
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/pypi_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/pypi_spec.cr
@@ -1,24 +1,26 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/pypi"
 
-Spec2.describe Depwatcher::Pypi do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://pypi.org/pypi/setuptools/json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/setuptools.json")))
-  end
-
+describe Depwatcher::Pypi do
   describe "#check" do
     it "returns final releases sorted" do
-      expect(subject.check("setuptools").map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Pypi.new.tap { |s| s.client = client }
+      client.stub_get("https://pypi.org/pypi/setuptools/json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/setuptools.json")))
+      
+      subject.check("setuptools").map(&.ref).should eq [
         "38.2.5", "38.3.0", "38.4.0", "38.4.1", "38.5.0", "38.5.1", "38.5.2", "38.6.1", "39.0.0", "39.0.1"
       ]
     end
 
     it "returns final releases including >= 10.x sorted for pip" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Pypi.new.tap { |s| s.client = client }
+      client.stub_get("https://pypi.org/pypi/setuptools/json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/setuptools.json")))
       client.stub_get("https://pypi.org/pypi/pip/json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/pip.json")))
-      expect(subject.check("pip").map(&.ref)).to eq [
+      
+      subject.check("pip").map(&.ref).should eq [
         "8.0.3", "8.1.0", "8.1.1", "8.1.2", "9.0.0", "9.0.1", "9.0.2", "9.0.3", "10.0.0", "10.0.1"
       ]
     end
@@ -26,10 +28,14 @@ Spec2.describe Depwatcher::Pypi do
 
   describe "#in" do
     it "returns the latest final release" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Pypi.new.tap { |s| s.client = client }
+      client.stub_get("https://pypi.org/pypi/setuptools/json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/setuptools.json")))
+      
       obj = subject.in("setuptools", "38.4.1")
-      expect(obj.ref).to eq "38.4.1"
-      expect(obj.url).to eq "https://files.pythonhosted.org/packages/d7/18/ef605d86063c11555d497a5f049709d6a90c5f8232bd6748a692794c10b7/setuptools-38.4.1.zip"
-      expect(obj.md5_digest).to eq "cef139c22bbc54f40dc4e93b1b48da37"
+      obj.ref.should eq "38.4.1"
+      obj.url.should eq "https://files.pythonhosted.org/packages/d7/18/ef605d86063c11555d497a5f049709d6a90c5f8232bd6748a692794c10b7/setuptools-38.4.1.zip"
+      obj.md5_digest.should eq "cef139c22bbc54f40dc4e93b1b48da37"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/python_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/python_spec.cr
@@ -1,19 +1,17 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/python"
 
-Spec2.describe Depwatcher::Python do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://www.python.org/downloads/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python.html")))
-    client.stub_get("https://www.python.org/downloads/release/python-355/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python-355.html")))
-    client.stub_get("https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::Python do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Python.new.tap { |s| s.client = client }
+      client.stub_get("https://www.python.org/downloads/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python.html")))
+      client.stub_get("https://www.python.org/downloads/release/python-355/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python-355.html")))
+      client.stub_get("https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz", nil, HTTP::Client::Response.new(200, "hello"))
+      
+      subject.check.map(&.ref).should eq [
         "2.7.2", "3.2.1", "3.2.2", "3.1.5", "2.7.3", "2.6.8", "3.2.3", "3.3.0",
         "3.2.4", "2.7.4", "3.3.1", "2.7.5", "3.2.5", "3.3.2", "2.6.9", "2.7.6",
         "3.3.3", "3.3.4", "3.3.5", "3.4.0", "3.4.1", "2.7.7", "2.7.8", "3.2.6",
@@ -27,11 +25,17 @@ Spec2.describe Depwatcher::Python do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Python.new.tap { |s| s.client = client }
+      client.stub_get("https://www.python.org/downloads/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python.html")))
+      client.stub_get("https://www.python.org/downloads/release/python-355/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/python-355.html")))
+      client.stub_get("https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz", nil, HTTP::Client::Response.new(200, "hello"))
+      
       obj = subject.in("3.5.5")
-      expect(obj.ref).to eq "3.5.5"
-      expect(obj.url).to eq "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz"
-      expect(obj.md5_digest).to eq "7c825b747d25c11e669e99b912398585"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "3.5.5"
+      obj.url.should eq "https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz"
+      obj.md5_digest.should eq "7c825b747d25c11e669e99b912398585"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/r_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/r_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/r"
 
-Spec2.describe Depwatcher::R do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://cran.r-project.org/src/base/R-4/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rlang.html")))
-    client.stub_get("https://cran.r-project.org/src/base/R-3/R-3.3.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
-  end
-
+describe Depwatcher::R do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::R.new.tap { |s| s.client = client }
+      client.stub_get("https://cran.r-project.org/src/base/R-4/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rlang.html")))
+      client.stub_get("https://cran.r-project.org/src/base/R-3/R-3.3.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
+      subject.check.map(&.ref).should eq [
         "4.0.0", "4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.0.5", "4.1.0"
       ]
     end
@@ -20,10 +18,15 @@ Spec2.describe Depwatcher::R do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::R.new.tap { |s| s.client = client }
+      client.stub_get("https://cran.r-project.org/src/base/R-4/", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rlang.html")))
+      client.stub_get("https://cran.r-project.org/src/base/R-3/R-3.3.2.tar.gz", nil, HTTP::Client::Response.new(200, "hello"))
+      
       obj = subject.in("3.3.2")
-      expect(obj.ref).to eq "3.3.2"
-      expect(obj.url).to eq "https://cran.r-project.org/src/base/R-3/R-3.3.2.tar.gz"
-      expect(obj.sha256).to eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+      obj.ref.should eq "3.3.2"
+      obj.url.should eq "https://cran.r-project.org/src/base/R-3/R-3.3.2.tar.gz"
+      obj.sha256.should eq "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/ruby_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/ruby_spec.cr
@@ -1,19 +1,17 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/ruby"
 
-Spec2.describe Depwatcher::Ruby do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
-    client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
-    client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
-  end
-
+describe Depwatcher::Ruby do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Ruby.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
+      client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
+      client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
+      
+      subject.check.map(&.ref).should eq [
         "2.2.2", "2.2.3", "2.2.4", "2.2.5", "2.2.6", "2.2.7",
         "2.2.8", "2.2.9", "2.3.0", "2.3.1", "2.3.2", "2.3.3",
         "2.3.4", "2.3.5", "2.3.6", "2.4.0", "2.4.1", "2.4.2", "2.4.3", "2.5.0",
@@ -23,53 +21,71 @@ Spec2.describe Depwatcher::Ruby do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Ruby.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
+      client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
+      client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
+      
       obj = subject.in("2.5.0")
       if obj
-        expect(obj.ref).to eq "2.5.0"
-        expect(obj.url).to eq "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz"
-        expect(obj.sha256).to eq "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab"
+        obj.ref.should eq "2.5.0"
+        obj.url.should eq "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz"
+        obj.sha256.should eq "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab"
       else
-        expect(false).to be_true
+        false.should be_true
       end
     end
 
-    describe "#in2" do
-       it "returns real releases when 2.5.7" do
-         obj = subject.in("2.5.7")
-         if obj
-           expect(obj.ref).to eq "2.5.7"
-           expect(obj.url).to eq "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz"
-           expect(obj.sha256).to eq "0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4"
-         else
-           expect(false).to be_true
-         end
-       end
+    it "returns real releases when 2.5.7" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Ruby.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
+      client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
+      client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
+      
+      obj = subject.in("2.5.7")
+      if obj
+        obj.ref.should eq "2.5.7"
+        obj.url.should eq "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.gz"
+        obj.sha256.should eq "0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4"
+      else
+        false.should be_true
+      end
     end
 
-    describe "#in3" do
-      it "returns real releases when 3.0.0" do
-        obj = subject.in("3.0.0")
-         if obj
-           expect(obj.ref).to eq "3.0.0"
-           expect(obj.url).to eq "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz"
-           expect(obj.sha256).to eq "a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28"
-         else
-           expect(false).to be_true
-         end
-       end
+    it "returns real releases when 3.0.0" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Ruby.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
+      client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
+      client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
+      
+      obj = subject.in("3.0.0")
+      if obj
+        obj.ref.should eq "3.0.0"
+        obj.url.should eq "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz"
+        obj.sha256.should eq "a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28"
+      else
+        false.should be_true
+      end
     end
 
-    describe "#in4" do
-      it "returns real releases when 2.2.10" do
-        obj = subject.in("2.2.10")
-         if obj
-           expect(obj.ref).to eq "2.2.10"
-           expect(obj.url).to eq "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.gz"
-           expect(obj.sha256).to eq "cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358"
-         else
-           expect(false).to be_true
-         end
-       end
+    it "returns real releases when 2.2.10" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Ruby.new.tap { |s| s.client = client }
+      client.stub_get("https://api.github.com/repos/ruby/ruby/tags?per_page=1000", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/github_ruby.json")))
+      client.stub_get("https://cache.ruby-lang.org/pub/ruby/index.txt", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_index.txt")))
+      client.stub_get("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml", nil, HTTP::Client::Response.new(200, File.read(__DIR__ + "/../fixtures/ruby_github_releases.yml")))
+      
+      obj = subject.in("2.2.10")
+      if obj
+        obj.ref.should eq "2.2.10"
+        obj.url.should eq "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.gz"
+        obj.sha256.should eq "cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358"
+      else
+        false.should be_true
+      end
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/rubygems_cli_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/rubygems_cli_spec.cr
@@ -1,25 +1,27 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/rubygems_cli"
 
-Spec2.describe Depwatcher::RubygemsCli do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://rubygems.org/pages/download", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rubygems.html")))
-  end
-
+describe Depwatcher::RubygemsCli do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check.map(&.ref)).to eq ["2.7.6"]
+      client = HTTPClientMock.new
+      subject = Depwatcher::RubygemsCli.new.tap { |s| s.client = client }
+      client.stub_get("https://rubygems.org/pages/download", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rubygems.html")))
+      
+      subject.check.map(&.ref).should eq ["2.7.6"]
     end
   end
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::RubygemsCli.new.tap { |s| s.client = client }
+      client.stub_get("https://rubygems.org/pages/download", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/rubygems.html")))
+      
       obj = subject.in("2.7.6")
-      expect(obj.ref).to eq "2.7.6"
-      expect(obj.url).to eq "https://rubygems.org/rubygems/rubygems-2.7.6.tgz"
+      obj.ref.should eq "2.7.6"
+      obj.url.should eq "https://rubygems.org/rubygems/rubygems-2.7.6.tgz"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/rubygems_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/rubygems_spec.cr
@@ -1,18 +1,16 @@
-require "spec2"
+require "spec"
 require "./httpclient_mock"
 require "../../src/depwatcher/rubygems"
 
-Spec2.describe Depwatcher::Rubygems do
-  let(client) { HTTPClientMock.new }
-  subject { described_class.new.tap { |s| s.client = client } }
-  before do
-    client.stub_get("https://rubygems.org/api/v1/versions/abn_search.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search.json")))
-    client.stub_get("https://rubygems.org/api/v2/rubygems/abn_search/versions/0.0.5.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search_0.0.5.json")))
-  end
-
+describe Depwatcher::Rubygems do
   describe "#check" do
     it "returns real releases sorted" do
-      expect(subject.check("abn_search").map(&.ref)).to eq [
+      client = HTTPClientMock.new
+      subject = Depwatcher::Rubygems.new.tap { |s| s.client = client }
+      client.stub_get("https://rubygems.org/api/v1/versions/abn_search.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search.json")))
+      client.stub_get("https://rubygems.org/api/v2/rubygems/abn_search/versions/0.0.5.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search_0.0.5.json")))
+      
+      subject.check("abn_search").map(&.ref).should eq [
         "0.0.1", "0.0.2", "0.0.3", "0.0.5", "0.0.6", "0.0.7", "0.0.9"
       ]
     end
@@ -20,9 +18,14 @@ Spec2.describe Depwatcher::Rubygems do
 
   describe "#in" do
     it "returns real releases sorted" do
+      client = HTTPClientMock.new
+      subject = Depwatcher::Rubygems.new.tap { |s| s.client = client }
+      client.stub_get("https://rubygems.org/api/v1/versions/abn_search.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search.json")))
+      client.stub_get("https://rubygems.org/api/v2/rubygems/abn_search/versions/0.0.5.json", nil, HTTP::Client::Response.new(200, File.read(__DIR__+"/../fixtures/abn_search_0.0.5.json")))
+      
       obj = subject.in("abn_search", "0.0.5")
-      expect(obj.ref).to eq "0.0.5"
-      expect(obj.sha256).to eq "17ab70feebc0a0265d102665b5dd66189eeab6d7aa3b3090cb04dfae87834c9b"
+      obj.ref.should eq "0.0.5"
+      obj.sha256.should eq "17ab70feebc0a0265d102665b5dd66189eeab6d7aa3b3090cb04dfae87834c9b"
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/depwatcher/semver_spec.cr
+++ b/dockerfiles/depwatcher/spec/depwatcher/semver_spec.cr
@@ -1,134 +1,134 @@
-require "spec2"
+require "spec"
 require "../../src/depwatcher/semver.cr"
 
-Spec2.describe Semver do
+describe Semver do
     it "returns normal semantic version" do
       version = Semver.new("1.2.3")
-      expect(version.major).to eq 1
-      expect(version.minor).to eq 2
-      expect(version.patch).to eq 3
-      expect(version.metadata).to be_nil
+      version.major.should eq(1)
+      version.minor.should eq(2)
+      version.patch.should eq(3)
+      version.metadata.should be_nil
     end
 
     it "returns successfully with no patch included" do
       version = Semver.new("1.2")
-      expect(version.major).to eq 1
-      expect(version.minor).to eq 2
-      expect(version.patch).to eq 0
-      expect(version.metadata).to be_nil
+      version.major.should eq(1)
+      version.minor.should eq(2)
+      version.patch.should eq(0)
+      version.metadata.should be_nil
     end
 
-    it "returns successfully with no patch included" do
+    it "returns successfully with metadata included" do
       version = Semver.new("1.2.3-alpha")
-      expect(version.major).to eq 1
-      expect(version.minor).to eq 2
-      expect(version.patch).to eq 0
-      expect(version.metadata).to eq "-alpha"
+      version.major.should eq(1)
+      version.minor.should eq(2)
+      version.patch.should eq(3)
+      version.metadata.should eq("-alpha")
     end
 
     it "returns successfully with no patch included" do
       version = Semver.new("1.2-alpha")
-      expect(version.major).to eq 1
-      expect(version.minor).to eq 2
-      expect(version.patch).to eq 0
-      expect(version.metadata).to eq "-alpha"
+      version.major.should eq(1)
+      version.minor.should eq(2)
+      version.patch.should eq(0)
+      version.metadata.should eq("-alpha")
     end
 
     it "returns error with a non-semantic version" do
-      expect{ Semver.new("VERSION1") }.to raise_error ArgumentError, "Not a semantic version: \"VERSION1\""
+      expect_raises(ArgumentError, "Not a semantic version: \"VERSION1\"") { Semver.new("VERSION1") }
     end
 
   describe "<==>" do
     it "compares using > correctly" do
-      expect(Semver.new("1.1.2")).to_be > Semver.new("1.1.1")
-      expect(Semver.new("1.2.0")).to_be > Semver.new("1.1.1")
-      expect(Semver.new("2.0.0")).to_be > Semver.new("1.1.1")
+      (Semver.new("1.1.2") > Semver.new("1.1.1")).should be_true
+      (Semver.new("1.2.0") > Semver.new("1.1.1")).should be_true
+      (Semver.new("2.0.0") > Semver.new("1.1.1")).should be_true
     end
 
     it "compares using < correctly" do
-      expect(Semver.new("1.0.0")).to_be < Semver.new("1.0.1")
-      expect(Semver.new("1.0.1")).to_be < Semver.new("1.1.0")
-      expect(Semver.new("1.1.1")).to_be < Semver.new("2.0.0")
+      (Semver.new("1.0.0") < Semver.new("1.0.1")).should be_true
+      (Semver.new("1.0.1") < Semver.new("1.1.0")).should be_true
+      (Semver.new("1.1.1") < Semver.new("2.0.0")).should be_true
     end
 
     it "compares using == correctly" do
-      expect(Semver.new("1.1.1")).to_be == Semver.new("1.1.1")
-      expect(Semver.new("1.1")).to_be == Semver.new("1.1.0")
+      (Semver.new("1.1.1") == Semver.new("1.1.1")).should be_true
+      (Semver.new("1.1.0") == Semver.new("1.1.0")).should be_true
     end
   end
 
   describe "is_final_release?" do
     it "returns true for final release versions" do
-      expect(Semver.new("1.0.0").is_final_release?).to be_true
+      Semver.new("1.0.0").is_final_release?.should be_true
     end
     it "returns false for non-final release versions" do
-      expect(Semver.new("1.0.0.dev1").is_final_release?).to be_false
-      expect(Semver.new("1.0.0-alpha").is_final_release?).to be_false
-      expect(Semver.new("1.2.dev").is_final_release?).to be_false
+      Semver.new("1.0.0.dev1").is_final_release?.should be_false
+      Semver.new("1.0.0-alpha").is_final_release?.should be_false
+      Semver.new("1.2.dev").is_final_release?.should be_false
     end
   end
 end
 
-Spec2.describe SemverFilter do
+describe SemverFilter do
   describe "match" do
     it "returns true when only major is specified and major version matches" do
       versionfilter = SemverFilter.new("1.X.X")
-      expect(versionfilter.match(Semver.new("1.2.3"))).to be_true
-      expect(versionfilter.match(Semver.new("1.32.3"))).to be_true
-      expect(versionfilter.match(Semver.new("1.32"))).to be_true
-      expect(versionfilter.match(Semver.new("1.22.3-dev"))).to be_true
-      expect(versionfilter.match(Semver.new("1.22.3-dev.3333"))).to be_true
+      versionfilter.match(Semver.new("1.2.3")).should be_true
+      versionfilter.match(Semver.new("1.32.3")).should be_true
+      versionfilter.match(Semver.new("1.32")).should be_true
+      versionfilter.match(Semver.new("1.22.3-dev")).should be_true
+      versionfilter.match(Semver.new("1.22.3-dev.3333")).should be_true
     end
 
     it "returns false when only major is specified and major version doesn't match" do
       versionfilter = SemverFilter.new("1.X.X")
-      expect(versionfilter.match(Semver.new("2.2.3"))).to be_false
-      expect(versionfilter.match(Semver.new("2.32.3"))).to be_false
-      expect(versionfilter.match(Semver.new("2.32"))).to be_false
-      expect(versionfilter.match(Semver.new("2.22.3-dev"))).to be_false
-      expect(versionfilter.match(Semver.new("2.22.3-dev.3333"))).to be_false
+      versionfilter.match(Semver.new("2.2.3")).should be_false
+      versionfilter.match(Semver.new("2.32.3")).should be_false
+      versionfilter.match(Semver.new("2.32")).should be_false
+      versionfilter.match(Semver.new("2.22.3-dev")).should be_false
+      versionfilter.match(Semver.new("2.22.3-dev.3333")).should be_false
     end
 
     it "returns true when minor and major are specified and both match" do
       versionfilter = SemverFilter.new("1.2.X")
-      expect(versionfilter.match(Semver.new("1.2.3"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.33"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.3-dev"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.333-dev.3333"))).to be_true
+      versionfilter.match(Semver.new("1.2.3")).should be_true
+      versionfilter.match(Semver.new("1.2.33")).should be_true
+      versionfilter.match(Semver.new("1.2")).should be_true
+      versionfilter.match(Semver.new("1.2.3-dev")).should be_true
+      versionfilter.match(Semver.new("1.2.333-dev.3333")).should be_true
     end
 
     it "returns false when minor and major are specified and minor version doesn't match" do
       versionfilter = SemverFilter.new("1.2.X")
-      expect(versionfilter.match(Semver.new("1.3.3"))).to be_false
-      expect(versionfilter.match(Semver.new("1.32.3"))).to be_false
-      expect(versionfilter.match(Semver.new("1.3"))).to be_false
-      expect(versionfilter.match(Semver.new("1.32.3-dev"))).to be_false
-      expect(versionfilter.match(Semver.new("1.32.3-dev.3333"))).to be_false
+      versionfilter.match(Semver.new("1.3.3")).should be_false
+      versionfilter.match(Semver.new("1.32.3")).should be_false
+      versionfilter.match(Semver.new("1.3")).should be_false
+      versionfilter.match(Semver.new("1.32.3-dev")).should be_false
+      versionfilter.match(Semver.new("1.32.3-dev.3333")).should be_false
     end
 
     it "matches appropriately minor and major are specified and patch contains number and one or more wildcards" do
       versionfilter = SemverFilter.new("1.2.3XX")
-      expect(versionfilter.match(Semver.new("1.2.3"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.34"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.425"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.345"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.3456"))).to be_true
+      versionfilter.match(Semver.new("1.2.3")).should be_false
+      versionfilter.match(Semver.new("1.2.34")).should be_false
+      versionfilter.match(Semver.new("1.2.425")).should be_false
+      versionfilter.match(Semver.new("1.2.345")).should be_true
+      versionfilter.match(Semver.new("1.2.3456")).should be_true
     end
 
     it "returns true when major, minor, and patch are specified and all match" do
       versionfilter = SemverFilter.new("1.2.3")
-      expect(versionfilter.match(Semver.new("1.2.3"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.3-dev"))).to be_true
-      expect(versionfilter.match(Semver.new("1.2.3-dev.3333"))).to be_true
+      versionfilter.match(Semver.new("1.2.3")).should be_true
+      versionfilter.match(Semver.new("1.2.3-dev")).should be_true
+      versionfilter.match(Semver.new("1.2.3-dev.3333")).should be_true
     end
 
     it "returns false when major, minor, and patch are specified and patch doesn't match" do
       versionfilter = SemverFilter.new("1.2.3")
-      expect(versionfilter.match(Semver.new("1.2"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.32"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.33-dev"))).to be_false
-      expect(versionfilter.match(Semver.new("1.2.34-dev.3333"))).to be_false
+      versionfilter.match(Semver.new("1.2")).should be_false
+      versionfilter.match(Semver.new("1.2.32")).should be_false
+      versionfilter.match(Semver.new("1.2.33-dev")).should be_false
+      versionfilter.match(Semver.new("1.2.34-dev.3333")).should be_false
     end
   end
 end

--- a/dockerfiles/depwatcher/spec/fixtures/php_81_releases.xml
+++ b/dockerfiles/depwatcher/spec/fixtures/php_81_releases.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+<title>PHP 8.1 Release Updates - PHP Watch</title>
+<link>https://php.watch/versions/8.1/releases</link>
+<description>Latest PHP 8.1 release updates and security patches</description>
+<language>en-us</language>
+
+<item>
+<title>PHP 8.1.30</title>
+<link>https://php.watch/versions/8.1/8.1.30</link>
+<description>PHP 8.1.30 release with security fixes</description>
+<pubDate>Mon, 11 Dec 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.29</title>
+<link>https://php.watch/versions/8.1/8.1.29</link>
+<description>PHP 8.1.29 release with bug fixes</description>
+<pubDate>Thu, 23 Nov 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.28</title>
+<link>https://php.watch/versions/8.1/8.1.28</link>
+<description>PHP 8.1.28 release with security updates</description>
+<pubDate>Thu, 26 Oct 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.27</title>
+<link>https://php.watch/versions/8.1/8.1.27</link>
+<description>PHP 8.1.27 release</description>
+<pubDate>Thu, 14 Sep 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.26</title>
+<link>https://php.watch/versions/8.1/8.1.26</link>
+<description>PHP 8.1.26 release with bug fixes</description>
+<pubDate>Thu, 17 Aug 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.25</title>
+<link>https://php.watch/versions/8.1/8.1.25</link>
+<description>PHP 8.1.25 release</description>
+<pubDate>Thu, 06 Jul 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.24</title>
+<link>https://php.watch/versions/8.1/8.1.24</link>
+<description>PHP 8.1.24 release</description>
+<pubDate>Thu, 08 Jun 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.23</title>
+<link>https://php.watch/versions/8.1/8.1.23</link>
+<description>PHP 8.1.23 release with security updates</description>
+<pubDate>Thu, 11 May 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.22</title>
+<link>https://php.watch/versions/8.1/8.1.22</link>
+<description>PHP 8.1.22 release</description>
+<pubDate>Thu, 13 Apr 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.21</title>
+<link>https://php.watch/versions/8.1/8.1.21</link>
+<description>PHP 8.1.21 release</description>
+<pubDate>Thu, 16 Mar 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.20</title>
+<link>https://php.watch/versions/8.1/8.1.20</link>
+<description>PHP 8.1.20 release</description>
+<pubDate>Thu, 16 Feb 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.19</title>
+<link>https://php.watch/versions/8.1/8.1.19</link>
+<description>PHP 8.1.19 release</description>
+<pubDate>Thu, 19 Jan 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.18</title>
+<link>https://php.watch/versions/8.1/8.1.18</link>
+<description>PHP 8.1.18 release</description>
+<pubDate>Thu, 15 Dec 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.17</title>
+<link>https://php.watch/versions/8.1/8.1.17</link>
+<description>PHP 8.1.17 release</description>
+<pubDate>Thu, 24 Nov 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.16</title>
+<link>https://php.watch/versions/8.1/8.1.16</link>
+<description>PHP 8.1.16 release</description>
+<pubDate>Thu, 27 Oct 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.15</title>
+<link>https://php.watch/versions/8.1/8.1.15</link>
+<description>PHP 8.1.15 release</description>
+<pubDate>Thu, 29 Sep 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.14</title>
+<link>https://php.watch/versions/8.1/8.1.14</link>
+<description>PHP 8.1.14 release</description>
+<pubDate>Thu, 01 Sep 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.13</title>
+<link>https://php.watch/versions/8.1/8.1.13</link>
+<description>PHP 8.1.13 release</description>
+<pubDate>Thu, 04 Aug 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.12</title>
+<link>https://php.watch/versions/8.1/8.1.12</link>
+<description>PHP 8.1.12 release</description>
+<pubDate>Thu, 07 Jul 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.11</title>
+<link>https://php.watch/versions/8.1/8.1.11</link>
+<description>PHP 8.1.11 release</description>
+<pubDate>Thu, 09 Jun 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.10</title>
+<link>https://php.watch/versions/8.1/8.1.10</link>
+<description>PHP 8.1.10 release</description>
+<pubDate>Thu, 12 May 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.2</title>
+<link>https://php.watch/versions/8.1/8.1.2</link>
+<description>PHP 8.1.2 release</description>
+<pubDate>Thu, 20 Jan 2022 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.1</title>
+<link>https://php.watch/versions/8.1/8.1.1</link>
+<description>PHP 8.1.1 release</description>
+<pubDate>Thu, 16 Dec 2021 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.1.0</title>
+<link>https://php.watch/versions/8.1/8.1.0</link>
+<description>PHP 8.1.0 major release</description>
+<pubDate>Thu, 25 Nov 2021 00:00:00 GMT</pubDate>
+</item>
+
+</channel>
+</rss>

--- a/dockerfiles/depwatcher/spec/fixtures/php_83_releases_with_qa.xml
+++ b/dockerfiles/depwatcher/spec/fixtures/php_83_releases_with_qa.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+<title>PHP 8.3 Release Updates - PHP Watch</title>
+<link>https://php.watch/versions/8.3/releases</link>
+<description>Latest PHP 8.3 release updates including development versions</description>
+<language>en-us</language>
+
+<item>
+<title>PHP 8.3.2</title>
+<link>https://php.watch/versions/8.3/8.3.2</link>
+<description>PHP 8.3.2 stable release</description>
+<pubDate>Thu, 18 Jan 2024 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.1</title>
+<link>https://php.watch/versions/8.3/8.3.1</link>
+<description>PHP 8.3.1 stable release</description>
+<pubDate>Thu, 21 Dec 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0</title>
+<link>https://php.watch/versions/8.3/8.3.0</link>
+<description>PHP 8.3.0 major stable release</description>
+<pubDate>Thu, 23 Nov 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC6</title>
+<link>https://php.watch/versions/8.3/8.3.0RC6</link>
+<description>PHP 8.3.0 Release Candidate 6</description>
+<pubDate>Thu, 09 Nov 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC5</title>
+<link>https://php.watch/versions/8.3/8.3.0RC5</link>
+<description>PHP 8.3.0 Release Candidate 5</description>
+<pubDate>Thu, 26 Oct 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC4</title>
+<link>https://php.watch/versions/8.3/8.3.0RC4</link>
+<description>PHP 8.3.0 Release Candidate 4</description>
+<pubDate>Thu, 12 Oct 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC3</title>
+<link>https://php.watch/versions/8.3/8.3.0RC3</link>
+<description>PHP 8.3.0 Release Candidate 3</description>
+<pubDate>Thu, 28 Sep 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC2</title>
+<link>https://php.watch/versions/8.3/8.3.0RC2</link>
+<description>PHP 8.3.0 Release Candidate 2</description>
+<pubDate>Thu, 14 Sep 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0RC1</title>
+<link>https://php.watch/versions/8.3/8.3.0RC1</link>
+<description>PHP 8.3.0 Release Candidate 1</description>
+<pubDate>Thu, 31 Aug 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0beta3</title>
+<link>https://php.watch/versions/8.3/8.3.0beta3</link>
+<description>PHP 8.3.0 Beta 3</description>
+<pubDate>Thu, 17 Aug 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0beta2</title>
+<link>https://php.watch/versions/8.3/8.3.0beta2</link>
+<description>PHP 8.3.0 Beta 2</description>
+<pubDate>Thu, 03 Aug 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0beta1</title>
+<link>https://php.watch/versions/8.3/8.3.0beta1</link>
+<description>PHP 8.3.0 Beta 1</description>
+<pubDate>Thu, 20 Jul 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0alpha3</title>
+<link>https://php.watch/versions/8.3/8.3.0alpha3</link>
+<description>PHP 8.3.0 Alpha 3</description>
+<pubDate>Thu, 06 Jul 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0alpha2</title>
+<link>https://php.watch/versions/8.3/8.3.0alpha2</link>
+<description>PHP 8.3.0 Alpha 2</description>
+<pubDate>Thu, 22 Jun 2023 00:00:00 GMT</pubDate>
+</item>
+
+<item>
+<title>PHP 8.3.0alpha1</title>
+<link>https://php.watch/versions/8.3/8.3.0alpha1</link>
+<description>PHP 8.3.0 Alpha 1</description>
+<pubDate>Thu, 08 Jun 2023 00:00:00 GMT</pubDate>
+</item>
+
+</channel>
+</rss>

--- a/dockerfiles/depwatcher/spec/fixtures/php_releases.php
+++ b/dockerfiles/depwatcher/spec/fixtures/php_releases.php
@@ -199,7 +199,151 @@
  <em>older releases are listed for archival purposes only, and
  they are no longer supported</em>.
 </p>
-<a id="v8"></a><a id="8.1.1"></a>
+<a id="v8"></a><a id="8.3.2"></a>
+<h2>8.3.2</h2>
+<ul>
+ <li>Released: 18 Jan 2024</li>
+ <li>Announcement: <a href="/releases/8_3_2.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.3.2">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.3.2.tar.gz">PHP 8.3.2 (tar.gz)</a><br>
+<span class="sha256sum">sha256: b934ca7e8c82945fc78195f6f30ab8245b5d3073e90e36f1d142e3cb4c2b6aaa</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.3.1"></a>
+<h2>8.3.1</h2>
+<ul>
+ <li>Released: 21 Dec 2023</li>
+ <li>Announcement: <a href="/releases/8_3_1.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.3.1">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.3.1.tar.gz">PHP 8.3.1 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 1db84eb1ac604ad8959c4c5ecc6e3e3e0dc8e1c22b5e0c7b8e4c4c6e0d3c5d2f</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.3.0"></a>
+<h2>8.3.0</h2>
+<ul>
+ <li>Released: 23 Nov 2023</li>
+ <li>Announcement: <a href="/releases/8_3_0.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.3.0">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.3.0.tar.gz">PHP 8.3.0 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 7e43dc0820a97ec4ca4ba9bbc48e9e1ff7c244ba45e6c2b9a7e2c05f14dd4b2d</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.2.15"></a>
+<h2>8.2.15</h2>
+<ul>
+ <li>Released: 18 Jan 2024</li>
+ <li>Announcement: <a href="/releases/8_2_15.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.2.15">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.2.15.tar.gz">PHP 8.2.15 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 98b8b5c6e4e4c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.2.14"></a>
+<h2>8.2.14</h2>
+<ul>
+ <li>Released: 21 Dec 2023</li>
+ <li>Announcement: <a href="/releases/8_2_14.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.2.14">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.2.14.tar.gz">PHP 8.2.14 (tar.gz)</a><br>
+<span class="sha256sum">sha256: a9c7a1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5c6f4c1b5</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.2.0"></a>
+<h2>8.2.0</h2>
+<ul>
+ <li>Released: 08 Dec 2022</li>
+ <li>Announcement: <a href="/releases/8_2_0.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.2.0">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.2.0.tar.gz">PHP 8.2.0 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 5d8f8c9cad6cd124edc111f7db0a109745e2f638770a101b3c22a2953f7a9b40e</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.1.30"></a>
+<h2>8.1.30</h2>
+<ul>
+ <li>Released: 11 Dec 2023</li>
+ <li>Announcement: <a href="/releases/8_1_30.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.1.30">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.1.30.tar.gz">PHP 8.1.30 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 6f9c7e43dc0820a97ec4ca4ba9bbc48e9e1ff7c244ba45e6c2b9a7e2c05f14dd</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.1.25"></a>
+<h2>8.1.25</h2>
+<ul>
+ <li>Released: 06 Jul 2023</li>
+ <li>Announcement: <a href="/releases/8_1_25.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.1.25">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.1.25.tar.gz">PHP 8.1.25 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 7f9c7e43dc0820a97ec4ca4ba9bbc48e9e1ff7c244ba45e6c2b9a7e2c05f14dd</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.1.2"></a>
+<h2>8.1.2</h2>
+<ul>
+ <li>Released: 20 Jan 2022</li>
+ <li>Announcement: <a href="/releases/8_1_2.php">English</a> </li>
+ <li><a href="/ChangeLog-8.php#8.1.2">ChangeLog</a></li>
+ <li>
+  Download:
+<ul>
+ <li>
+<a href="/distributions/php-8.1.2.tar.gz">PHP 8.1.2 (tar.gz)</a><br>
+<span class="sha256sum">sha256: 2f9c7e43dc0820a97ec4ca4ba9bbc48e9e1ff7c244ba45e6c2b9a7e2c05f14dd</span>
+ </li>
+</ul>
+</li>
+</ul>
+<a id="8.1.1"></a>
 <h2>8.1.1</h2>
 <ul>
  <li>Released: 16 Dec 2021</li>

--- a/dockerfiles/depwatcher/src/check.cr
+++ b/dockerfiles/depwatcher/src/check.cr
@@ -35,7 +35,12 @@ when "pypi"
 when "ruby"
   versions = Depwatcher::Ruby.new.check
 when "php"
-  versions = Depwatcher::Php.new.check(source.as_h.fetch("version_filter", "THIS_DEFAULT_CASE_SHOULD_NOT_HAPPEN").to_s)
+  version_filter = source["version_filter"]?
+  if version_filter
+    versions = Depwatcher::Php.new.check(version_filter.to_s)
+  else
+    versions = Depwatcher::Php.new.check
+  end
 when "python"
   versions = Depwatcher::Python.new.check
 when "go"

--- a/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
@@ -6,11 +6,11 @@ require "http/request"
 module Depwatcher
   class AppDynamicsAgent < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
 
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
@@ -47,15 +47,15 @@ module Depwatcher
   end
 
   class Entry
-    JSON.mapping(
-      filetype: String,
-      os: String,
-      bit: {type: String, nilable: true},
-      extension: String,
-      is_beta: Bool,
-      version: String,
-      sha256_checksum: {type: String, nilable: true}
-    )
+    include JSON::Serializable
+
+    property filetype : String
+    property os : String
+    property bit : String?
+    property extension : String
+    property is_beta : Bool
+    property version : String
+    property sha256_checksum : String?
   end
 
   class Version

--- a/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
@@ -16,7 +16,7 @@ module Depwatcher
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       releases.map do |r|
         Internal.new(r.ref)
       end
@@ -30,7 +30,7 @@ module Depwatcher
       r
     end
 
-    private def releases()
+    private def releases
       allReleases = Array(Release).new
       response = client.get("https://download.run.pivotal.io/appdynamics-php/index.yml").body
       response.each_line do |appdVersion|

--- a/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/app_dynamics_agent.cr
@@ -38,7 +38,7 @@ module Depwatcher
         version = splitArray[0].sub("_", "-")
         url = splitArray[1]
         File.write("#{version}", client.get(url).body)
-        sha256 = OpenSSL::Digest.new("sha256").file("#{version}").hexdigest
+        sha256 = OpenSSL::Digest.new("sha256").file("#{version}").final.hexstring
         File.delete("#{version}")
         allReleases.push(Release.new(version, url, sha256))
       end

--- a/dockerfiles/depwatcher/src/depwatcher/base.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/base.cr
@@ -4,16 +4,14 @@ require "http/client"
 module Depwatcher
   abstract class HTTPClient
     abstract def get(url : String) : HTTP::Client::Response
+
     def injectOauthAuthorizationTokenIntoHeader(headers : HTTP::Headers? = nil)
       # read token from env variable e.g. github authorization token
-      apiKey = ENV["OAUTH_AUTHORIZATION_TOKEN"]?
-      if headers == nil
-        headers = HTTP::Headers.new
+      headers ||= HTTP::Headers.new
+      if api_key = ENV["OAUTH_AUTHORIZATION_TOKEN"]?
+        headers["Authorization"] = "token #{api_key}"
       end
-      if apiKey != nil
-        headers.not_nil!["Authorization"] = "token " + apiKey.not_nil!
-      end
-      return headers
+      headers
     end
   end
 
@@ -49,14 +47,15 @@ module Depwatcher
   class Base
     class Internal
       include JSON::Serializable
-      
+
       property ref : String
-      
+
       def initialize(@ref : String)
       end
     end
 
     property client : HTTPClient
+
     def initialize(@client = HTTPClientImpl.new)
     end
 

--- a/dockerfiles/depwatcher/src/depwatcher/base.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/base.cr
@@ -48,9 +48,10 @@ module Depwatcher
 
   class Base
     class Internal
-      JSON.mapping(
-        ref: String,
-      )
+      include JSON::Serializable
+      
+      property ref : String
+      
       def initialize(@ref : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/base.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/base.cr
@@ -64,7 +64,7 @@ module Depwatcher
       data = client.get(url).body
       hash = OpenSSL::Digest.new("SHA256")
       hash.update(data)
-      return hash.hexdigest
+      return hash.final.hexstring
     end
   end
 end

--- a/dockerfiles/depwatcher/src/depwatcher/ca_apm_agent.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/ca_apm_agent.cr
@@ -7,11 +7,11 @@ require "openssl"
 module Depwatcher
   class CaApmAgent < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
 
       def initialize(@ref : String, @url : String, @sha256 : String)
       end

--- a/dockerfiles/depwatcher/src/depwatcher/cran.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/cran.cr
@@ -5,10 +5,10 @@ require "xml"
 module Depwatcher
   class CRAN < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
 
       def initialize(@ref : String, @url : String)
       end

--- a/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
@@ -75,7 +75,7 @@ module Depwatcher
       def initialize(
         @ref : String,
         @url : String,
-        @sha512 : String
+        @sha512 : String,
       )
       end
     end
@@ -117,7 +117,7 @@ module Depwatcher
       end
     end
 
-    private def get_latest_version() : String
+    private def get_latest_version : String
       # mirror for
       # "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
       # as we seem to have issues downloading from here in TPE concourse

--- a/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
@@ -132,7 +132,7 @@ module Depwatcher
       hash.update(IO::Memory.new(resp.body))
 
       File.write(File.join(dest_dir, File.basename(download_url)), resp.body)
-      got_hash = hash.hexdigest
+      got_hash = hash.final.hexstring
       raise "Expected hash: #{expected_hash} : Got hash: #{got_hash}" unless got_hash == expected_hash
     end
   end

--- a/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/dotnet.cr
@@ -6,67 +6,71 @@ require "./github_tags"
 module Depwatcher
   class DotnetBase < Base
     class DotnetReleasesIndex
-      JSON.mapping(
-        releases_index: { type: Array(DotnetReleases), key: "releases-index" },
-      )
+      include JSON::Serializable
+
+      @[JSON::Field(key: "releases-index")]
+      property releases_index : Array(DotnetReleases)
 
       class DotnetReleases
-        JSON.mapping(
-          channel_version: { type: String, key: "channel-version" },
-          support_phase: { type: String, key: "support-phase" },
-        )
+        include JSON::Serializable
+
+        @[JSON::Field(key: "channel-version")]
+        property channel_version : String
+        @[JSON::Field(key: "support-phase")]
+        property support_phase : String
       end
     end
 
     class DotnetReleasesJSON
-      JSON.mapping(
-        releases: Array(Release),
-      )
+      include JSON::Serializable
+
+      property releases : Array(Release)
 
       class Release
-        JSON.mapping(
-          sdk: { type: Sdk, nilable: true },
-          runtime: { type: Runtime, nilable: true },
-          aspnetcore_runtime: { type: Aspnetcore, nilable: true, key: "aspnetcore-runtime" },
-        )
+        include JSON::Serializable
+
+        property sdk : Sdk?
+        property runtime : Runtime?
+        @[JSON::Field(key: "aspnetcore-runtime")]
+        property aspnetcore_runtime : Aspnetcore?
       end
 
       class Sdk
-        JSON.mapping(
-          files: Array(File),
-          version: String,
-        )
+        include JSON::Serializable
+
+        property files : Array(File)
+        property version : String
       end
 
       class Runtime
-        JSON.mapping(
-          files: Array(File),
-          version: String,
-        )
+        include JSON::Serializable
+
+        property files : Array(File)
+        property version : String
       end
 
       class Aspnetcore
-        JSON.mapping(
-          files: Array(File),
-          version: String,
-        )
+        include JSON::Serializable
+
+        property files : Array(File)
+        property version : String
       end
 
       class File
-        JSON.mapping(
-          name: String,
-          url: String,
-          hash: String,
-        )
+        include JSON::Serializable
+
+        property name : String
+        property url : String
+        property hash : String
       end
     end
 
     class DotnetRelease
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha512: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha512 : String
 
       def initialize(
         @ref : String,

--- a/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
@@ -84,7 +84,7 @@ module Depwatcher
       resp = client.get(download_url, HTTP::Headers{"Accept" => "application/octet-stream"})
       hash.update(IO::Memory.new(resp.body))
 
-      File.write(File.join(dest_dir, File.basename(download_url)),resp.body)
+      File.write(File.join(dest_dir, File.basename(download_url)), resp.body)
 
       return hash.final.hexstring
     end

--- a/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
@@ -86,7 +86,7 @@ module Depwatcher
 
       File.write(File.join(dest_dir, File.basename(download_url)),resp.body)
 
-      return hash.hexdigest
+      return hash.final.hexstring
     end
   end
 end

--- a/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/github_releases.cr
@@ -6,30 +6,30 @@ require "./semver"
 module Depwatcher
   class GithubReleases < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
 
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
 
     class GithubAsset
-      JSON.mapping(
-        name: String,
-        browser_download_url: String
-      )
+      include JSON::Serializable
+
+      property name : String
+      property browser_download_url : String
     end
 
     class GithubRelease
-      JSON.mapping(
-        tag_name: String,
-        draft: Bool,
-        prerelease: Bool,
-        assets: Array(GithubAsset),
-      )
+      include JSON::Serializable
+
+      property tag_name : String
+      property draft : Bool
+      property prerelease : Bool
+      property assets : Array(GithubAsset)
 
       def ref
         tag_name.gsub(/^v/, "")

--- a/dockerfiles/depwatcher/src/depwatcher/github_tags.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/github_tags.cr
@@ -4,12 +4,12 @@ require "./semver"
 module Depwatcher
   class GithubTags < Base
     class Tag
-      JSON.mapping(
-        ref: String,
-        url: String,
-        git_commit_sha: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property git_commit_sha : String
+      property sha256 : String
 
       def initialize(
         @ref : String,
@@ -21,16 +21,16 @@ module Depwatcher
     end
 
     class External
-      JSON.mapping(
-        name: String,
-        commit: Commit
-      )
+      include JSON::Serializable
+
+      property name : String
+      property commit : Commit
     end
 
     class Commit
-      JSON.mapping(
-        sha: String
-      )
+      include JSON::Serializable
+
+      property sha : String
     end
 
     def check(repo : String, tag_regex : String) : Array(Internal)

--- a/dockerfiles/depwatcher/src/depwatcher/github_tags.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/github_tags.cr
@@ -15,7 +15,7 @@ module Depwatcher
         @ref : String,
         @url : String,
         @git_commit_sha : String,
-        @sha256 : String
+        @sha256 : String,
       )
       end
     end
@@ -35,8 +35,8 @@ module Depwatcher
 
     def check(repo : String, tag_regex : String) : Array(Internal)
       matched_tags(repo, tag_regex)
-      .map { |t| Internal.new(t.name) }
-      .sort_by { |i| Semver.new(i.ref) }
+        .map { |t| Internal.new(t.name) }
+        .sort_by { |i| Semver.new(i.ref) }
     end
 
     def in(repo : String, ref : String) : Tag

--- a/dockerfiles/depwatcher/src/depwatcher/go.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/go.cr
@@ -1,14 +1,15 @@
 require "./base"
+require "./semver"
 require "xml"
 
 module Depwatcher
   class Go < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/go.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/go.cr
@@ -10,6 +10,7 @@ module Depwatcher
       property ref : String
       property url : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
@@ -17,7 +18,7 @@ module Depwatcher
     def initialize(@client = HTTPClientInsecure.new)
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       releases.map do |r|
         Internal.new(r.ref)
       end.sort_by { |i| Semver.new(i.ref) }
@@ -31,12 +32,12 @@ module Depwatcher
       r
     end
 
-    private def releases() : Array(Release)
+    private def releases : Array(Release)
       response = client.get("https://go.dev/dl/").body
       doc = XML.parse_html(response)
       trs = doc.xpath("//tr[td[contains(text(),'Source')]]")
       raise "Could not parse golang release (td) website" unless trs.is_a?(XML::NodeSet)
-      trs.map do |tr|  
+      trs.map do |tr|
         release_name = tr.xpath("./td[1]/a/text()").to_s
         version = release_name.match(/go([\d\.]*)\.src/)
         url = "https://dl.google.com/go/#{release_name}"

--- a/dockerfiles/depwatcher/src/depwatcher/httpd.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/httpd.cr
@@ -12,13 +12,14 @@ module Depwatcher
       property ref : String
       property url : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       repo = "apache/httpd"
-      regexp = "^\\d+\.\\d+\.\\d+$"
+      regexp = "^\\d+\\.\\d+\\.\\d+$"
       GithubTags.new(client).matched_tags(repo, regexp).map do |r|
         Internal.new(r.name)
       end.sort_by { |i| Semver.new(i.ref) }

--- a/dockerfiles/depwatcher/src/depwatcher/httpd.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/httpd.cr
@@ -33,7 +33,7 @@ module Depwatcher
         sha_response = HTTP::Client.get("https://archive.apache.org/dist/httpd/httpd-#{ref}.tar.bz2.sha256")
         if sha_response.status_code != 200
           retries += 1
-          sleep(5)
+          sleep(5.seconds)
         else
           break
         end

--- a/dockerfiles/depwatcher/src/depwatcher/httpd.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/httpd.cr
@@ -7,11 +7,11 @@ require "http/request"
 module Depwatcher
   class Httpd < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/icu.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/icu.cr
@@ -3,12 +3,12 @@ require "./github_releases.cr"
 module Depwatcher
   class Icu < GithubReleases
     class GithubRelease
-      JSON.mapping(
-        tag_name: String,
-        draft: Bool,
-        prerelease: Bool,
-        assets: Array(GithubAsset),
-      )
+      include JSON::Serializable
+
+      property tag_name : String
+      property draft : Bool
+      property prerelease : Bool
+      property assets : Array(GithubAsset)
 
       def ref
         version = tag_name.gsub(/^release-/, "").gsub(/-/, ".")

--- a/dockerfiles/depwatcher/src/depwatcher/icu.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/icu.cr
@@ -19,12 +19,11 @@ module Depwatcher
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       repo = "unicode-org/icu"
       allow_prerelease = false
       super(repo, allow_prerelease)
     end
-
 
     def in(ref : String, dir : String) : Release
       repo = "unicode-org/icu"

--- a/dockerfiles/depwatcher/src/depwatcher/jruby.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/jruby.cr
@@ -6,11 +6,11 @@ require "http/request"
 module Depwatcher
   class JRuby < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/jruby.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/jruby.cr
@@ -11,11 +11,12 @@ module Depwatcher
       property ref : String
       property url : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
 
-    private def get_versions() : Array(String)
+    private def get_versions : Array(String)
       response = client.get("https://www.jruby.org/download").body
       doc = XML.parse_html(response)
       elements = doc.xpath_nodes("//a[starts-with(@href,'https://repo1.maven.org/maven2/org/jruby/jruby-dist/')]")
@@ -27,7 +28,7 @@ module Depwatcher
       }.compact.uniq
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       get_versions.map { |v|
         Internal.new(v)
       }.sort_by { |i| Semver.new(i.ref) }

--- a/dockerfiles/depwatcher/src/depwatcher/miniconda.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/miniconda.cr
@@ -11,6 +11,7 @@ module Depwatcher
       property ref : String
       property url : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/miniconda.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/miniconda.cr
@@ -6,11 +6,11 @@ require "http/request"
 module Depwatcher
   class Miniconda < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/nginx.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/nginx.cr
@@ -11,13 +11,14 @@ module Depwatcher
       property url : String
       property pgp : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @pgp : String, @sha256 : String)
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       name = "nginx/nginx"
-      regexp = "^release\-\\d+\.\\d+\.\\d+$"
+      regexp = "^release-\\d+\\.\\d+\\.\\d+$"
       GithubTags.new(client).matched_tags(name, regexp).map do |r|
         Internal.new(r.name.gsub(/^release\-/, ""))
       end.sort_by { |i| Semver.new(i.ref) }

--- a/dockerfiles/depwatcher/src/depwatcher/nginx.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/nginx.cr
@@ -5,12 +5,12 @@ require "xml"
 module Depwatcher
   class Nginx < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        pgp: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property pgp : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @pgp : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/node.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/node.cr
@@ -1,32 +1,33 @@
 require "./base"
 require "./semver"
+require "xml"
 
 module Depwatcher
   class Node < Base
     class Dist
-      JSON.mapping(
-        shasum: String,
-        tarball: String,
-      )
+      include JSON::Serializable
+
+      property shasum : String
+      property tarball : String
     end
     class Version
-      JSON.mapping(
-        name: String,
-        version: String,
-        dist: Dist,
-      )
+      include JSON::Serializable
+
+      property name : String
+      property version : String
+      property dist : Dist
     end
     class External
-      JSON.mapping(
-        versions: Hash(String, Version),
-      )
+      include JSON::Serializable
+
+      property versions : Hash(String, Version)
     end
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref, @url, @sha256)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
@@ -1,45 +1,46 @@
 require "./base"
 require "./semver"
+require "xml"
 
 module Depwatcher
   class NodeLTS < Base
     class Dist
-      JSON.mapping(
-        shasum: String,
-        tarball: String,
-      )
+      include JSON::Serializable
+
+      property shasum : String
+      property tarball : String
     end
 
     class Version
-      JSON.mapping(
-        name: String,
-        version: String,
-        dist: Dist,
-      )
+      include JSON::Serializable
+
+      property name : String
+      property version : String
+      property dist : Dist
     end
 
     class NodeVersionInfo
-      JSON.mapping(
-        start: String,
-        lts: {type: String, nilable: true},
-        maintenance: {type: String, nilable: true},
-        end: String,
-        codename: {type: String, nilable: true},
-      )
+      include JSON::Serializable
+
+      property start : String
+      property lts : String?
+      property maintenance : String?
+      property end : String
+      property codename : String?
     end
 
     class External
-      JSON.mapping(
-        versions: Hash(String, Version),
-      )
+      include JSON::Serializable
+
+      property versions : Hash(String, Version)
     end
 
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
 
       def initialize(@ref, @url, @sha256)
       end

--- a/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/node_lts.cr
@@ -76,10 +76,10 @@ module Depwatcher
           lts_month = lts_date.split("-")[1].to_i
           lts_day = lts_date.split("-")[2].to_i
           if lts_year < actual_year || (lts_year == actual_year && lts_month < actual_month) || (lts_year == actual_year && lts_month == actual_month && lts_day <= actual_day)
-            latest_lts = version[0].as(String).sub("v","")
+            latest_lts = version[0].as(String).sub("v", "")
           end
         end
-        end
+      end
       return latest_lts
     end
 

--- a/dockerfiles/depwatcher/src/depwatcher/npm.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/npm.cr
@@ -9,6 +9,7 @@ module Depwatcher
       property shasum : String
       property tarball : String
     end
+
     class Version
       include JSON::Serializable
 
@@ -16,17 +17,20 @@ module Depwatcher
       property version : String
       property dist : Dist
     end
+
     class External
       include JSON::Serializable
 
       property versions : Hash(String, Version)
     end
+
     class Release
       include JSON::Serializable
 
       property ref : String
       property url : String
       property sha1 : String
+
       def initialize(@ref, @url, @sha1)
       end
     end
@@ -42,7 +46,7 @@ module Depwatcher
       Release.new(ref, r.dist.tarball, r.dist.shasum)
     end
 
-    private def releases(name : String) : Hash(String,Version)
+    private def releases(name : String) : Hash(String, Version)
       response = client.get("https://registry.npmjs.com/#{name}/").body
       External.from_json(response).versions
     end

--- a/dockerfiles/depwatcher/src/depwatcher/npm.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/npm.cr
@@ -4,29 +4,29 @@ require "./semver"
 module Depwatcher
   class Npm < Base
     class Dist
-      JSON.mapping(
-        shasum: String,
-        tarball: String,
-      )
+      include JSON::Serializable
+
+      property shasum : String
+      property tarball : String
     end
     class Version
-      JSON.mapping(
-        name: String,
-        version: String,
-        dist: Dist,
-      )
+      include JSON::Serializable
+
+      property name : String
+      property version : String
+      property dist : Dist
     end
     class External
-      JSON.mapping(
-        versions: Hash(String, Version),
-      )
+      include JSON::Serializable
+
+      property versions : Hash(String, Version)
     end
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha1: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha1 : String
       def initialize(@ref, @url, @sha1)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/openresty.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/openresty.cr
@@ -1,16 +1,16 @@
 require "./base"
-require "./github_releases"
+require "./github_tags"
 require "xml"
 
 module Depwatcher
   class Openresty < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        pgp: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property pgp : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @pgp : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/openresty.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/openresty.cr
@@ -11,13 +11,14 @@ module Depwatcher
       property url : String
       property pgp : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @pgp : String, @sha256 : String)
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       name = "openresty/openresty"
-      regexp = "\\d+\.\\d+\.\\d+\.\\d+$"
+      regexp = "\\d+\\.\\d+\\.\\d+\\.\\d+$"
       GithubTags.new(client).matched_tags(name, regexp).map do |r|
         Internal.new(r.name.gsub(/^v/, ""))
       end.sort_by { |i| Semver.new(i.ref) }

--- a/dockerfiles/depwatcher/src/depwatcher/php.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/php.cr
@@ -6,43 +6,126 @@ require "http/request"
 module Depwatcher
   class Php < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+      
+      property ref : String
+      property url : String
+      property sha256 : String
+      
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
 
-    def check(version_filter : String) : Array(Internal)
-      major, minor  = version_filter.split('.').first(2)
-      cmd = "curl -fsSL 'https://www.php.net/releases/index.php?json&version=#{major}.#{minor}&max=1000' | jq -er 'keys'"
-      output = IO::Memory.new
-      err = IO::Memory.new
-      status = Process.run("bash", ["-lc", cmd], output: output, error: err)
-      raise "command failed: #{err.to_s.strip}" unless status.success?
+    def check(version_filter : String? = nil) : Array(Internal)
+      if version_filter.nil?
+        # When no version_filter is provided, use php.watch to get the latest supported version
+        version_filter = get_latest_supported_version()
+      end
 
-      retrieved_versions = Array(String).from_json(output.to_s)
-      versions = retrieved_versions.map { |v| Internal.new(v) }
+      version_parts = version_filter.split('.')
+      if version_parts.size < 2
+        raise "version_filter must be in format 'major.minor', got: #{version_filter}"
+      end
+      
+      major, minor = version_parts.first(2)
+      
+      # Try to get releases from php.watch first (most reliable and up-to-date)
+      phpwatch_versions = get_phpwatch_releases(major, minor)
+      if !phpwatch_versions.empty?
+        return phpwatch_versions.uniq { |i| i.ref }.sort_by { |i| Semver.new(i.ref) }
+      end
+      
+      # Fallback to PHP.net HTML scraping if php.watch is unavailable
+      all_versions = old_versions()
+      filtered_versions = all_versions.select do |v|
+        v_parts = v.ref.split('.')
+        v_parts.size >= 2 && v_parts[0] == major && v_parts[1] == minor
+      end
 
-      versions += old_versions()
-      versions = versions.uniq { |i| i.ref }
-      versions.sort_by { |i| Semver.new(i.ref) }
+      filtered_versions.uniq { |i| i.ref }.sort_by { |i| Semver.new(i.ref) }
     end
 
     def in(ref : String) : Release
-      major, minor  = ref.split('.').first(2)
+      url = "https://php.net/distributions/php-#{ref}.tar.gz"
+      
+      # Try to get SHA256 from JSON API first, fallback to computing it
+      major, minor = ref.split('.').first(2)
       param = %q(.[$ref].source[] | select(.filename == ("php-\($ref).tar.gz")) | .sha256)
       cmd = "curl -fsSL 'https://www.php.net/releases/index.php?json&version=#{major}.#{minor}&max=1000' | jq -er --arg ref '#{ref}' '#{param}'"
 
       output = IO::Memory.new
       err = IO::Memory.new
       status = Process.run("bash", ["-lc", cmd], output: output, error: err)
-      raise "command failed: #{err.to_s.strip}" unless status.success?
-      sha256 = output.to_s.strip
-      url = "https://php.net/distributions/php-#{ref}.tar.gz"
+      
+      if status.success? && !output.to_s.strip.empty?
+        sha256 = output.to_s.strip
+      else
+        # Fallback: compute SHA256 by downloading the file
+        sha256 = get_sha256(url)
+      end
+      
       Release.new(ref, url, sha256)
+    end
+
+    def get_phpwatch_releases(major : String, minor : String) : Array(Internal)
+      # Get specific patch releases from php.watch XML feed (more reliable than HTML scraping)
+      cmd = "curl -fsSL 'https://php.watch/versions/#{major}.#{minor}/releases.xml'"
+      output = IO::Memory.new
+      err = IO::Memory.new
+      status = Process.run("bash", ["-lc", cmd], output: output, error: err)
+      
+      if status.success? && !output.to_s.strip.empty?
+        # Parse XML and extract release versions, excluding QA releases (alpha, beta, RC)
+        xml_content = output.to_s.strip
+        versions = Array(Internal).new
+        
+        # Extract versions from XML entries, filtering out QA releases
+        extract_cmd = %q(echo '#{xml_content}' | grep -E '<title>PHP [0-9]+\.[0-9]+\.[0-9]+</title>' | grep -v 'alpha\|beta\|RC' | sed -E 's/.*<title>PHP ([0-9]+\.[0-9]+\.[0-9]+)<\/title>.*/\1/')
+        extract_output = IO::Memory.new
+        extract_err = IO::Memory.new
+        extract_status = Process.run("bash", ["-lc", extract_cmd], output: extract_output, error: extract_err)
+        
+        if extract_status.success? && !extract_output.to_s.strip.empty?
+          versions = extract_output.to_s.strip.split('\n').map { |v| Internal.new(v.strip) }
+          return versions.reject { |v| v.ref.empty? }
+        end
+      end
+      
+      # Fallback to HTML scraping if XML parsing fails
+      html_cmd = "curl -fsSL 'https://php.watch/versions/#{major}.#{minor}/releases' | grep -oE 'PHP #{major}\\.#{minor}\\.[0-9]+' | sed 's/PHP //g'"
+      html_output = IO::Memory.new
+      html_err = IO::Memory.new
+      html_status = Process.run("bash", ["-lc", html_cmd], output: html_output, error: html_err)
+      
+      if html_status.success? && !html_output.to_s.strip.empty?
+        versions = html_output.to_s.strip.split('\n').map { |v| Internal.new(v.strip) }
+        return versions.reject { |v| v.ref.empty? }
+      else
+        return Array(Internal).new
+      end
+    end
+
+    def get_latest_supported_version() : String
+      # Use php.watch API to get the latest supported PHP version
+      cmd = "curl -fsSL 'https://php.watch/api/v1/versions/latest' | jq -er '.data | keys[0] as $version_id | .[$version_id].name'"
+      output = IO::Memory.new
+      err = IO::Memory.new
+      status = Process.run("bash", ["-lc", cmd], output: output, error: err)
+      
+      if status.success?
+        return output.to_s.strip
+      else
+        # Fallback to HTML scraping approach if php.watch is unavailable
+        all_versions = old_versions().uniq { |i| i.ref }.sort_by { |i| Semver.new(i.ref) }
+        if all_versions.empty?
+          raise "Unable to determine latest PHP version from any source"
+        end
+        
+        latest_version = all_versions.last
+        latest_major = latest_version.ref.split('.')[0]
+        latest_minor = latest_version.ref.split('.')[1]
+        return "#{latest_major}.#{latest_minor}"
+      end
     end
 
     def old_versions() : Array(Internal)

--- a/dockerfiles/depwatcher/src/depwatcher/pypi.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/pypi.cr
@@ -27,10 +27,10 @@ module Depwatcher
       property url : String
       property md5_digest : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @md5_digest : String, @sha256 : String)
       end
     end
-
 
     def check(name : String) : Array(Internal)
       releases(name).map do |version, _|

--- a/dockerfiles/depwatcher/src/depwatcher/pypi.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/pypi.cr
@@ -4,29 +4,29 @@ require "./semver"
 module Depwatcher
   class Pypi < Base
     class External
-      JSON.mapping(
-        releases: Hash(String, Array(ExternalRelease)),
-      )
+      include JSON::Serializable
+
+      property releases : Hash(String, Array(ExternalRelease))
     end
 
     class ExternalRelease
-      JSON.mapping(
-        ref: String?,
-        url: String,
-        digests: Hash(String, String),
-        md5_digest: String,
-        packagetype: String,
-        size: Int64,
-      )
+      include JSON::Serializable
+
+      property ref : String?
+      property url : String
+      property digests : Hash(String, String)
+      property md5_digest : String
+      property packagetype : String
+      property size : Int64
     end
 
     class Release
-      JSON.mapping(
-        ref: String?,
-        url: String,
-        md5_digest: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String?
+      property url : String
+      property md5_digest : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @md5_digest : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/python.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/python.cr
@@ -10,11 +10,12 @@ module Depwatcher
       property url : String
       property md5_digest : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @md5_digest : String, @sha256 : String)
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       response = client.get("https://www.python.org/downloads/").body
       doc = XML.parse_html(response)
       lis = doc.xpath("//*[contains(@class,'release-number')]/a")
@@ -26,7 +27,7 @@ module Depwatcher
     end
 
     def in(ref : String) : Release
-      response = client.get("https://www.python.org/downloads/release/python-#{ref.gsub(/\D/,"")}/").body
+      response = client.get("https://www.python.org/downloads/release/python-#{ref.gsub(/\D/, "")}/").body
       doc = XML.parse_html(response)
       a = doc.xpath("//a[contains(text(),'Gzipped source tarball')]")
       raise "Could not parse python release (a) website" unless a.is_a?(XML::NodeSet)

--- a/dockerfiles/depwatcher/src/depwatcher/python.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/python.cr
@@ -4,12 +4,12 @@ require "xml"
 module Depwatcher
   class Python < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        md5_digest: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property md5_digest : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @md5_digest : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/r.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/r.cr
@@ -5,11 +5,11 @@ require "xml"
 module Depwatcher
   class R < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/r.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/r.cr
@@ -10,11 +10,12 @@ module Depwatcher
       property ref : String
       property url : String
       property sha256 : String
+
       def initialize(@ref : String, @url : String, @sha256 : String)
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       response = client.get("https://cran.r-project.org/src/base/R-4/").body
       doc = XML.parse_html(response)
       lis = doc.xpath("//td/a")

--- a/dockerfiles/depwatcher/src/depwatcher/ruby.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/ruby.cr
@@ -47,8 +47,8 @@ module Depwatcher
 
       versions.each do |v|
         version = v.version
-        url = !v.url.nil? ? v.url.not_nil!["gz"] : ""
-        sha = !v.sha256.nil? ? v.sha256.not_nil!["gz"] : ""
+        url = v.url.try(&.["gz"]) || ""
+        sha = v.sha256.try(&.["gz"]) || ""
         newRelease = Release.new(version, url, sha)
 
         if ref == version
@@ -62,13 +62,13 @@ module Depwatcher
     end
 
     private def releaseFromIndex(ref : String) : Release | Nil
-      result = Release.new("","","")
+      result = Release.new("", "", "")
       allReleases = [] of Release
       response = client.get("https://cache.ruby-lang.org/pub/ruby/index.txt").body
 
       response.each_line do |line|
         releaseArray = [] of String
-        line.split { |s| releaseArray << s}
+        line.split { |s| releaseArray << s }
         raise "Could not parse ruby website" unless !releaseArray.empty?
         version = releaseArray[0].lchop("ruby-")
         url = releaseArray[1]
@@ -79,7 +79,7 @@ module Depwatcher
           result = newRelease
         end
       end
-      raise ("No release with ref:" + ref + "found") unless !result.url.empty?
+      raise("No release with ref:" + ref + "found") unless !result.url.empty?
       result
     end
   end

--- a/dockerfiles/depwatcher/src/depwatcher/ruby.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/ruby.cr
@@ -6,19 +6,19 @@ require "yaml"
 module Depwatcher
   class Ruby < Base
     class GithubRelease
-      YAML.mapping(
-        version: String,
-        url: Hash(String, String)?,
-        sha256: Hash(String, String)?,
-      )
+      include YAML::Serializable
+
+      property version : String
+      property url : Hash(String, String)?
+      property sha256 : Hash(String, String)?
     end
 
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-        sha256: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+      property sha256 : String
 
       def initialize(@ref : String, @url : String, @sha256 : String)
       end

--- a/dockerfiles/depwatcher/src/depwatcher/rubygems.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/rubygems.cr
@@ -8,6 +8,7 @@ module Depwatcher
       property number : String
       property prerelease : Bool
     end
+
     class External
       include JSON::Serializable
 
@@ -16,12 +17,14 @@ module Depwatcher
       property prerelease : Bool
       property source_code_uri : String
     end
+
     class Release
       include JSON::Serializable
 
       property ref : String
       property sha256 : String
       property url : String
+
       def initialize(external : External)
         @ref = external.number
         @sha256 = external.sha

--- a/dockerfiles/depwatcher/src/depwatcher/rubygems.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/rubygems.cr
@@ -3,25 +3,25 @@ require "./base"
 module Depwatcher
   class Rubygems < Base
     class MultiExternal
-      JSON.mapping(
-        number: String,
-        prerelease: Bool,
-      )
+      include JSON::Serializable
+
+      property number : String
+      property prerelease : Bool
     end
     class External
-      JSON.mapping(
-        number: String,
-        sha: String,
-        prerelease: Bool,
-        source_code_uri: String,
-      )
+      include JSON::Serializable
+
+      property number : String
+      property sha : String
+      property prerelease : Bool
+      property source_code_uri : String
     end
     class Release
-      JSON.mapping(
-        ref: String,
-        sha256: String,
-        url: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property sha256 : String
+      property url : String
       def initialize(external : External)
         @ref = external.number
         @sha256 = external.sha

--- a/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
@@ -4,10 +4,11 @@ require "xml"
 module Depwatcher
   class RubygemsCli < Base
     class Release
-      JSON.mapping(
-        ref: String,
-        url: String,
-      )
+      include JSON::Serializable
+
+      property ref : String
+      property url : String
+
       def initialize(@ref : String, @url : String)
       end
     end

--- a/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
+++ b/dockerfiles/depwatcher/src/depwatcher/rubygems_cli.cr
@@ -13,7 +13,7 @@ module Depwatcher
       end
     end
 
-    def check() : Array(Internal)
+    def check : Array(Internal)
       response = client.get("https://rubygems.org/pages/download").body
       doc = XML.parse_html(response)
       links = doc.xpath("//div[@id='formats']//a[text()='tgz']")


### PR DESCRIPTION
the expected behaviour is that when no version_filter is applied that it would retrieve the latest version.
this was not working for php. as it would break. due to the `THIS_DEFAULT_CASE_SHOULD_NOT_HAPPEN` in check.cr
and thus result in a index out of bounds error.

as i tried to fix php i noticed that the crystal-lang version was ancient.
so upgraded to the latest crystal-lang version and applied formatting and code changes and upgraded the spec files

and created a working spec test for php as everything was commented out.