### PR TITLE
fix: make any-stack build stack configurable

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -459,6 +459,9 @@ dependencies:
     any_stack: true
     versions_to_keep: 2
 build_stacks: [ 'cflinuxfs4', 'cflinuxfs5' ]
+# Stack used to build any_stack: true dependencies (stack-neutral binaries).
+# When a new stack becomes the default, update this one value.
+any_stack_build_stack: cflinuxfs4
 windows_stacks: [ 'windows' ]
 
 #! only check deprecation dates for dotnet-runtime as they are redundant for sdk and aspnetcore

--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -323,7 +323,7 @@ jobs:
     #@ end
     #@ images_to_get = []
     #@ for stack in build_stacks:
-    #@   img = "cflinuxfs4" if stack == "any-stack" else stack
+    #@   img = data.values.any_stack_build_stack if stack == "any-stack" else stack
     #@   if img not in images_to_get:
     #@     images_to_get.append(img)
     #@   end
@@ -337,7 +337,7 @@ jobs:
     #@ for stack in build_stacks:
     - do:
       - task: #@ "build-binary-{}".format(stack)
-        image: #@ "{}-image".format("cflinuxfs4" if stack == "any-stack" else stack)
+        image: #@ "{}-image".format(data.values.any_stack_build_stack if stack == "any-stack" else stack)
         file: buildpacks-ci/tasks/build-binary/build.yml
         timeout: 3h
         attempts: 2
@@ -346,6 +346,7 @@ jobs:
           builds-artifacts: #@ "{}-builds-metadata".format(stack)
         params:
           STACK: #@ stack
+          ANY_STACK_BUILD_STACK: #@ data.values.any_stack_build_stack
       #@ if getattr(dep, "third_party_hosted", False):
       - put: #@ "builds-metadata-{}".format(stack)
         resource: builds

--- a/tasks/build-binary/build.sh
+++ b/tasks/build-binary/build.sh
@@ -19,8 +19,17 @@ export NEEDRESTART_MODE=a
 # cflinuxfs4/cflinuxfs5 are minimal rootfs images: no Go, no Python.
 # Extract the pinned Go URL and SHA256 from the stack YAML using awk,
 # then download, verify, and install into /usr/local/go.
+#
+# any-stack builds run on the stack named by ANY_STACK_BUILD_STACK (default:
+# cflinuxfs4). Use that stack's YAML for bootstrapping — any-stack.yaml does
+# not exist and should never be created; it is a build-label, not a stack.
 if ! command -v go &>/dev/null; then
-  STACK_YAML="binary-builder/stacks/${STACK}.yaml"
+  BUILD_STACK="${STACK}"
+  if [[ "${STACK}" == "any-stack" ]]; then
+    BUILD_STACK="${ANY_STACK_BUILD_STACK}"
+    echo "[task] STACK=any-stack — using ${BUILD_STACK} for Go bootstrap"
+  fi
+  STACK_YAML="binary-builder/stacks/${BUILD_STACK}.yaml"
 
   # Parse the bootstrap.go block: match the 'go:' key under 'bootstrap:',
   # then grab the next 'url:' and 'sha256:' values.

--- a/tasks/build-binary/build.yml
+++ b/tasks/build-binary/build.yml
@@ -25,4 +25,5 @@ run:
   path: buildpacks-ci/tasks/build-binary/build.sh
 params:
   STACK:
+  ANY_STACK_BUILD_STACK:
   SKIP_COMMIT:


### PR DESCRIPTION
## Problem

The `build-binary-any-stack` CI job was failing with:

```
awk: cannot open binary-builder/stacks/any-stack.yaml (No such file or directory)
```

`any-stack` is a build label (meaning "this binary is stack-neutral"), not a real stack. `any-stack.yaml` does not exist and should never be created. The pipeline already runs `any-stack` builds on the `cflinuxfs4` image, but that mapping was:

- Hardcoded in two places in `pipeline.yml`
- **Not propagated to `build.sh` at all** — causing the failure

## Solution

Introduce `any_stack_build_stack` as a single, explicit configuration value. When migrating `any-stack` builds to `cflinuxfs5` in the future, only this one value needs to change.

## Changes

| File | Change |
|------|--------|
| `pipelines/dependency-builds/config.yml` | Add `any_stack_build_stack: cflinuxfs4` — single source of truth |
| `pipelines/dependency-builds/pipeline.yml` | Replace both hardcoded `"cflinuxfs4" if stack == "any-stack"` with `data.values.any_stack_build_stack`; pass `ANY_STACK_BUILD_STACK` param to the build task |
| `tasks/build-binary/build.yml` | Declare `ANY_STACK_BUILD_STACK: cflinuxfs4` param (safe default if task is run outside the pipeline) |
| `tasks/build-binary/build.sh` | When `STACK=any-stack`, resolve `BUILD_STACK` from `ANY_STACK_BUILD_STACK` before reading the stack YAML and invoking `binary-builder`; add comment that `any-stack.yaml` must never be created |

## To migrate to cflinuxfs5 in the future

Change one line in `config.yml`:

```yaml
any_stack_build_stack: cflinuxfs5
```

That's it — `pipeline.yml`, `build.yml`, and `build.sh` all follow automatically.