### PR TITLE
Use version: latest instead of version: every for dependency source resources

### DIFF
--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -243,7 +243,7 @@ jobs:
     - get: source
       resource: #@ "source-{}-latest".format(dep_name.lower())
       trigger: true
-      version: every
+      version: latest
   - do:
     - task: create-new-version-line-story
       file: buildpacks-ci/tasks/create-new-version-line-story/create-new-version-line-story.yml
@@ -264,7 +264,7 @@ jobs:
     - get: source
       resource: source-node-node-lts
       trigger: true
-      version: every
+      version: latest
     - get: builds
   - do:
     - task: create-new-version-line-story-node
@@ -282,7 +282,7 @@ jobs:
     - get: source
       resource: #@ "source-{}-{}".format(dep_name.lower(), line.lower())
       trigger: true
-      version: every
+      version: latest
       passed: 
       - #@ "build-{}-{}".format(dep_name.lower(), line.lower())
     - get: builds
@@ -315,11 +315,11 @@ jobs:
     - get: source
       resource: #@ "source-{}-{}".format(dep_name.lower(), line.lower())
       trigger: true
-      version: every
+      version: latest
     #@ for monitored_dep_name in getattr(dep, "monitored_deps", []):
     - get: #@ "source-{}-latest".format(monitored_dep_name.lower())
       trigger: true
-      version: every
+      version: latest
     #@ end
     #@ images_to_get = []
     #@ for stack in build_stacks:
@@ -391,12 +391,12 @@ jobs:
       #@ else:
       - #@ "build-{}-{}".format(dep_name.lower(), line_hash["line"].lower())
       #@ end
-      version: every
+      version: latest
       trigger: true
     #@ for monitored_dep_name in getattr(dep, "monitored_deps", []):
     - get: #@ "source-{}-latest".format(monitored_dep_name.lower())
       trigger: true
-      version: every
+      version: latest
       passed: 
       - #@ "build-{}-{}".format(dep_name.lower(), line_hash["line"].lower())
     #@ end


### PR DESCRIPTION
## Problem

Using `version: every` on monitored dependency resources (e.g. `source-rserve-latest`) causes `update-*` jobs to get permanently stuck when an intermediate version of a monitored dep is released but never flows through the corresponding `build-*` job.

**Example**: `rserve` released `1.8.18` between two `build-r` runs. The `build-r` job jumped directly from `1.8.17` to `1.8.19`, so `1.8.18` never had a `build-r` build associated with it. With `version: every`, Concourse requires each version to satisfy the `passed` constraint sequentially — so the `update-r` jobs were permanently blocked even after `build-r` succeeded with `1.8.19`.

## Fix

Change `version: every` to `version: latest` for all dependency source resource `get` steps. This means Concourse only requires the **latest** available version to have passed through the upstream job, rather than every intermediate version.

The `update-*` jobs are not lossy with this change — they still trigger on every new R (or other primary dependency) version via the `source-r-X.X.x` resource. The monitored deps (`rserve`, `forecast`, `shiny`, `plumber`) are used to ensure the built binary is tested with up-to-date packages, so tracking only the latest is sufficient.