### PR TITLE
Fix nginx buildpack PR automation to update integration test expectations

### DIFF
--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -216,6 +216,38 @@ if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
     puts "Warning: nginx test file not found at #{full_test_file_path}"
   end
 
+  # Update nginx override buildpack fixture
+  # The override buildpack test uses a fake nginx version to test error handling
+  # The version needs to match the current mainline version line
+  override_file_path = 'fixtures/util/override_buildpack/override.yml'
+  full_override_file_path = File.join('buildpack', override_file_path)
+  if File.exist?(full_override_file_path)
+    override_content = File.read(full_override_file_path)
+    
+    mainline_version = manifest['version_lines']['mainline']
+    
+    # Extract the major.minor from mainline (e.g., "1.28.x" -> "1.28")
+    if mainline_version && mainline_version.match(/^(\d+\.\d+)/)
+      mainline_major_minor = $1
+      fake_version = "#{mainline_major_minor}.999"  # e.g., "1.28.999"
+      
+      # Update version_lines.mainline
+      override_content.gsub!(/^(\s*mainline:\s+)\d+\.\d+\.\d+/, "\\1#{fake_version}")
+      
+      # Update nginx dependency version
+      override_content.gsub!(/^(\s*version:\s+)\d+\.\d+\.\d+/, "\\1#{fake_version}")
+      
+      # Update URI
+      override_content.gsub!(/nginx-\d+\.\d+\.\d+/, "nginx-#{fake_version}")
+      
+      nginx_files_to_edit[override_file_path] = override_content
+      puts "Prepared override buildpack fixture update for #{override_file_path}"
+      puts "  Fake version: #{fake_version}"
+    end
+  else
+    puts "Warning: override buildpack fixture not found at #{full_override_file_path}"
+  end
+
 end
 
 #

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -157,6 +157,7 @@ commit_message += "\n\nfor stack(s) #{total_stacks.join(', ')}"
 # Special Nginx stuff (for Nginx buildpack)
 # * There are two version lines, stable & mainline
 #   when we add a new minor line, we should update the version line regex
+nginx_files_to_edit = {}
 if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
   v = SemVer.parse(resource_version)
   raise "Invalid version format: #{resource_version}" if v.nil?
@@ -167,6 +168,52 @@ if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
   else
     # 1.13.X is mainline
     manifest['version_lines']['mainline'] = data['source']['version_filter'].downcase
+  end
+
+  # Update nginx integration test expectations
+  # The test file contains hardcoded version strings that need to match the manifest
+  test_file_path = 'src/nginx/integration/default_test.go'
+  full_test_file_path = File.join('buildpack', test_file_path)
+  if File.exist?(full_test_file_path)
+    test_content = File.read(full_test_file_path)
+    
+    # Get mainline and stable major.minor versions from version_lines
+    mainline_version = manifest['version_lines']['mainline']
+    stable_version = manifest['version_lines']['stable']
+    
+    # Extract unique version lines (X.Y.x format) from dependencies
+    version_lines = manifest['dependencies']
+      .select { |dep| dep['name'] == 'nginx' }
+      .map { |dep| dep['version'] }
+      .map { |ver| ver.match(/^(\d+\.\d+)\./) }
+      .compact
+      .map { |m| "#{m[1]}.x" }
+      .uniq
+      .sort_by { |v| Gem::Version.new(v.sub(/\.x$/, '.0')) }
+    
+    # Create the available versions string: "mainline, stable, 1.26.x, 1.28.x, 1.29.x"
+    available_versions = (['mainline', 'stable'] + version_lines).join(', ')
+    
+    # Update test expectations
+    # 1. Update "using mainline => X.Y." pattern
+    test_content.gsub!(/using mainline => \d+\.\d+\./, "using mainline => #{mainline_version.sub(/\.x$/, '.')}") if mainline_version
+    
+    # 2. Update "mainline => X.Y." pattern (for explicit mainline request)
+    test_content.gsub!(/Requested nginx version: mainline => \d+\.\d+\./, "Requested nginx version: mainline => #{mainline_version.sub(/\.x$/, '.')}") if mainline_version
+    
+    # 3. Update "stable => X.Y." pattern
+    test_content.gsub!(/stable => \d+\.\d+\./, "stable => #{stable_version.sub(/\.x$/, '.')}") if stable_version
+    
+    # 4. Update "Available versions: ..." line
+    test_content.gsub!(/Available versions: [^\`]+/, "Available versions: #{available_versions}")
+    
+    nginx_files_to_edit[test_file_path] = test_content
+    puts "Prepared nginx test expectations update for #{test_file_path}"
+    puts "  Mainline: #{mainline_version}"
+    puts "  Stable: #{stable_version}"
+    puts "  Available versions: #{available_versions}"
+  else
+    puts "Warning: nginx test file not found at #{full_test_file_path}"
   end
 
 end
@@ -278,6 +325,13 @@ Dir.chdir('artifacts') do
   GitClient.add_file('manifest.yml')
 
   ruby_files_to_edit.each do |path, content|
+    if content
+      File.write(path, content)
+      GitClient.add_file(path)
+    end
+  end
+
+  nginx_files_to_edit.each do |path, content|
     if content
       File.write(path, content)
       GitClient.add_file(path)


### PR DESCRIPTION
## Summary

Fixes the automatic nginx version PR generation to also update integration test expectations **and override buildpack fixture**, preventing test failures in all nginx version update PRs.

**Note**: This PR previously included a pipeline change to add a `passed` constraint to the update job. That change has been removed because it doesn't solve the root cause of the multi-stack issue. The proper fix for that is in PR #608 (atomic commits).

## Problem

All automatically generated nginx version update PRs (#392, #394, #389, #390, #384, #385, etc.) are failing integration tests with two types of errors:

1. **Override test:** "Expected an error, got nil" - deployment succeeds when it should fail
2. **Version tests:** Timeout waiting for version strings that don't match
3. **Available versions test:** Expects old version list

**Root Cause:**
The automation in `tasks/update-buildpack-dependency/run.rb` updates `manifest.yml` with new nginx versions and adjusts `version_lines` (mainline/stable), but doesn't update:
- Integration test file `src/nginx/integration/default_test.go` (hardcoded version strings)
- Override buildpack fixture `fixtures/util/override_buildpack/override.yml` (fake version for testing)

**Example:** When nginx 1.29.7 is added and mainline changes from `1.28.x` to `1.29.x`:

*Tests still expect:*
- `mainline => 1.28.`
- `Available versions: mainline, stable, 1.28.x, 1.29.x`
- Override fixture has `1.28.999`

*But buildpack outputs:*
- `mainline => 1.29.`  
- `Available versions: mainline, stable, 1.26.x, 1.28.x, 1.29.x`
- Override `1.28.999` doesn't match mainline `1.29.x`, so override doesn't apply

## Changes

Enhanced `tasks/update-buildpack-dependency/run.rb` with nginx-specific file updates:

### 1. Update Integration Test Expectations

Updates `src/nginx/integration/default_test.go` patterns:
- `using mainline => X.Y.` → Updated to current mainline version
- `Requested nginx version: mainline => X.Y.` → Updated to current mainline version  
- `stable => X.Y.` → Updated to current stable version
- `Available versions: ...` → Recalculated from manifest dependencies

### 2. Update Override Buildpack Fixture

Updates `fixtures/util/override_buildpack/override.yml` to match current mainline:
- Extracts mainline version (e.g., `1.29.x`)
- Generates fake version (e.g., `1.29.999`)
- Updates `version_lines.mainline` in override.yml
- Updates nginx dependency version
- Updates URI to reference fake version
- **Keeps SHA256 intentionally wrong** (for testing validation)

The override test uses a fake version with wrong SHA256 to verify the buildpack properly validates checksums. If the fake version doesn't match the mainline version line, the override won't apply and the test passes when it should fail.

### 3. Follows Existing Patterns

Uses same file-editing pattern as JRuby Gemfile updates - stores files in a hash and commits them together.

## Testing Plan

After this PR is merged:

1. Close all failing nginx version PRs
2. Trigger regeneration of nginx 1.29.7 PR (or manually create one)
3. Verify the new PR includes updates to:
   - ✅ `manifest.yml`
   - ✅ `src/nginx/integration/default_test.go`
   - ✅ `fixtures/util/override_buildpack/override.yml`
4. Verify all integration tests pass (including override test)
5. Regenerate remaining nginx version PRs

## Related Issues

- nginx-buildpack#392, #394, #389, #390, #384, #385, #377, #382, #396, #395, #378 - All failing integration tests
- nginx-buildpack#397, #398, #399 - Attempted manual fixes (closed, superseded by this automation fix)

## Dependencies

Should be merged **before** regenerating nginx version PRs to ensure new PRs have correct test expectations.