### PR TITLE
Increase node build timeout to 5h for Node 24 LTS compile time

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -213,6 +213,7 @@ dependencies:
     source_type: nginx
     versions_to_keep: 2
   node:
+    build_timeout: 5h
     buildpacks:
       nodejs:
         lines:

--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -339,7 +339,7 @@ jobs:
       - task: #@ "build-binary-{}".format(stack)
         image: #@ "{}-image".format(data.values.any_stack_build_stack if stack == "any-stack" else stack)
         file: buildpacks-ci/tasks/build-binary/build.yml
-        timeout: 3h
+        timeout: #@ getattr(dep, "build_timeout", "3h")
         attempts: 2
         output_mapping:
           artifacts: #@ "{}-artifacts".format(stack)


### PR DESCRIPTION
Node.js 24 (current LTS) has significantly longer compile times than previous versions due to the V8 torque-generated files and full test suite compilation. The existing 3h timeout is consistently exceeded when building node-lts on both cflinuxfs4 and cflinuxfs5.

**Changes**:

 - Add optional build_timeout field to the dependency config schema in `pipeline.yml`, falling back to 3h for all other dependencies
 - Set build_timeout: 5h for the node dependency in config.yml