### PR TITLE
fix: compute source SHA256 in rubygems_cli depwatcher

### DIFF
--- a/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli.go
@@ -60,10 +60,18 @@ func (w *RubygemsCLIWatcher) Check() ([]base.Internal, error) {
 	return versions, nil
 }
 
-// In returns the download URL for a specific RubyGems CLI version.
+// In returns the download URL and source SHA256 for a specific RubyGems CLI version.
 func (w *RubygemsCLIWatcher) In(version string) (base.Release, error) {
+	url := fmt.Sprintf("https://rubygems.org/rubygems/rubygems-%s.tgz", version)
+
+	sha256, err := base.GetSHA256(w.client, url)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("calculating SHA256 for rubygems %s: %w", version, err)
+	}
+
 	return base.Release{
-		Ref: version,
-		URL: fmt.Sprintf("https://rubygems.org/rubygems/rubygems-%s.tgz", version),
+		Ref:    version,
+		URL:    url,
+		SHA256: sha256,
 	}, nil
 }

--- a/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli_test.go
@@ -160,28 +160,56 @@ var _ = Describe("RubygemsCLIWatcher", func() {
 	})
 
 	Context("In", func() {
-		It("returns download URL for version", func() {
+		It("returns download URL and SHA256 for version", func() {
+			client.responses["https://rubygems.org/rubygems/rubygems-3.4.10.tgz"] = mockResponse{
+				body:   "fake-tarball-content",
+				status: 200,
+			}
+
 			release, err := watcher.In("3.4.10")
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(release.Ref).To(Equal("3.4.10"))
 			Expect(release.URL).To(Equal("https://rubygems.org/rubygems/rubygems-3.4.10.tgz"))
+			Expect(release.SHA256).NotTo(BeEmpty())
+			Expect(release.SHA256).To(HaveLen(64)) // SHA256 hex digest is 64 chars
 		})
 
-		It("constructs URL with version", func() {
+		It("constructs URL with version and computes SHA256", func() {
+			client.responses["https://rubygems.org/rubygems/rubygems-3.5.0.tgz"] = mockResponse{
+				body:   "another-fake-tarball",
+				status: 200,
+			}
+
 			release, err := watcher.In("3.5.0")
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(release.Ref).To(Equal("3.5.0"))
 			Expect(release.URL).To(Equal("https://rubygems.org/rubygems/rubygems-3.5.0.tgz"))
+			Expect(release.SHA256).NotTo(BeEmpty())
 		})
 
 		It("handles pre-release versions", func() {
+			client.responses["https://rubygems.org/rubygems/rubygems-3.4.0.rc1.tgz"] = mockResponse{
+				body:   "prerelease-content",
+				status: 200,
+			}
+
 			release, err := watcher.In("3.4.0.rc1")
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(release.Ref).To(Equal("3.4.0.rc1"))
 			Expect(release.URL).To(Equal("https://rubygems.org/rubygems/rubygems-3.4.0.rc1.tgz"))
+			Expect(release.SHA256).NotTo(BeEmpty())
+		})
+
+		Context("when the download fails", func() {
+			It("returns an error", func() {
+				// No mock response registered for this URL
+				_, err := watcher.In("9.9.9")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("calculating SHA256"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Fix the `rubygems_cli` depwatcher to compute source SHA256 hash when fetching version details, matching the pattern used by other watchers (python, jruby, php, nginx, etc.)
- This resolves empty `source_sha256` fields in buildpack manifest entries produced after the Go binary-builder migration

## Root Cause

The `RubygemsCLIWatcher.In()` method was constructing the download URL deterministically but never downloading the source or computing its SHA256 hash. Other depwatchers like `python`, `jruby`, and `php` call `base.GetSHA256()` to download and hash the source.

The old Ruby binary-builder computed source hashes during the build phase, masking this gap. The Go binary-builder rewrite propagates whatever the depwatcher provides but does not independently compute source hashes, exposing the missing SHA256.

## Changes

- `rubygems_cli.go`: `In()` now downloads the source tarball and computes SHA256 using `base.GetSHA256()`
- `rubygems_cli_test.go`: Updated `In` tests to mock the download response and verify SHA256 is computed; added error case test