### PR TITLE
Depwatcher fixes

### DIFF
--- a/dockerfiles/depwatcher-go/pkg/watchers/appd_agent_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/appd_agent_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -48,11 +47,13 @@ var _ = Describe("AppdAgentWatcher", func() {
 	Describe("Check", func() {
 		Context("when the index returns valid YAML", func() {
 			It("returns sorted versions with calendar versioning", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/appd_agent.yml")
-				Expect(err).NotTo(HaveOccurred())
+				yaml := `1.1.1_2: https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-2.tar.bz2
+1.1.1_3: https://download.run.pivotal.io/appdynamics-php/appdynamics-1.1.1-3.tar.bz2
+2.1.1_1: https://download.run.pivotal.io/appdynamics-php/appdynamics-2.1.1-1.tar.bz2
+3.1.1_14: https://download.run.pivotal.io/appdynamics-php/appdynamics-3.1.1-14.tar.bz2`
 
 				client.responses["https://download.run.pivotal.io/appdynamics-php/index.yml"] = mockResponse{
-					body:   string(fixtureData),
+					body:   yaml,
 					status: 200,
 				}
 

--- a/dockerfiles/depwatcher-go/pkg/watchers/cran_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/cran_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,11 +42,15 @@ var _ = Describe("CRANWatcher", func() {
 	Describe("Check", func() {
 		Context("when checking Rserve package", func() {
 			It("returns the latest version in semver form", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/rserve.html")
-				Expect(err).NotTo(HaveOccurred())
+				html := `<!DOCTYPE html>
+<html><body>
+<table>
+<tr><td>Version:</td><td>1.7-3</td></tr>
+</table>
+</body></html>`
 
 				client.responses["https://cran.r-project.org/web/packages/Rserve/index.html"] = mockResponse{
-					body:   string(fixtureData),
+					body:   html,
 					status: 200,
 				}
 
@@ -61,11 +64,15 @@ var _ = Describe("CRANWatcher", func() {
 
 		Context("when checking forecast package", func() {
 			It("returns the latest version", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/forecast.html")
-				Expect(err).NotTo(HaveOccurred())
+				html := `<!DOCTYPE html>
+<html><body>
+<table>
+<tr><td>Version:</td><td>8.4</td></tr>
+</table>
+</body></html>`
 
 				client.responses["https://cran.r-project.org/web/packages/forecast/index.html"] = mockResponse{
-					body:   string(fixtureData),
+					body:   html,
 					status: 200,
 				}
 
@@ -79,11 +86,15 @@ var _ = Describe("CRANWatcher", func() {
 
 		Context("when checking shiny package", func() {
 			It("returns the latest version", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/shiny.html")
-				Expect(err).NotTo(HaveOccurred())
+				html := `<!DOCTYPE html>
+<html><body>
+<table>
+<tr><td>Version:</td><td>1.2.0</td></tr>
+</table>
+</body></html>`
 
 				client.responses["https://cran.r-project.org/web/packages/shiny/index.html"] = mockResponse{
-					body:   string(fixtureData),
+					body:   html,
 					status: 200,
 				}
 
@@ -97,11 +108,15 @@ var _ = Describe("CRANWatcher", func() {
 
 		Context("when checking plumber package", func() {
 			It("returns the latest version", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/plumber.html")
-				Expect(err).NotTo(HaveOccurred())
+				html := `<!DOCTYPE html>
+<html><body>
+<table>
+<tr><td>Version:</td><td>0.4.6</td></tr>
+</table>
+</body></html>`
 
 				client.responses["https://cran.r-project.org/web/packages/plumber/index.html"] = mockResponse{
-					body:   string(fixtureData),
+					body:   html,
 					status: 200,
 				}
 

--- a/dockerfiles/depwatcher-go/pkg/watchers/miniconda_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/miniconda_test.go
@@ -3,7 +3,6 @@ package watchers_test
 import (
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,11 +36,88 @@ var _ = Describe("MinicondaWatcher", func() {
 		client = &mockMinicondaClient{}
 	})
 
+	minicondaHTML := `
+		<html>
+			<table>
+				<tr>
+					<td><a href="Miniconda3-py39_22.11.1-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2022-11-01 00:00:00</td>
+					<td>aaa111</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py39_23.1.0-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2023-02-07 21:27:23</td>
+					<td>5dc619babc1d19d6688617966251a38d245cb93d69066ccde9a013e1ebb5bf18</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py39_23.3.1-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2023-03-01 00:00:00</td>
+					<td>bbb333</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py39_23.5.0-3-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2023-05-01 00:00:00</td>
+					<td>ccc500</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py39_23.5.1-0-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2023-05-15 00:00:00</td>
+					<td>ddd511</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py39_23.5.2-0-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">66.7M</td>
+					<td>2023-05-20 00:00:00</td>
+					<td>eee522</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_22.11.1-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2022-11-01 00:00:00</td>
+					<td>fff111</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_23.1.0-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2023-02-07 21:27:23</td>
+					<td>640b7dceee6fad10cb7e7b54667b2945c4d6f57625d062b2b0952b7f3a908ab7</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_23.3.1-1-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2023-03-01 00:00:00</td>
+					<td>ggg333</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_23.5.0-3-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2023-05-01 00:00:00</td>
+					<td>hhh500</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_23.5.1-0-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2023-05-15 00:00:00</td>
+					<td>iii511</td>
+				</tr>
+				<tr>
+					<td><a href="Miniconda3-py38_23.5.2-0-Linux-x86_64.sh">Linux</a></td>
+					<td class="s">64.7M</td>
+					<td>2023-05-20 00:00:00</td>
+					<td>jjj522</td>
+				</tr>
+			</table>
+		</html>
+	`
+
 	Context("Check", func() {
 		It("extracts versions for py39 from HTML table sorted", func() {
-			fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/miniconda.html")
-			Expect(err).NotTo(HaveOccurred())
-			client.htmlResponse = string(fixtureData)
+			client.htmlResponse = minicondaHTML
 
 			watcher = watchers.NewMinicondaWatcher(client, "3.9")
 			versions, err := watcher.Check()
@@ -57,9 +133,7 @@ var _ = Describe("MinicondaWatcher", func() {
 		})
 
 		It("extracts versions for py38 from HTML table sorted", func() {
-			fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/miniconda.html")
-			Expect(err).NotTo(HaveOccurred())
-			client.htmlResponse = string(fixtureData)
+			client.htmlResponse = minicondaHTML
 
 			watcher = watchers.NewMinicondaWatcher(client, "3.8")
 			versions, err := watcher.Check()
@@ -152,9 +226,7 @@ var _ = Describe("MinicondaWatcher", func() {
 
 	Context("In", func() {
 		BeforeEach(func() {
-			fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/miniconda.html")
-			Expect(err).NotTo(HaveOccurred())
-			client.htmlResponse = string(fixtureData)
+			client.htmlResponse = minicondaHTML
 		})
 
 		It("returns release details for py39 version 23.1.0", func() {

--- a/dockerfiles/depwatcher-go/pkg/watchers/r_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/r_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,11 +51,21 @@ var _ = Describe("RWatcher", func() {
 	Describe("Check", func() {
 		Context("when the CRAN website returns valid HTML", func() {
 			It("returns sorted versions from the R-4 directory", func() {
-				fixtureData, err := os.ReadFile("../../../depwatcher/spec/fixtures/rlang.html")
-				Expect(err).NotTo(HaveOccurred())
+				html := `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html><body>
+<table>
+<tr><td><a href="R-4.0.0.tar.gz">R-4.0.0.tar.gz</a></td></tr>
+<tr><td><a href="R-4.0.1.tar.gz">R-4.0.1.tar.gz</a></td></tr>
+<tr><td><a href="R-4.0.2.tar.gz">R-4.0.2.tar.gz</a></td></tr>
+<tr><td><a href="R-4.0.3.tar.gz">R-4.0.3.tar.gz</a></td></tr>
+<tr><td><a href="R-4.0.4.tar.gz">R-4.0.4.tar.gz</a></td></tr>
+<tr><td><a href="R-4.0.5.tar.gz">R-4.0.5.tar.gz</a></td></tr>
+<tr><td><a href="R-4.1.0.tar.gz">R-4.1.0.tar.gz</a></td></tr>
+</table>
+</body></html>`
 
 				client.responses["https://cran.r-project.org/src/base/R-4/"] = mockResponse{
-					body:   string(fixtureData),
+					body:   html,
 					status: 200,
 				}
 

--- a/dockerfiles/depwatcher-go/pkg/watchers/zulu.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/zulu.go
@@ -35,7 +35,9 @@ func NewZuluWatcher(client base.HTTPClient, version, typ string) *ZuluWatcher {
 
 func (w *ZuluWatcher) Check() ([]base.Internal, error) {
 	if w.version == "" {
-		return nil, fmt.Errorf("version must be specified")
+		// No version specified — return all available latest versions per major line.
+		// This is used by the create-new-line-story job to detect new major versions.
+		return w.fetchAllLatestVersions()
 	}
 
 	pkg, err := w.fetchLatestPackage()
@@ -73,9 +75,6 @@ func (w *ZuluWatcher) In(ref string) (base.Release, error) {
 }
 
 func (w *ZuluWatcher) fetchLatestPackage() (*zuluPackage, error) {
-	if w.version == "" {
-		return nil, fmt.Errorf("version must be specified")
-	}
 	if w.typ == "" {
 		return nil, fmt.Errorf("type must be specified")
 	}

--- a/dockerfiles/depwatcher-go/pkg/watchers/zulu_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/zulu_test.go
@@ -35,13 +35,29 @@ var _ = Describe("ZuluWatcher", func() {
 			})
 		})
 
-		Context("when version is missing", func() {
-			It("returns an error", func() {
-				watcher = watchers.NewZuluWatcher(client, "", "jdk")
+		Context("when version is not specified (latest-line check)", func() {
+			It("returns all available major-version lines", func() {
+				client.Response = `[
+					{
+						"java_version": [8, 0, 302],
+						"download_url": "https://cdn.azul.com/zulu/bin/zulu8.56.0.21-ca-jre8.0.302-linux_x64.tar.gz",
+						"name": "zulu8.56.0.21-ca-jre8.0.302-linux_x64.tar.gz",
+						"latest": true
+					},
+					{
+						"java_version": [11, 0, 12],
+						"download_url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jre11.0.12-linux_x64.tar.gz",
+						"name": "zulu11.50.19-ca-jre11.0.12-linux_x64.tar.gz",
+						"latest": true
+					}
+				]`
+				watcher = watchers.NewZuluWatcher(client, "", "jre")
 
-				_, err := watcher.Check()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("version must be specified"))
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(2))
+				refs := []string{versions[0].Ref, versions[1].Ref}
+				Expect(refs).To(ContainElements("8.0.302", "11.0.12"))
 			})
 		})
 


### PR DESCRIPTION
this will fix the fetch all version for zulu
so `source-zulu-latest` resource will actually fetch the latest versions for zulu

also fixed tests fixtures as they where using the specs from the old crystal based depwatcher