### PR TITLE
Remove windows from binary-buildpack pipeline stacks

### DIFF
--- a/pipelines/buildpack/binary-values.yml
+++ b/pipelines/buildpack/binary-values.yml
@@ -7,7 +7,6 @@ buildpack:
   stacks:
   - cflinuxfs4
   - cflinuxfs5
-  - windows
   product_slug: binary-buildpack
   skip_docker_start: true
   skip_brats: true


### PR DESCRIPTION
The CF environment provisioned for integration tests does not have a Windows cell/stack. 
Listing windows in stacks caused the pipeline to generate integration-test-windows-* jobs that fail trying to register the buildpack with a non-existent CF stack.