### PR TITLE
Enable cflinuxfs5 stack across all buildpack pipelines

### DIFF
--- a/pipelines/buildpack/apt-values.yml
+++ b/pipelines/buildpack/apt-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: ""
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/binary-values.yml
+++ b/pipelines/buildpack/binary-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   - windows
   product_slug: binary-buildpack
   skip_docker_start: true

--- a/pipelines/buildpack/dotnet-core-values.yml
+++ b/pipelines/buildpack/dotnet-core-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: dotnet-core-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/go-values.yml
+++ b/pipelines/buildpack/go-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: go-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/java-values.yml
+++ b/pipelines/buildpack/java-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: java-buildpack
   branch: main
   skip_docker_start: true

--- a/pipelines/buildpack/nginx-values.yml
+++ b/pipelines/buildpack/nginx-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: nginx-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/nodejs-values.yml
+++ b/pipelines/buildpack/nodejs-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: nodejs-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/php-values.yml
+++ b/pipelines/buildpack/php-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: php-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/pipeline.yml
+++ b/pipelines/buildpack/pipeline.yml
@@ -226,6 +226,7 @@ resources:
       access_key_id: ((buildpacks-cloudfoundry-org-aws-access-key-id))
       secret_access_key: ((buildpacks-cloudfoundry-org-aws-secret-access-key))
 
+  #@ if "cflinuxfs5" in data.values.buildpack.stacks:
   - name: version-stack-cflinuxfs5
     type: semver
     source:
@@ -233,6 +234,7 @@ resources:
       key: versions/stack-cflinuxfs5
       access_key_id: ((buildpacks-cloudfoundry-org-aws-access-key-id))
       secret_access_key: ((buildpacks-cloudfoundry-org-aws-secret-access-key))
+  #@ end
 
   #! GitHub Releases
   - name: buildpack-github-release

--- a/pipelines/buildpack/r-values.yml
+++ b/pipelines/buildpack/r-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: r-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/ruby-values.yml
+++ b/pipelines/buildpack/ruby-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: ruby-buildpack
   skip_docker_start: true
   skip_brats: true

--- a/pipelines/buildpack/staticfile-values.yml
+++ b/pipelines/buildpack/staticfile-values.yml
@@ -6,7 +6,7 @@ organization: cloudfoundry
 buildpack:
   stacks:
   - cflinuxfs4
-  #! - cflinuxfs5  #! TODO: re-enable when cf-runtime cflinuxfs5 support is ready
+  - cflinuxfs5
   product_slug: staticfile-buildpack
   skip_docker_start: true
   skip_brats: true


### PR DESCRIPTION
## Summary

- Enable cflinuxfs5 stack in all 11 buildpack values files (was commented out with `TODO: re-enable when cf-runtime cflinuxfs5 support is ready`)
- Guard the `version-stack-cflinuxfs5` semver resource in `pipeline.yml` with a ytt conditional so it is only defined for buildpacks that include cflinuxfs5 in their stacks list

## Changes

**Values files** (11 files): Uncomment `- cflinuxfs5` in `buildpack.stacks`:
- `apt-values.yml`, `binary-values.yml`, `dotnet-core-values.yml`, `go-values.yml`, `java-values.yml`, `nginx-values.yml`, `nodejs-values.yml`, `php-values.yml`, `r-values.yml`, `ruby-values.yml`, `staticfile-values.yml`

**`pipeline.yml`**: Wrap `version-stack-cflinuxfs5` resource definition in `#@ if "cflinuxfs5" in data.values.buildpack.stacks:` / `#@ end` to avoid defining an unused resource for buildpacks that don't list cflinuxfs5.