### PR TITLE
Fix: Add missing version field to build artifacts JSON

### DIFF
--- a/tasks/build-binary/build.sh
+++ b/tasks/build-binary/build.sh
@@ -102,6 +102,7 @@ mkdir -p "${BUILDS_DIR}"
 BUILDS_FILE="${BUILDS_DIR}/${VERSION}-${STACK}.json"
 
 jq '{
+  version:          .version,
   url:              (.url // ""),
   sha256:           (.sha256 // ""),
   source:           (.source // {}),


### PR DESCRIPTION
## Summary

This PR fixes a critical bug preventing PR generation for buildpack dependency updates after the filename format fix (#601) was merged.

## Problem

After commit d0299cea fixed the build artifact filename format, builds now create correctly-named files (e.g., `1.29.2.3-cflinuxfs4.json`), but **no PRs are being generated** because the build artifact JSON is missing the required `version` field.

### Root Cause

The `update-buildpack-dependency` script (`run.rb:94-95`) expects each build artifact JSON to contain a `version` field:

```ruby
version = builds[stack]['version']  # Returns nil when field is missing
next unless version                 # Skips processing when nil
```

The Go binary-builder's `build.sh` was not including this field in the jq output (lines 104-110), causing:
1. Build artifacts are created successfully ✅
2. Update job finds the files via glob pattern ✅
3. Script reads the JSON but finds `version = nil` ❌
4. Guard clause `next unless version` skips processing ❌
5. `rebuilt` array remains empty ❌
6. Early-exit at line 139: "SKIP: No build artifacts found" ❌
7. No PR is created ❌

## Solution

Add the `version` field to the build artifact JSON output in `tasks/build-binary/build.sh`:

```bash
jq '{
  version:          .version,    # ← ADDED
  url:              (.url // ""),
  sha256:           (.sha256 // ""),
  source:           (.source // {}),
  source_sha256:    (.source.sha256 // ""),
  sub_dependencies: (.sub_dependencies // {})
}' ...
```

This matches the format produced by the old Ruby builder and expected by `run.rb`.

## Impact

### Before Fix
- Build artifacts created: ✅
- PRs generated: ❌
- Affected: **ALL** dependencies built after March 30, 2026 (nginx, openresty, ruby, php, pipenv, hwc, tomcat, rubygems, etc.)

### After Fix
- Build artifacts created: ✅
- PRs generated: ✅
- Dependencies can receive cflinuxfs5 (and all stack) updates

## Testing Plan

1. Deploy updated `build.sh` to dependency-builds pipeline
2. Trigger a rebuild for openresty 1.29.2.3
3. Verify build artifact JSON now includes `"version": "1.29.2.3"`
4. Verify update-buildpack-dependency job creates PR with cflinuxfs5 entries
5. Trigger rebuilds for other affected dependencies

## Related

- Depends on: #601 (filename format fix)
- Fixes the issue reported where nginx/openresty builds complete but no PRs are created
- Completes the migration from Ruby to Go binary-builder

## Files Changed

- `tasks/build-binary/build.sh` - Add `version` field to build artifacts JSON output (1 line)