### PR TITLE
Bootstrap fix: skip S3 artifact inputs until initial cflinuxfs5 artifacts exist

### DIFF
--- a/pipelines/buildpack/pipeline.yml
+++ b/pipelines/buildpack/pipeline.yml
@@ -349,14 +349,17 @@ jobs:
           - #@ "specs-switchblade-docker-" + stack
           #@ end
         - get: version
-        #@ for stack in bucket_stacks():
-        - get: #@ "pivotal-buildpack-cached-" + stack
-          version: every
-          trigger: false
-        - get: #@ "pivotal-buildpack-" + stack
-          version: every
-          trigger: false
-        #@ end
+        #! BOOTSTRAP FIX: Comment out to enable initial cflinuxfs5 buildpack creation when S3 artifacts don't exist yet
+        #! Uncomment these lines once initial artifacts are uploaded to S3
+        #! See: https://github.com/cloudfoundry/buildpacks-ci/pull/482
+        #! #@ for stack in bucket_stacks():
+        #! - get: #@ "pivotal-buildpack-cached-" + stack
+        #!   version: every
+        #!   trigger: false
+        #! - get: #@ "pivotal-buildpack-" + stack
+        #!   version: every
+        #!   trigger: false
+        #! #@ end
       - in_parallel:
           #@ for stack in bucket_stacks():
           - do:


### PR DESCRIPTION
## Problem

The `detect-new-version-and-upload-artifacts` job fetches existing `pivotal-buildpack-*` and `pivotal-buildpack-cached-*` artifacts from S3 as inputs before running `detect-and-upload`. When a new stack is added to a buildpack pipeline (in this case `cflinuxfs5`), no artifacts exist yet in S3 for that stack, so the `get` step blocks indefinitely and the job never runs — making it impossible to produce the first artifact.

This is the same pattern as [#482.](https://github.com/cloudfoundry/buildpacks-ci/pull/482)

## Fix

Commented out the `get` steps for `pivotal-buildpack-*` and `pivotal-buildpack-cached-*` resources in the `in_parallel` input block.
The `detect-and-upload` tasks and `put` steps still reference these resources correctly — they will be implicitly available from the pipeline resource definitions. This allows the job to trigger on `buildpack` + `version` alone and produce the initial cflinuxfs5 artifacts.

## Follow-up

Once the first cflinuxfs5 artifacts are uploaded to S3 under `buildpack-release-candidates/binary/` for instance, uncommenting these lines will restore the original behavior where the job is gated on the latest uploaded artifact version.