### PR TITLE
Fix: Ensure update job waits for all stack builds to complete

### DIFF
--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -402,6 +402,14 @@ jobs:
       - #@ "build-{}-{}".format(dep_name.lower(), line_hash["line"].lower())
     #@ end
     - get: builds
+      passed:
+      #@ if getattr(dep, "copy-stacks", None):
+      #@   for copy_stack in dep["copy-stacks"]:
+      - #@ "copy-{}-{}-{}".format(dep_name.lower(), line_hash["line"].lower(), copy_stack.lower())
+      #@   end
+      #@ else:
+      - #@ "build-{}-{}".format(dep_name.lower(), line_hash["line"].lower())
+      #@ end
   - task: update-buildpack-dependency
     file: buildpacks-ci/tasks/update-buildpack-dependency/task.yml
     params:


### PR DESCRIPTION
## Summary

This PR fixes a critical race condition in the dependency-builds pipeline where the `update-buildpack-dependency` job creates PRs with only one stack even when multiple stacks were built successfully.

## Problem

The `update-buildpack-dependency` job's `get: builds` resource was missing a `passed` constraint. This caused it to fetch **any** version of the builds git repo rather than waiting for the **specific version** produced by the build job that triggered it.

### The Race Condition

1. ✅ Build job (`build-openresty-1.29.x`) runs cflinuxfs4 and cflinuxfs5 builds **in parallel**
2. ✅ Each build commits to the `builds` git repo independently
   - cflinuxfs4 commits at T+0s
   - cflinuxfs5 commits at T+8s
3. ✅ Build job completes and triggers update job
4. ❌ Update job does `get: builds` **without** `passed` constraint
5. ❌ Concourse fetches the builds repo at that moment - may only see one commit
6. ❌ Update script globs for `1.29.2.3-*.json` files - finds only one file
7. ❌ PR is created with only one stack (e.g., cflinuxfs5) instead of both

### Evidence

- **PR #393**: openresty 1.29.2.3 - commit message says "for stack(s) cflinuxfs4, cflinuxfs5" but only added cflinuxfs5
- **PR #396**: openresty 1.29.2.3 (rebuild) - same issue, only cflinuxfs5
- Both stack builds completed successfully and committed to git, but update job didn't see both

## Solution

Add `passed: [build-{dep}-{line}]` constraint to the `builds` resource in the update job:

```yaml
- get: builds
  passed:
  - build-openresty-1.29.x  # (or whichever build job)
```

This ensures the update job waits for the **exact version** of the builds resource that was updated by the build job. In Concourse, a `passed` constraint means:
- Wait for the specified job(s) to complete
- Fetch the version of the resource that those job(s) used or created
- This guarantees all parallel `put` operations within that job have completed

## Impact

### Before Fix
- Build job completes → update job may run with incomplete builds resource
- PRs created with missing stacks
- Requires manual intervention to add missing stacks

### After Fix
- Build job completes → update job waits for all stack commits
- PRs created with all stacks
- No manual intervention needed

## Testing Plan

1. Merge this PR
2. Deploy updated pipeline to dependency-builds
3. Trigger rebuild of openresty 1.29.2.3
4. Verify new PR includes **both** cflinuxfs4 and cflinuxfs5 entries

## Related Issues

- Complements PR #601 (filename fix)
- Complements PR #602 (version field fix)
- Complements PR #603 (rsync ordering fix)
- This is the FOURTH fix needed to fully resolve the cflinuxfs5 PR generation issues

## Files Changed

- `pipelines/dependency-builds/pipeline.yml` - Added `passed` constraint to `builds` resource in update job (8 lines)