### PR TITLE
fix: align build artifact filename with update script expectations

### DIFF
--- a/tasks/build-binary/build.sh
+++ b/tasks/build-binary/build.sh
@@ -99,7 +99,7 @@ fi
 # ── 5. Write builds-artifacts JSON ───────────────────────────────────────────
 BUILDS_DIR="builds-artifacts/binary-builds-new/${DEP_NAME}"
 mkdir -p "${BUILDS_DIR}"
-BUILDS_FILE="${BUILDS_DIR}/${DEP_NAME}-${VERSION}-${STACK}.json"
+BUILDS_FILE="${BUILDS_DIR}/${VERSION}-${STACK}.json"
 
 jq '{
   url:              (.url // ""),

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -136,6 +136,10 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
   rebuilt += [old_versions.include?(resource_version)]
 end
 
+if rebuilt.empty?
+  puts 'SKIP: No build artifacts found for this version.'
+  exit 0
+end
 rebuilt = rebuilt.all?
 puts 'REBUILD: skipping most version updating logic' if rebuilt
 


### PR DESCRIPTION
## Summary

- Fixes a filename convention mismatch between the Go binary-builder (`build.sh`) and the dependency update script (`run.rb`) that caused multiple dependencies to silently fail to update their buildpack manifests
- Adds an early-exit guard in `run.rb` to prevent silent no-op "Rebuild" commits when no build artifacts are found

## Problem

When the build phase was rewritten from Ruby to Go/shell (commit `7924da87`), the artifact JSON filename convention changed:

| | Old (Ruby builder) | New (Go builder) |
|---|---|---|
| Pattern | `<version>-<stack>.json` | `<dep>-<version>-<stack>.json` |
| Example | `1.29.6-cflinuxfs5.json` | `nginx-1.29.7-cflinuxfs5.json` |

The update script (`run.rb:55`) globs for `<version>-<stack>.json`, so it finds zero files for any dependency built exclusively by the new builder. Ruby's `[].all?` returns `true` (vacuous truth), causing the script to silently create a no-op "Rebuild" commit instead of failing — hiding the problem.

## Impact

All dependencies whose latest version was built exclusively by the new Go builder are affected — their manifest entries are missing or stale:

| Dependency | Version(s) | Missing Artifacts |
|---|---|---|
| **nginx** | 1.28.3, 1.29.7 | cflinuxfs4 + cflinuxfs5 |
| **openresty** | 1.29.2.3 | cflinuxfs4 + cflinuxfs5 |
| **ruby** | 3.2.11, 3.3.11 | cflinuxfs4 + cflinuxfs5 |
| **php** | 8.1.34 | cflinuxfs5 |
| **pipenv** | 2026.2.2, 2026.5.0, 2026.5.1 | cflinuxfs4 + cflinuxfs5 |
| **hwc** | 110.0.0, 111.0.0 | any-stack |
| **tomcat** | 10.1.53 | any-stack |
| **rubygems** | 4.0.9 | any-stack |

This is the root cause of the `specs-switchblade-docker-cflinuxfs5` test failure in the nginx-buildpack pipeline — the manifest has zero cflinuxfs5 entries, so `buildpack-packager build --stack=cflinuxfs5` fails.

## Fix

1. **`build.sh:102`** — Remove the `${DEP_NAME}-` prefix from the artifact filename, restoring the `<version>-<stack>.json` convention that `run.rb` expects and that 237+ existing artifact files already follow.

2. **`run.rb:139`** — Add an early-exit guard when zero build artifacts are found (`rebuilt.empty?`), preventing the `[].all?` vacuous truth from creating silent no-op commits.

## Post-merge Actions

After this PR is merged, the following build jobs need to be re-triggered in the `dependency-builds` pipeline so that correctly-named artifact files are created:

1. `build-nginx-1.28.x`
2. `build-nginx-1.29.x`
3. `build-openresty-1.29.x`
4. `build-ruby-3.2.x`
5. `build-ruby-3.3.x`
6. `build-php-8.1.x`
7. `build-pipenv-latest`
8. `build-hwc-latest`
9. `build-tomcat-latest`
10. `build-rubygems-latest`

The downstream update jobs will then automatically pick up the correctly-named artifacts and add the missing manifest entries.