### PR TITLE
Fix maven watcher: fall back to SHA1 when SHA512 not available

### DIFF
--- a/dockerfiles/depwatcher-go/pkg/watchers/maven.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/maven.go
@@ -125,7 +125,7 @@ func (w *MavenWatcher) In(ref string) (base.Release, error) {
 		headers.Set("Authorization", "Basic "+base64Encode(auth))
 	}
 
-	// Fetch SHA512 checksum (available in Maven 3.9.9+)
+	// Try SHA512 first, fall back to SHA1 (Maven Central only provides sha1)
 	sha512URL := fmt.Sprintf("%s.sha512", artifactURL)
 	resp, err := w.client.GetWithHeaders(sha512URL, headers)
 	if err != nil {
@@ -133,22 +133,46 @@ func (w *MavenWatcher) In(ref string) (base.Release, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return base.Release{}, fmt.Errorf("unexpected status code %d fetching SHA512", resp.StatusCode)
+	if resp.StatusCode == http.StatusOK {
+		sha512Bytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return base.Release{}, fmt.Errorf("failed to read SHA512: %w", err)
+		}
+		sha512Hash := strings.TrimSpace(strings.Fields(string(sha512Bytes))[0])
+		return base.Release{
+			Ref:    ref,
+			URL:    artifactURL,
+			SHA512: sha512Hash,
+		}, nil
 	}
 
-	sha512Bytes, err := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusNotFound {
+		return base.Release{}, fmt.Errorf("fetching version data: failed to fetch SHA512: request failed with status %d: %s", resp.StatusCode, sha512URL)
+	}
+
+	// Fall back to SHA1
+	sha1URL := fmt.Sprintf("%s.sha1", artifactURL)
+	resp1, err := w.client.GetWithHeaders(sha1URL, headers)
 	if err != nil {
-		return base.Release{}, fmt.Errorf("failed to read SHA512: %w", err)
+		return base.Release{}, fmt.Errorf("failed to fetch SHA1: %w", err)
+	}
+	defer resp1.Body.Close()
+
+	if resp1.StatusCode != http.StatusOK {
+		return base.Release{}, fmt.Errorf("fetching version data: failed to fetch SHA1: request failed with status %d: %s", resp1.StatusCode, sha1URL)
 	}
 
-	// SHA512 files may contain just the hash or "hash filename" format
-	sha512Hash := strings.TrimSpace(strings.Fields(string(sha512Bytes))[0])
+	sha1Bytes, err := io.ReadAll(resp1.Body)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to read SHA1: %w", err)
+	}
 
+	// SHA1 files may contain just the hash or "hash filename" format
+	sha1Hash := strings.TrimSpace(strings.Fields(string(sha1Bytes))[0])
 	return base.Release{
-		Ref:    ref,
-		URL:    artifactURL,
-		SHA512: sha512Hash,
+		Ref:  ref,
+		URL:  artifactURL,
+		SHA1: sha1Hash,
 	}, nil
 }
 

--- a/dockerfiles/depwatcher-go/pkg/watchers/maven_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/maven_test.go
@@ -11,15 +11,25 @@ import (
 )
 
 type mavenMockClient struct {
-	response *http.Response
-	err      error
+	responses map[string]*http.Response
+	err       error
+}
+
+func newMavenMockClient(response *http.Response) *mavenMockClient {
+	return &mavenMockClient{responses: map[string]*http.Response{"*": response}}
 }
 
 func (m *mavenMockClient) Get(url string) (*http.Response, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.response, nil
+	if resp, ok := m.responses[url]; ok {
+		return resp, nil
+	}
+	if resp, ok := m.responses["*"]; ok {
+		return resp, nil
+	}
+	return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil
 }
 
 func (m *mavenMockClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
@@ -33,13 +43,13 @@ var _ = Describe("MavenWatcher", func() {
 	)
 
 	BeforeEach(func() {
-		mockClient = &mavenMockClient{}
+		mockClient = &mavenMockClient{responses: map[string]*http.Response{}}
 	})
 
 	Describe("Check", func() {
 		Context("when the metadata XML is valid", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 200,
 					Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
@@ -53,7 +63,7 @@ var _ = Describe("MavenWatcher", func() {
     </versions>
   </versioning>
 </metadata>`)),
-				}
+				})
 				watcher = watchers.NewMavenWatcher(
 					mockClient,
 					"https://repo1.maven.org/maven2",
@@ -129,10 +139,10 @@ var _ = Describe("MavenWatcher", func() {
 
 		Context("when the server returns non-200 status", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 404,
 					Body:       io.NopCloser(strings.NewReader("")),
-				}
+				})
 				watcher = watchers.NewMavenWatcher(mockClient, "https://repo1.maven.org/maven2", "org.test", "artifact", "", "jar", "", "")
 			})
 
@@ -145,10 +155,10 @@ var _ = Describe("MavenWatcher", func() {
 
 		Context("when the XML is invalid", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader("invalid xml")),
-				}
+				})
 				watcher = watchers.NewMavenWatcher(mockClient, "https://repo1.maven.org/maven2", "org.test", "artifact", "", "jar", "", "")
 			})
 
@@ -161,12 +171,12 @@ var _ = Describe("MavenWatcher", func() {
 	})
 
 	Describe("In", func() {
-		Context("with basic Maven coordinates", func() {
+		Context("when SHA512 is available", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 200,
-					Body:       io.NopCloser(strings.NewReader("abc123def456")),
-				}
+					Body:       io.NopCloser(strings.NewReader("abc123sha512hash")),
+				})
 				watcher = watchers.NewMavenWatcher(
 					mockClient,
 					"https://repo1.maven.org/maven2",
@@ -179,20 +189,79 @@ var _ = Describe("MavenWatcher", func() {
 				)
 			})
 
-			It("returns the correct artifact URL", func() {
+			It("returns the correct artifact URL and SHA512", func() {
 				release, err := watcher.In("5.3.0")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(release.Ref).To(Equal("5.3.0"))
 				Expect(release.URL).To(Equal("https://repo1.maven.org/maven2/org/springframework/spring-core/5.3.0/spring-core-5.3.0.jar"))
+				Expect(release.SHA512).To(Equal("abc123sha512hash"))
+				Expect(release.SHA1).To(BeEmpty())
+			})
+		})
+
+		Context("when SHA512 is not available but SHA1 is (e.g. Maven Central)", func() {
+			BeforeEach(func() {
+				sha512URL := "https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar.sha512"
+				sha1URL := "https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar.sha1"
+				mockClient = &mavenMockClient{
+					responses: map[string]*http.Response{
+						sha512URL: {StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))},
+						sha1URL:   {StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("deadbeefsha1hash"))},
+					},
+				}
+				watcher = watchers.NewMavenWatcher(
+					mockClient,
+					"https://repo1.maven.org/maven2",
+					"io.pivotal.cfenv",
+					"java-cfenv",
+					"",
+					"jar",
+					"",
+					"",
+				)
+			})
+
+			It("falls back to SHA1 and returns it", func() {
+				release, err := watcher.In("3.5.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("3.5.1"))
+				Expect(release.URL).To(Equal("https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar"))
+				Expect(release.SHA1).To(Equal("deadbeefsha1hash"))
+				Expect(release.SHA512).To(BeEmpty())
+			})
+		})
+
+		Context("when neither SHA512 nor SHA1 is available", func() {
+			BeforeEach(func() {
+				mockClient = newMavenMockClient(&http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("")),
+				})
+				watcher = watchers.NewMavenWatcher(
+					mockClient,
+					"https://repo1.maven.org/maven2",
+					"org.test",
+					"artifact",
+					"",
+					"jar",
+					"",
+					"",
+				)
+			})
+
+			It("returns an error", func() {
+				_, err := watcher.In("1.0.0")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch SHA1"))
 			})
 		})
 
 		Context("with classifier", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader("abc123def456")),
-				}
+				})
 				watcher = watchers.NewMavenWatcher(
 					mockClient,
 					"https://repo1.maven.org/maven2",
@@ -214,10 +283,10 @@ var _ = Describe("MavenWatcher", func() {
 
 		Context("with custom packaging", func() {
 			BeforeEach(func() {
-				mockClient.response = &http.Response{
+				mockClient = newMavenMockClient(&http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(strings.NewReader("abc123def456")),
-				}
+				})
 				watcher = watchers.NewMavenWatcher(
 					mockClient,
 					"https://repo1.maven.org/maven2",


### PR DESCRIPTION
## Problem

After merging #623, the maven watcher broke for `java-cfenv` (and any artifact hosted on Maven Central):

```
error: fetching version data: failed to fetch SHA512: request failed with status 404:
https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar.sha512
```

Maven Central only publishes `.sha1` and `.md5` checksums — `.sha512` is not part of the Maven repository standard and is not available there.

## Fix

`In()` now tries `.sha512` first and falls back to `.sha1` on a 404. Any other non-200 status is still an error.

The returned `Release` populates `SHA512` or `SHA1` depending on which was found. This is safe because:
- The SHA is used only for **download integrity verification** in the builder (`Sha.verify_digest`), which already handles sha512 → sha256 → sha1 → md5 in priority order
- `manifest.yml` always receives a freshly computed **sha256** of the re-hosted artifact via `ArtifactOutput#move_dependency` — libbuildpack is unaffected

## Tests

Updated the mock client to support URL-keyed responses, and added three new `In` test cases:
- SHA512 available → uses it
- SHA512 returns 404, SHA1 available → falls back correctly (the `java-cfenv` scenario)
- Neither available → returns an error