### PR TITLE
fix psych errors that where not solved when we migratied to ruby 3.4

### DIFF
--- a/lib/buildpack-binary-checksum-verifier.rb
+++ b/lib/buildpack-binary-checksum-verifier.rb
@@ -6,7 +6,7 @@ require 'digest/md5'
 
 class BuildpackBinaryChecksumVerifier
   def self.run!(buildpack_dir, whitelist_file)
-    uris_to_ignore = YAML.load_file(whitelist_file)
+    uris_to_ignore = YAML.load_file(whitelist_file, permitted_classes: [Date, Time])
     uri_to_sha256_mapping = get_checksums_by_uri(buildpack_dir, uris_to_ignore)
     show_mismatches(uri_to_sha256_mapping)
   end
@@ -19,7 +19,7 @@ class BuildpackBinaryChecksumVerifier
     release_tag_shas.each do |release_sha|
       begin
         manifest_contents = GitClient.get_file_contents_at_sha(buildpack_dir, release_sha, 'manifest.yml')
-        manifest = YAML.load(manifest_contents)
+        manifest = YAML.load(manifest_contents, permitted_classes: [Date, Time])
 
         manifest["dependencies"].each do |dependency|
           uri = dependency["uri"]

--- a/lib/buildpack-dependency.rb
+++ b/lib/buildpack-dependency.rb
@@ -17,7 +17,7 @@ class BuildpackDependency
 
   def self.buildpack_manifests
     @buildpack_manifests ||= BUILDPACKS.map do |name|
-      [name, YAML.load(open("https://raw.githubusercontent.com/cloudfoundry/#{name}-buildpack/develop/manifest.yml"))]
+      [name, YAML.load(open("https://raw.githubusercontent.com/cloudfoundry/#{name}-buildpack/develop/manifest.yml"), permitted_classes: [Date, Time])]
     end
   end
 end

--- a/lib/buildpacks-ci-configuration.rb
+++ b/lib/buildpacks-ci-configuration.rb
@@ -1,10 +1,10 @@
 class BuildpacksCIConfiguration
   def organization
-    YAML.load_file('public-config.yml')['buildpacks-github-org']
+    YAML.load_file('public-config.yml', permitted_classes: [Date, Time])['buildpacks-github-org']
   end
 
   def run_oracle_php_tests?
-    YAML.load_file('public-config.yml')['run-oracle-php-tests']
+    YAML.load_file('public-config.yml', permitted_classes: [Date, Time])['run-oracle-php-tests']
   end
 
   def concourse_target_name

--- a/lib/cve-history.rb
+++ b/lib/cve-history.rb
@@ -9,7 +9,7 @@ class CVEHistory
     file_path = File.join(cves_dir, yaml_filename)
 
     if File.exist? file_path
-      YAML.load_file("#{cves_dir}/#{yaml_filename}") || []
+      YAML.load_file("#{cves_dir}/#{yaml_filename}", permitted_classes: [Date, Time]) || []
     else
       File.open(file_path, 'w') { |handle| handle.write([].to_yaml) }
       []

--- a/lib/release-notes-creator.rb
+++ b/lib/release-notes-creator.rb
@@ -10,7 +10,7 @@ class RootfsReleaseNotesCreator
   end
 
   def cves
-    @cves ||= YAML.load_file(@cves_yaml_file)
+    @cves ||= YAML.load_file(@cves_yaml_file, permitted_classes: [Date, Time])
   end
 
   def release_notes

--- a/scripts/php-modules/update.rb
+++ b/scripts/php-modules/update.rb
@@ -14,7 +14,7 @@ def update_modules(&f)
     path = File.expand_path("../../tasks/build-binary-new/#{ext_file}")
 
     puts "==> Processing: #{path}"
-    data = YAML.load_file(path)
+    data = YAML.load_file(path, permitted_classes: [Date, Time])
 
     extensions = ['extensions']
     native_modules = ['native_modules']

--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/extensions_helper.rb
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/extensions_helper.rb
@@ -6,7 +6,7 @@ class PHPExtensionsHelper
   def initialize(path)
     yml_validate(path)
     @base_path = path
-    @base_yml = YAML.load_file(path)
+    @base_yml = YAML.load_file(path, permitted_classes: [Date, Time])
   end
 
   def yml_validate(path)
@@ -24,7 +24,7 @@ class PHPExtensionsHelper
 
   def patch!(patch_file)
     yml_validate(patch_file)
-    patch_yml = YAML.load_file(patch_file)
+    patch_yml = YAML.load_file(patch_file, permitted_classes: [Date, Time])
     return false unless patch_yml
 
     %w[extensions native_modules].each do |category|

--- a/tasks/build-binary-new/merge-extensions.rb
+++ b/tasks/build-binary-new/merge-extensions.rb
@@ -7,7 +7,7 @@ class BaseExtensions
   def initialize(path)
     yml_validate(path)
     @base_path = path
-    @base_yml = YAML::load_file(path)
+    @base_yml = YAML::load_file(path, permitted_classes: [Date, Time])
   end
 
   def yml_validate(path)
@@ -27,7 +27,7 @@ class BaseExtensions
 
   def patch!(patch_file)
     yml_validate(patch_file)
-    patch_yml = YAML::load_file(patch_file)
+    patch_yml = YAML::load_file(patch_file, permitted_classes: [Date, Time])
     return false unless patch_yml
     ['extensions', 'native_modules'].each do |category|
       patch_yml.dig(category,'additions')&.each do |ext|

--- a/tasks/create-bosh-release/buildpack-bosh-release-updater.rb
+++ b/tasks/create-bosh-release/buildpack-bosh-release-updater.rb
@@ -49,7 +49,7 @@ class BuildpackBOSHReleaseUpdater
   end
 
   def delete_old_blobs
-    blobs = YAML.load_file('config/blobs.yml') || {}
+    blobs = YAML.load_file('config/blobs.yml', permitted_classes: [Date, Time]) || {}
 
     blobs.keys.each do |key|
       blobs.delete(key) if key.include?('buildpack')

--- a/tasks/create-deployment-source-config/run.rb
+++ b/tasks/create-deployment-source-config/run.rb
@@ -13,7 +13,7 @@ Dir.chdir("bbl-state/#{ENV['ENV_NAME']}") do
     "client_secret"=> `bbl director-password`.strip,
     "ca_cert"=> `bbl director-ca-cert`.strip,
     "jumpbox_url"=> `bbl jumpbox-address`.strip + ':22',
-    "jumpbox_ssh_key"=>YAML.load(open('vars/jumpbox-vars-store.yml').read).dig('jumpbox_ssh','private_key')
+    "jumpbox_ssh_key"=>YAML.load(open('vars/jumpbox-vars-store.yml').read, permitted_classes: [Date, Time]).dig('jumpbox_ssh','private_key')
   }
 end
 

--- a/tasks/generate-rootfs-release-notes/run.rb
+++ b/tasks/generate-rootfs-release-notes/run.rb
@@ -49,7 +49,7 @@ body_file = 'release-body/body'
 File.write(body_file, notes)
 old_receipt.unlink
 
-cves = YAML.load_file(cve_yaml_file)
+cves = YAML.load_file(cve_yaml_file, permitted_classes: [Date, Time])
 
 updated_cves = cves.map do |cve|
   cve['stack_release'] = new_version if cve['stack_release'] == 'unreleased'

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -22,8 +22,8 @@ all_stacks = BUILD_STACKS + WINDOWS_STACKS + ["any-stack"]
 cflinuxfs4_dependencies = config['cflinuxfs4_dependencies']
 cflinuxfs4_buildpacks = config['cflinuxfs4_buildpacks']
 
-manifest = YAML.load_file('buildpack/manifest.yml')
-manifest_latest_released = YAML.load_file('buildpack-latest-released/manifest.yml') # rescue { 'dependencies' => [] }
+manifest = YAML.load_file('buildpack/manifest.yml', permitted_classes: [Date, Time])
+manifest_latest_released = YAML.load_file('buildpack-latest-released/manifest.yml', permitted_classes: [Date, Time]) # rescue { 'dependencies' => [] }
 
 data = JSON.parse(open('source/data.json').read)
 source_name = data.dig('source', 'name')


### PR DESCRIPTION
we noticed that allot of yaml load calls where still not fixed for the new psych version when we migrated to ruby 3.4