### PR TITLE
fix: auto-update nginx integration tests when versions change

### DIFF
--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -216,6 +216,38 @@ if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
     puts "Warning: nginx test file not found at #{full_test_file_path}"
   end
 
+  # Update nginx override buildpack fixture
+  # The override buildpack test uses a fake nginx version to test error handling
+  # The version needs to match the current mainline version line
+  override_file_path = 'fixtures/util/override_buildpack/override.yml'
+  full_override_file_path = File.join('buildpack', override_file_path)
+  if File.exist?(full_override_file_path)
+    override_content = File.read(full_override_file_path)
+    
+    mainline_version = manifest['version_lines']['mainline']
+    
+    # Extract the major.minor from mainline (e.g., "1.28.x" -> "1.28")
+    if mainline_version && mainline_version.match(/^(\d+\.\d+)/)
+      mainline_major_minor = $1
+      fake_version = "#{mainline_major_minor}.999"  # e.g., "1.28.999"
+      
+      # Update version_lines.mainline
+      override_content.gsub!(/^(\s*mainline:\s+)\d+\.\d+\.\d+/, "\\1#{fake_version}")
+      
+      # Update nginx dependency version
+      override_content.gsub!(/^(\s*version:\s+)\d+\.\d+\.\d+/, "\\1#{fake_version}")
+      
+      # Update URI
+      override_content.gsub!(/nginx-\d+\.\d+\.\d+/, "nginx-#{fake_version}")
+      
+      nginx_files_to_edit[override_file_path] = override_content
+      puts "Prepared override buildpack fixture update for #{override_file_path}"
+      puts "  Fake version: #{fake_version}"
+    end
+  else
+    puts "Warning: override buildpack fixture not found at #{full_override_file_path}"
+  end
+
 end
 
 #

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -157,6 +157,7 @@ commit_message += "\n\nfor stack(s) #{total_stacks.join(', ')}"
 # Special Nginx stuff (for Nginx buildpack)
 # * There are two version lines, stable & mainline
 #   when we add a new minor line, we should update the version line regex
+nginx_files_to_edit = {}
 if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
   v = SemVer.parse(resource_version)
   raise "Invalid version format: #{resource_version}" if v.nil?
@@ -167,6 +168,52 @@ if !rebuilt && manifest_name == 'nginx' && buildpack_name == 'nginx'
   else
     # 1.13.X is mainline
     manifest['version_lines']['mainline'] = data['source']['version_filter'].downcase
+  end
+
+  # Update nginx integration test expectations
+  # The test file contains hardcoded version strings that need to match the manifest
+  test_file_path = 'src/nginx/integration/default_test.go'
+  full_test_file_path = File.join('buildpack', test_file_path)
+  if File.exist?(full_test_file_path)
+    test_content = File.read(full_test_file_path)
+    
+    # Get mainline and stable major.minor versions from version_lines
+    mainline_version = manifest['version_lines']['mainline']
+    stable_version = manifest['version_lines']['stable']
+    
+    # Extract unique version lines (X.Y.x format) from dependencies
+    version_lines = manifest['dependencies']
+      .select { |dep| dep['name'] == 'nginx' }
+      .map { |dep| dep['version'] }
+      .map { |ver| ver.match(/^(\d+\.\d+)\./) }
+      .compact
+      .map { |m| "#{m[1]}.x" }
+      .uniq
+      .sort_by { |v| Gem::Version.new(v.sub(/\.x$/, '.0')) }
+    
+    # Create the available versions string: "mainline, stable, 1.26.x, 1.28.x, 1.29.x"
+    available_versions = (['mainline', 'stable'] + version_lines).join(', ')
+    
+    # Update test expectations
+    # 1. Update "using mainline => X.Y." pattern
+    test_content.gsub!(/using mainline => \d+\.\d+\./, "using mainline => #{mainline_version.sub(/\.x$/, '.')}") if mainline_version
+    
+    # 2. Update "mainline => X.Y." pattern (for explicit mainline request)
+    test_content.gsub!(/Requested nginx version: mainline => \d+\.\d+\./, "Requested nginx version: mainline => #{mainline_version.sub(/\.x$/, '.')}") if mainline_version
+    
+    # 3. Update "stable => X.Y." pattern
+    test_content.gsub!(/stable => \d+\.\d+\./, "stable => #{stable_version.sub(/\.x$/, '.')}") if stable_version
+    
+    # 4. Update "Available versions: ..." line
+    test_content.gsub!(/Available versions: [^\`]+/, "Available versions: #{available_versions}")
+    
+    nginx_files_to_edit[test_file_path] = test_content
+    puts "Prepared nginx test expectations update for #{test_file_path}"
+    puts "  Mainline: #{mainline_version}"
+    puts "  Stable: #{stable_version}"
+    puts "  Available versions: #{available_versions}"
+  else
+    puts "Warning: nginx test file not found at #{full_test_file_path}"
   end
 
 end
@@ -278,6 +325,13 @@ Dir.chdir('artifacts') do
   GitClient.add_file('manifest.yml')
 
   ruby_files_to_edit.each do |path, content|
+    if content
+      File.write(path, content)
+      GitClient.add_file(path)
+    end
+  end
+
+  nginx_files_to_edit.each do |path, content|
     if content
       File.write(path, content)
       GitClient.add_file(path)


### PR DESCRIPTION
## Summary

This PR fixes nginx buildpack version update PRs that were failing integration tests due to hardcoded version expectations in test files.

## Problem

When nginx version PRs are automatically generated:
1. The manifest.yml is updated with new nginx versions
2. The version_lines (mainline/stable) are adjusted
3. **BUT** integration tests in `src/nginx/integration/default_test.go` contain hardcoded version strings
4. The override test fixture in `fixtures/override_buildpack/override.yml` has a hardcoded fake version
5. All nginx version update PRs fail integration tests

**Evidence**: PRs #392, #394, #389, etc. all failed integration tests

## Solution

### Part 1: Auto-update integration test expectations

Adds logic to `tasks/update-buildpack-dependency/run.rb` to automatically update `default_test.go` when nginx versions change:

1. Detects when updating nginx dependency in nginx buildpack
2. Extracts current mainline and stable versions from version_lines
3. Calculates available nginx version lines from manifest
4. Updates all version string patterns in the test file:
   - `'using mainline => X.Y.'` pattern
   - `'Requested nginx version: mainline => X.Y.'` pattern
   - `'stable => X.Y.'` pattern
   - `'Available versions: mainline, stable, X.Y.x, ...'` list
5. Adds the updated test file to the git commit

### Part 2: Auto-update override fixture

The override buildpack test uses a fake nginx version (X.Y.999) with an intentionally incorrect SHA256 to verify checksum validation.

When mainline changes from 1.28.x to 1.29.x, the fixture must update from 1.28.999 to 1.29.999.

Adds logic to automatically update `override.yml`:
1. Extracts current mainline version (e.g., '1.29.x')
2. Generates fake version (e.g., '1.29.999')
3. Updates `version_lines.mainline` in override.yml
4. Updates nginx dependency version
5. Updates URI to reference the fake version
6. Adds the file to the commit

## Testing Plan

1. Trigger a nginx version update manually
2. Verify the generated PR includes updates to:
   - `manifest.yml` (versions and version_lines)
   - `src/nginx/integration/default_test.go` (hardcoded version expectations)
   - `fixtures/override_buildpack/override.yml` (fake version for override test)
3. Verify integration tests pass in the PR

## Files Changed

- `tasks/update-buildpack-dependency/run.rb` - Add nginx-specific test file updates (86 lines added)

## Related Issues

Fixes nginx version update PRs that were failing integration tests due to hardcoded version strings.