### PR TITLE
Bump APCu from 5.1.23 to 5.1.28

### DIFF
--- a/tasks/build-binary-new-cflinuxfs4/php_extensions/php8-base-extensions.yml
+++ b/tasks/build-binary-new-cflinuxfs4/php_extensions/php8-base-extensions.yml
@@ -26,8 +26,8 @@ native_modules:
   klass: LibSodiumRecipe
 extensions:
 - name: apcu
-  version: 5.1.23
-  md5: c6ed350a587cf2b376c1efeb31f68907
+  version: 5.1.28
+  md5: 69e2063b28725aca0ce6cac087a5d2bc
   klass: PeclRecipe
 - name: igbinary
   version: 3.2.15

--- a/tasks/build-binary-new-cflinuxfs5/php_extensions/php8-base-extensions.yml
+++ b/tasks/build-binary-new-cflinuxfs5/php_extensions/php8-base-extensions.yml
@@ -26,8 +26,8 @@ native_modules:
   klass: LibSodiumRecipe
 extensions:
 - name: apcu
-  version: 5.1.23
-  md5: c6ed350a587cf2b376c1efeb31f68907
+  version: 5.1.28
+  md5: 69e2063b28725aca0ce6cac087a5d2bc
   klass: PeclRecipe
 - name: igbinary
   version: 3.2.15


### PR DESCRIPTION
## Why

APCu 5.1.23 fails to build against PHP 8.4 and 8.5. The `config.m4` script has a bug where `APCU_CFLAGS=` is treated as a shell command rather than a variable assignment, causing `-DZEND_COMPILE_DL_EXT=1` to be passed with surrounding quotes to `cc`. The compiler then interprets it as a linker input filename instead of a preprocessor flag, resulting in:
```
cc: error: -DZEND_COMPILE_DL_EXT=1: linker input file not found
make: *** [Makefile:210: apc.lo] Error 1
```
This was breaking the `build-php-8.4.x` and `build-php-8.5.x` dependency pipeline jobs.

## What

Bump APCu from 5.1.23 to 5.1.28 in the php8 extension configs for both cflinuxfs4 and cflinuxfs5. The fix for this bug was introduced in APCu 5.1.24.

## Files changed

- `tasks/build-binary-new-cflinuxfs4/php_extensions/php8-base-extensions.yml`
- `tasks/build-binary-new-cflinuxfs5/php_extensions/php8-base-extensions.yml`