### PR TITLE
feat: Add poetry-core configuration to dependency builds

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -376,6 +376,14 @@ dependencies:
     source_type: pypi
     any_stack: true
     versions_to_keep: 2
+  poetry-core:
+    buildpacks:
+      python:
+        lines:
+          - line: latest
+    source_type: pypi
+    any_stack: true
+    versions_to_keep: 2
   yarn:
     buildpacks:
       nodejs:


### PR DESCRIPTION
feat: Add poetry-core configuration to dependency builds

**Python buildpack PR:** https://github.com/cloudfoundry/python-buildpack/pull/1181