### PR TITLE
[dependency-builds] remove depreacted php 8.1 and added 8.4 and 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 private.yml
 .vagrant/
 .rspec
+.opencode
 rspec.failures
 tags
 deployments/concourse-gcp/manifest.yml
@@ -17,4 +18,3 @@ deployments/concourse-gcp-terraform/terraform.tfstate.backup
 **cves.json
 
 scripts/gcp-env-checkup/.cache/
-

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -227,17 +227,21 @@ dependencies:
     buildpacks:
       php:
         lines:
-          - line: 8.1.X
-            match: 8.1.\d+
-            deprecation_date: 2024-11-25
-            link: http://php.net/supported-versions.php
           - line: 8.2.X
             match: 8.2.\d+
             deprecation_date: 2025-12-08
             link: http://php.net/supported-versions.php
           - line: 8.3.X
             match: 8.3.\d+
-            deprecation_date: 2026-11-23
+            deprecation_date: 2025-12-31
+            link: http://php.net/supported-versions.php
+          - line: 8.4.X
+            match: 8.4.\d+
+            deprecation_date: 2026-12-31
+            link: http://php.net/supported-versions.php
+          - line: 8.5.X
+            match: 8.5.\d+
+            deprecation_date: 2027-12-31
             link: http://php.net/supported-versions.php
         removal_strategy: keep_latest_released
     source_type: php


### PR DESCRIPTION
this will remove the depreacted php 8.1 from the dependecy-builds pipeline
and adds 8.4 and 8.5

see: https://www.php.net/supported-versions.php

please not that im not sure which deprecation date we should set.
the end of security updates (which basically means EOL)
or the end of the updates