### PR TITLE
fix: move rsync seeding before artifact write to prevent overwrite

### DIFF
--- a/tasks/build-binary/build.sh
+++ b/tasks/build-binary/build.sh
@@ -8,9 +8,10 @@
 #      ($BUILD_STACK equals $STACK unless STACK=any-stack, in which case ANY_STACK_BUILD_STACK is used)
 #   3. Read the JSON summary from the output file.
 #   4. Move the artifact from CWD to artifacts/.
-#   5. Write builds-artifacts/binary-builds-new/<dep>/<dep>-<version>-<stack>.json
-#   6. Write dep-metadata/<artifact>_metadata.json
-#   7. Optionally commit the builds-artifacts changes to git (when SKIP_COMMIT != true).
+#   5. Seed builds-artifacts from builds git repo (so it is a valid git clone).
+#   6. Write builds-artifacts/binary-builds-new/<dep>/<version>-<stack>.json
+#   7. Write dep-metadata/<artifact>_metadata.json
+#   8. Optionally commit the builds-artifacts changes to git (when SKIP_COMMIT != true).
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -96,7 +97,17 @@ else
   echo "[task] No artifact file (URL-passthrough dep), skipping move"
 fi
 
-# ── 5. Write builds-artifacts JSON ───────────────────────────────────────────
+# ── 5. Seed builds-artifacts from builds git repo ────────────────────────────
+# builds-artifacts is a plain task output dir; it must be seeded from the
+# builds git resource so that it is a valid git clone before we can run
+# git config / git add / git commit inside it.
+# IMPORTANT: this MUST happen BEFORE writing the artifact JSON (step 6),
+# otherwise rsync overwrites the newly-written file with the stale copy
+# from the builds resource.
+echo "[task] Seeding builds-artifacts from builds git repo..."
+rsync -a builds/ builds-artifacts/
+
+# ── 6. Write builds-artifacts JSON ───────────────────────────────────────────
 BUILDS_DIR="builds-artifacts/binary-builds-new/${DEP_NAME}"
 mkdir -p "${BUILDS_DIR}"
 BUILDS_FILE="${BUILDS_DIR}/${VERSION}-${STACK}.json"
@@ -113,7 +124,7 @@ jq '{
 
 echo "[task] Wrote builds-artifacts to ${BUILDS_FILE}"
 
-# ── 6. Write dep-metadata JSON ───────────────────────────────────────────────
+# ── 7. Write dep-metadata JSON ───────────────────────────────────────────────
 # Format mirrors the Ruby builder's out_data.to_json output:
 #   version, source, url, sha256 (+ git_commit_sha and sub_dependencies when present).
 # Do NOT add extra fields (name, uri, source_sha256) that Ruby doesn't write.
@@ -131,18 +142,11 @@ jq '{
 
 echo "[task] Wrote dep-metadata to ${DEP_META_FILE}"
 
-# ── 7. Git commit builds-artifacts (unless SKIP_COMMIT=true) ─────────────────
+# ── 8. Git commit builds-artifacts (unless SKIP_COMMIT=true) ─────────────────
 if [[ "${SKIP_COMMIT:-}" == "true" ]]; then
   echo "[task] SKIP_COMMIT=true — skipping git commit"
   exit 0
 fi
-
-# Seed builds-artifacts with the builds git repo so that git commands work.
-# The Ruby builder did: rsync -a builds/ builds-artifacts/ (build_input.rb:16).
-# builds-artifacts is a plain task output dir; it must be a git clone before
-# we can run git config / git add / git commit inside it.
-echo "[task] Seeding builds-artifacts from builds git repo..."
-rsync -a builds/ builds-artifacts/
 
 echo "[task] Committing builds-artifacts..."
 pushd builds-artifacts >/dev/null


### PR DESCRIPTION
## Summary

- Fixes a bug where `rsync -a builds/ builds-artifacts/` overwrites the newly-generated artifact JSON with the stale copy from the `builds` git resource, causing rebuild jobs to silently produce no changes

## Problem

In `build.sh`, the artifact JSON was written to `builds-artifacts/` at step 5 (line 111), but the rsync seeding from the `builds` git resource happened later at step 7 (line 144). This ordering meant:

1. Step 5: Write new artifact JSON (with `version` field, per #602) to `builds-artifacts/binary-builds-new/<dep>/<version>-<stack>.json`
2. Step 7: `rsync -a builds/ builds-artifacts/` copies the **old** file from the `builds` git resource, **overwriting** the new one
3. Step 7: `git diff --cached --quiet` → no changes detected → "No changes to commit"
4. The update job then finds the old artifact (missing `version` field) and prints "SKIP: No build artifacts found for this version"

This was confirmed in today's `build-nginx-1.28.x` build #9 logs:
```
[task] Wrote builds-artifacts to builds-artifacts/binary-builds-new/nginx/1.28.3-cflinuxfs5.json
[task] Seeding builds-artifacts from builds git repo...
[task] No changes to commit in builds-artifacts
```

### Impact

Every rebuild of an existing dependency silently produces a no-op commit, preventing the update jobs from creating PRs with cflinuxfs5 entries. This blocked all dependency updates since the Go builder migration (March 12, 2026).

## Fix

Move the rsync seeding step to **before** writing the artifact JSON, so the new file correctly overwrites the stale copy instead of the other way around:

```
Step 5: rsync -a builds/ builds-artifacts/     ← seed git repo first
Step 6: jq '...' > builds-artifacts/.../X.json ← new file overwrites stale copy
Step 8: git add . && git commit                ← detects the change
```

## Related

- Depends on: #601 (filename format fix) and #602 (missing `version` field fix)
- Completes the fix chain: #601 fixed filenames → #602 added `version` field → this PR fixes the write ordering
- After merge: rebuild jobs will correctly commit updated artifacts, and update jobs will create PRs with cflinuxfs5 entries

## Files Changed

- `tasks/build-binary/build.sh` — Move rsync seeding from after artifact write to before it; renumber steps accordingly