### PR TITLE
Add java-cfenv dependency using maven source_type

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -35,16 +35,17 @@ dependencies:
     source_type: rubygems
     any_stack: true
     versions_to_keep: 2
-  cfenv:
+  java-cfenv:
     buildpacks:
       java:
         lines:
           - line: 3.X.X
           - line: 4.X.X
-    source_type: github_releases
+    source_type: maven
     source_params:
-      - 'repo: pivotal-cf/java-cfenv'
-      - 'fetch_source: true'
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: io.pivotal.cfenv'
+      - 'artifact_id: java-cfenv-boot'
     any_stack: true
     versions_to_keep: 1
   composer:

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -45,7 +45,7 @@ dependencies:
     source_params:
       - 'uri: https://repo1.maven.org/maven2'
       - 'group_id: io.pivotal.cfenv'
-      - 'artifact_id: java-cfenv-boot'
+      - 'artifact_id: java-cfenv'
     any_stack: true
     versions_to_keep: 1
   composer:


### PR DESCRIPTION
## Summary

- Renames `cfenv` → `java-cfenv` to match the dependency name used in the java-buildpack `manifest.yml`
- Switches `source_type` from `github_releases` to `maven` so depwatcher's `MavenWatcher` produces a `data.json` with a direct JAR URL from Maven Central (rather than a GitHub source tarball)
- Maven coordinates: `io.pivotal.cfenv:java-cfenv-boot` at `https://repo1.maven.org/maven2`

## Why maven instead of github_releases?

The original PR #617 used `github_releases` + `fetch_source: true`, which produces a GitHub source tarball URL in `data.json`. `java-cfenv` is a pre-built JAR on Maven Central — no compilation is needed. Using `source_type: maven` gives depwatcher a direct JAR URL, which `binary-builder`'s `PassthroughRecipe` can download and stage without any build step.

## Pairs with

cloudfoundry/binary-builder#105

this superseeds https://github.com/cloudfoundry/buildpacks-ci/pull/617