### PR TITLE
Automate buildpack version bumping using git-based semver resource

### DIFF
--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -334,28 +334,12 @@ jobs: ##########################################################################
           resource: buildpack-master
       - task: check-tag-not-already-added
         file: buildpacks-ci/tasks/check-tag-not-already-added/task.yml
-      - put: buildpack-master
-        params:
-          repository: buildpack
-          tag: version/number
-          tag_prefix: v
-  - name: buildpack-to-github
-    serial: true
-    public: true
-    plan:
-      - in_parallel:
-        - get: buildpacks-ci
-        <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
-        - get: uncached-buildpack-for-stack<%= ndx.to_s %>
-          resource: pivotal-buildpack-<%= stack %>
-          passed: [ ship-it ]
-        <% end %>
-        - get: buildpack
-          resource: buildpack-master
-          passed: [ ship-it ]
-          trigger: true
       - task: finalize-buildpack
         file: buildpacks-ci/tasks/finalize-buildpack/task.yml
+        input_mapping:
+          <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
+          uncached-buildpack-for-stack<%= ndx.to_s %>: pivotal-buildpack-<%= stack %>
+          <% end %>
       - put: buildpack-github-release
         params:
           name: buildpack-artifacts/tag

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -137,6 +137,15 @@ resources: #####################################################################
       branch: master
       private_key: '((cf-buildpacks-eng-github-ssh-key.private_key))'
 
+  - name: version
+    type: semver
+    source:
+      driver: git
+      uri: git@github.com:<%= organization %>/<%= language %>-buildpack.git
+      branch: master
+      file: VERSION
+      private_key: ((cf-buildpacks-eng-github-ssh-key.private_key))
+
 
   ## Github Releases ##
 
@@ -263,12 +272,16 @@ jobs: ##########################################################################
         - get: buildpack
           resource: buildpack-master
           trigger: true
+        - get: version
+          params: { bump: patch }
 <% bucket_stacks = buildpacks[language]['stacks']
    bucket_stacks = bucket_stacks + ['any'] if language.to_s == 'hwc' || language.to_s == 'binary'
    bucket_stacks.each do |stack| %> #change bucket_stacks to buildpacks[language]['stacks'] when removing any_stack
         - get: pivotal-buildpack-cached-<%= stack %>
         - get: pivotal-buildpack-<%= stack %>
 <% end %>
+      - put: version
+        params: { file: version/number }
       - do:
         - in_parallel:
 <% bucket_stacks = buildpacks[language]['stacks']
@@ -300,6 +313,9 @@ jobs: ##########################################################################
     plan:
       - in_parallel:
         - get: buildpacks-ci
+        - get: version
+          passed:
+            - detect-new-version-and-upload-artifacts
         <%
         all_stacks = buildpacks[language]['stacks']
         all_stacks = all_stacks + ['any'] if language.to_s == 'hwc' || language.to_s == 'binary'
@@ -321,7 +337,7 @@ jobs: ##########################################################################
       - put: buildpack-master
         params:
           repository: buildpack
-          tag: buildpack/VERSION
+          tag: version/number
           tag_prefix: v
   - name: buildpack-to-github
     serial: true
@@ -345,6 +361,7 @@ jobs: ##########################################################################
           name: buildpack-artifacts/tag
           tag: buildpack-artifacts/tag
           body: buildpack-artifacts/RECENT_CHANGES
+          generate_release_notes: true
           globs:
             - buildpack-artifacts/*-buildpack*-v*.zip
             - buildpack-artifacts/*-buildpack*-v*.zip.SHA256SUM.txt

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -344,6 +344,7 @@ jobs: ##########################################################################
           globs:
             - buildpack-artifacts/*-buildpack*-v*.zip
             - buildpack-artifacts/*-buildpack*-v*.zip.SHA256SUM.txt
+          commitish: buildpack-master/.git/ref
 
 <% relevant_stacks = buildpacks[language]['stacks'] %>
 <% relevant_stacks.each do |stack| %>

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -315,7 +315,8 @@ jobs: ##########################################################################
           passed:
             - detect-new-version-and-upload-artifacts
         <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
-        - get: pivotal-buildpack-<%= stack %>
+        - get: uncached-buildpack-for-stack<%= ndx.to_s %>
+          resource: pivotal-buildpack-<%= stack %>
           passed:
             - detect-new-version-and-upload-artifacts
         <% end %>
@@ -332,9 +333,6 @@ jobs: ##########################################################################
         file: buildpacks-ci/tasks/finalize-buildpack/task.yml
         input_mapping:
           buildpack: buildpack-master
-          <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
-          uncached-buildpack-for-stack<%= ndx.to_s %>: pivotal-buildpack-<%= stack %>
-          <% end %>
       - put: buildpack-github-release
         params:
           name: buildpack-artifacts/tag

--- a/pipelines/templates/buildpack.yml.erb
+++ b/pipelines/templates/buildpack.yml.erb
@@ -280,8 +280,6 @@ jobs: ##########################################################################
         - get: pivotal-buildpack-cached-<%= stack %>
         - get: pivotal-buildpack-<%= stack %>
 <% end %>
-      - put: version
-        params: { file: version/number }
       - do:
         - in_parallel:
 <% bucket_stacks = buildpacks[language]['stacks']
@@ -316,14 +314,7 @@ jobs: ##########################################################################
         - get: version
           passed:
             - detect-new-version-and-upload-artifacts
-        <%
-        all_stacks = buildpacks[language]['stacks']
-        all_stacks = all_stacks + ['any'] if language.to_s == 'hwc' || language.to_s == 'binary'
-        all_stacks.each_with_index do |stack, ndx|
-        %>
-        - get: pivotal-buildpack-cached-<%= stack %>
-          passed:
-            - detect-new-version-and-upload-artifacts
+        <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
         - get: pivotal-buildpack-<%= stack %>
           passed:
             - detect-new-version-and-upload-artifacts
@@ -334,9 +325,13 @@ jobs: ##########################################################################
           resource: buildpack-master
       - task: check-tag-not-already-added
         file: buildpacks-ci/tasks/check-tag-not-already-added/task.yml
+      - put: version
+        params: { file: version/number }
+      - get: buildpack-master
       - task: finalize-buildpack
         file: buildpacks-ci/tasks/finalize-buildpack/task.yml
         input_mapping:
+          buildpack: buildpack-master
           <% buildpacks[language]['stacks'].each_with_index do |stack, ndx| %>
           uncached-buildpack-for-stack<%= ndx.to_s %>: pivotal-buildpack-<%= stack %>
           <% end %>

--- a/tasks/check-tag-not-already-added/run.sh
+++ b/tasks/check-tag-not-already-added/run.sh
@@ -6,7 +6,11 @@ set -o pipefail
 
 VERSION=""
 if [[ -d "version" ]]; then
-    VERSION=$(cat version/version)
+    if [[ -f "version/number" ]]; then
+        VERSION=$(cat version/number)
+    elif [[ -f "version/version" ]]; then
+        VERSION=$(cat version/version)
+    fi
 else
     VERSION=$(cat buildpack/VERSION)
 fi

--- a/tasks/detect-and-upload/task.yml
+++ b/tasks/detect-and-upload/task.yml
@@ -13,6 +13,8 @@ inputs:
     optional: true
   - name: buildpacks-ci
   - name: buildpack
+  - name: version
+    optional: true
 outputs:
   - name: buildpack-artifacts
 run:
@@ -21,6 +23,10 @@ run:
     - -cl
     - |
       set -e
+      if [ -d "version" ] && [ -f "version/number" ]; then
+        cp version/number buildpack/VERSION
+        echo "Updated buildpack VERSION to $(cat buildpack/VERSION)"
+      fi
       pushd buildpacks-ci
         tasks/detect-and-upload/run.rb
       popd

--- a/tasks/finalize-buildpack/buildpack-finalizer.rb
+++ b/tasks/finalize-buildpack/buildpack-finalizer.rb
@@ -25,10 +25,12 @@ class BuildpackFinalizer
 
   def add_changelog
     Dir.chdir(@buildpack_repo_dir) do
-      changes = File.read('CHANGELOG')
-      recent_changes = changes.split(/^v[0-9.]+.*?=+$/m)[1].strip
+      return unless File.exist?('CHANGELOG')
 
-      File.write(@recent_changes_file, "#{recent_changes}\n")
+      changes = File.read('CHANGELOG')
+      recent_changes = changes.split(/^v[0-9.]+.*?=+$/m)[1]&.strip
+
+      File.write(@recent_changes_file, "#{recent_changes}\n") if recent_changes
     end
   end
 

--- a/tasks/finalize-buildpack/run.rb
+++ b/tasks/finalize-buildpack/run.rb
@@ -3,7 +3,13 @@
 require_relative 'buildpack-finalizer'
 
 artifact_dir = File.join(Dir.pwd, 'buildpack-artifacts')
-version = File.read('buildpack/VERSION').strip
+
+# Read version from semver resource if available, otherwise from buildpack/VERSION
+version = if File.directory?('version') && File.file?('version/number')
+            File.read('version/number').strip
+          else
+            File.read('buildpack/VERSION').strip
+          end
 
 buildpack_repo_dir = 'buildpack'
 uncached_buildpack_dirs = Dir.glob('uncached-buildpack-for-stack*')

--- a/tasks/finalize-buildpack/task.yml
+++ b/tasks/finalize-buildpack/task.yml
@@ -9,6 +9,8 @@ image_resource:
 inputs:
   - name: buildpacks-ci
   - name: buildpack
+  - name: version
+    optional: true
   - name: uncached-buildpack-for-stack0
   - name: uncached-buildpack-for-stack1
     optional: true


### PR DESCRIPTION
After PR #473 removed the buildpack-to-master job, dependency update PRs would merge but ship-it would fail because VERSION files weren't being bumped, causing attempts to create artifacts for existing tags.

This adds a semver resource that:
- Uses the buildpack repo's VERSION file as the version state
- Automatically bumps patch version on each master merge
- Updates detect-and-upload to use the bumped version
- Tags releases with the semver version instead of VERSION file
- Enables auto-generated GitHub release notes
- Makes CHANGELOG optional in buildpack finalizer

This enables fully automated dependency releases without manual VERSION file management.