### PR TITLE
Fix maven SHA512 fallback: use GetRaw to actually inspect status code

### DIFF
--- a/dockerfiles/depwatcher-go/internal/factory/factory_test.go
+++ b/dockerfiles/depwatcher-go/internal/factory/factory_test.go
@@ -41,6 +41,10 @@ func (m *mockHTTPClient) GetWithHeaders(url string, headers http.Header) (*http.
 	return m.Get(url)
 }
 
+func (m *mockHTTPClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockHTTPClient() *mockHTTPClient {
 	return &mockHTTPClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/base/client.go
+++ b/dockerfiles/depwatcher-go/pkg/base/client.go
@@ -55,6 +55,24 @@ func (c *HTTPClientImpl) Get(url string) (*http.Response, error) {
 
 // GetWithHeaders performs an HTTP GET request with custom headers
 func (c *HTTPClientImpl) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	resp, err := c.GetRaw(url, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for successful response
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		resp.Body.Close()
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, url)
+	}
+
+	return resp, nil
+}
+
+// GetRaw performs an HTTP GET request with custom headers and returns the response
+// regardless of status code. Unlike GetWithHeaders, it does NOT error on non-2xx responses.
+// Use this when you need to inspect the status code yourself (e.g. for fallback logic).
+func (c *HTTPClientImpl) GetRaw(url string, headers http.Header) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
@@ -79,12 +97,6 @@ func (c *HTTPClientImpl) GetWithHeaders(url string, headers http.Header) (*http.
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
-	}
-
-	// Check for successful response
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, url)
 	}
 
 	return resp, nil

--- a/dockerfiles/depwatcher-go/pkg/base/types.go
+++ b/dockerfiles/depwatcher-go/pkg/base/types.go
@@ -29,6 +29,10 @@ type Release struct {
 type HTTPClient interface {
 	Get(url string) (*http.Response, error)
 	GetWithHeaders(url string, headers http.Header) (*http.Response, error)
+	// GetRaw performs a GET request and returns the response regardless of status code.
+	// Unlike GetWithHeaders, it does NOT return an error for non-2xx responses.
+	// Use this when you need to inspect the status code yourself (e.g. for fallback logic).
+	GetRaw(url string, headers http.Header) (*http.Response, error)
 }
 
 // SortVersions sorts a slice of Internal versions using semver comparison

--- a/dockerfiles/depwatcher-go/pkg/watchers/adoptopenjdk_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/adoptopenjdk_test.go
@@ -26,6 +26,10 @@ func (m *adoptOpenJDKMockClient) GetWithHeaders(url string, headers http.Header)
 	return m.Get(url)
 }
 
+func (m *adoptOpenJDKMockClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("AdoptOpenJDKWatcher", func() {
 	var (
 		watcher    *watchers.AdoptOpenJDKWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/appd_agent_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/appd_agent_test.go
@@ -33,6 +33,10 @@ func (m *mockAppdAgentClient) GetWithHeaders(url string, headers http.Header) (*
 	return m.Get(url)
 }
 
+func (m *mockAppdAgentClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("AppdAgentWatcher", func() {
 	var (
 		client  *mockAppdAgentClient

--- a/dockerfiles/depwatcher-go/pkg/watchers/ca_apm_agent_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/ca_apm_agent_test.go
@@ -32,6 +32,10 @@ func (m *mockCaApmAgentClient) GetWithHeaders(url string, headers http.Header) (
 	return m.Get(url)
 }
 
+func (m *mockCaApmAgentClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("CaApmAgentWatcher", func() {
 	var (
 		client  *mockCaApmAgentClient

--- a/dockerfiles/depwatcher-go/pkg/watchers/cran_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/cran_test.go
@@ -32,6 +32,10 @@ func (m *mockCRANClient) GetWithHeaders(url string, headers http.Header) (*http.
 	return m.Get(url)
 }
 
+func (m *mockCRANClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("CRANWatcher", func() {
 	var client *mockCRANClient
 

--- a/dockerfiles/depwatcher-go/pkg/watchers/dotnet_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/dotnet_test.go
@@ -358,3 +358,7 @@ func (m *mockHTTPClient) Get(url string) (*http.Response, error) {
 func (m *mockHTTPClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
 	return m.Get(url)
 }
+
+func (m *mockHTTPClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/github_releases_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/github_releases_test.go
@@ -51,6 +51,10 @@ func (m *mockGithubReleasesClient) GetWithHeaders(url string, headers http.Heade
 	}, nil
 }
 
+func (m *mockGithubReleasesClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockGithubReleasesClient(releases string) *mockGithubReleasesClient {
 	return &mockGithubReleasesClient{
 		responses: map[string]string{

--- a/dockerfiles/depwatcher-go/pkg/watchers/github_tags_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/github_tags_test.go
@@ -40,6 +40,10 @@ func (m *mockGithubTagsClient) GetWithHeaders(url string, headers http.Header) (
 	return m.Get(url)
 }
 
+func (m *mockGithubTagsClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockGithubTagsClient(tags string) *mockGithubTagsClient {
 	return &mockGithubTagsClient{
 		responses: map[string]string{

--- a/dockerfiles/depwatcher-go/pkg/watchers/go_watcher_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/go_watcher_test.go
@@ -35,6 +35,10 @@ func (m *mockGoClient) GetWithHeaders(url string, headers http.Header) (*http.Re
 	return m.Get(url)
 }
 
+func (m *mockGoClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockGoClient() *mockGoClient {
 	return &mockGoClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/gradle_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/gradle_test.go
@@ -27,6 +27,10 @@ func (m *gradleMockClient) GetWithHeaders(url string, headers http.Header) (*htt
 	return m.Get(url)
 }
 
+func (m *gradleMockClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("GradleWatcher", func() {
 	var (
 		watcher    *watchers.GradleWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/httpd_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/httpd_test.go
@@ -45,6 +45,10 @@ func (m *mockHttpdClient) GetWithHeaders(url string, headers http.Header) (*http
 	return m.Get(url)
 }
 
+func (m *mockHttpdClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockHttpdClient() *mockHttpdClient {
 	return &mockHttpdClient{
 		responses:   make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/icu_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/icu_test.go
@@ -248,3 +248,7 @@ func (m *mockICUClient) Get(url string) (*http.Response, error) {
 func (m *mockICUClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
 	return m.Get(url)
 }
+
+func (m *mockICUClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/jruby_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/jruby_test.go
@@ -35,6 +35,10 @@ func (m *mockJRubyClient) GetWithHeaders(url string, headers http.Header) (*http
 	return m.Get(url)
 }
 
+func (m *mockJRubyClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockJRubyClient() *mockJRubyClient {
 	return &mockJRubyClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/maven.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/maven.go
@@ -127,7 +127,7 @@ func (w *MavenWatcher) In(ref string) (base.Release, error) {
 
 	// Try SHA512 first, fall back to SHA1 (Maven Central only provides sha1)
 	sha512URL := fmt.Sprintf("%s.sha512", artifactURL)
-	resp, err := w.client.GetWithHeaders(sha512URL, headers)
+	resp, err := w.client.GetRaw(sha512URL, headers)
 	if err != nil {
 		return base.Release{}, fmt.Errorf("failed to fetch SHA512: %w", err)
 	}

--- a/dockerfiles/depwatcher-go/pkg/watchers/maven_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/maven_test.go
@@ -36,6 +36,10 @@ func (m *mavenMockClient) GetWithHeaders(url string, headers http.Header) (*http
 	return m.Get(url)
 }
 
+func (m *mavenMockClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("MavenWatcher", func() {
 	var (
 		watcher    *watchers.MavenWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/miniconda_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/miniconda_test.go
@@ -26,6 +26,10 @@ func (m *mockMinicondaClient) GetWithHeaders(url string, headers http.Header) (*
 	return m.Get(url)
 }
 
+func (m *mockMinicondaClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("MinicondaWatcher", func() {
 	var (
 		watcher *watchers.MinicondaWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/mock_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/mock_test.go
@@ -61,3 +61,38 @@ func (m *MockHTTPClient) Get(url string) (*http.Response, error) {
 func (m *MockHTTPClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
 	return m.Get(url)
 }
+
+// GetRaw implements the HTTPClient interface — returns response regardless of status code
+func (m *MockHTTPClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+
+	statusCode := m.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+
+	// Check URL-mapped responses first
+	if m.Responses != nil {
+		if response, ok := m.Responses[url]; ok {
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(response)),
+			}, nil
+		}
+		// Check for default response
+		if response, ok := m.Responses["default"]; ok {
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(response)),
+			}, nil
+		}
+	}
+
+	// Fall back to single Response field
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(m.Response)),
+	}, nil
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/nginx_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/nginx_test.go
@@ -35,6 +35,10 @@ func (m *mockNginxClient) GetWithHeaders(url string, headers http.Header) (*http
 	return m.Get(url)
 }
 
+func (m *mockNginxClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockNginxClient() *mockNginxClient {
 	return &mockNginxClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/node_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/node_test.go
@@ -35,6 +35,10 @@ func (m *mockNodeClient) GetWithHeaders(url string, headers http.Header) (*http.
 	return m.Get(url)
 }
 
+func (m *mockNodeClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockNodeClient() *mockNodeClient {
 	return &mockNodeClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/npm_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/npm_test.go
@@ -35,6 +35,10 @@ func (m *mockNPMClient) GetWithHeaders(url string, headers http.Header) (*http.R
 	return m.Get(url)
 }
 
+func (m *mockNPMClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockNPMClient() *mockNPMClient {
 	return &mockNPMClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/openresty_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/openresty_test.go
@@ -37,6 +37,10 @@ func (m *mockOpenrestyClient) GetWithHeaders(url string, headers http.Header) (*
 	return m.Get(url)
 }
 
+func (m *mockOpenrestyClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("OpenrestyWatcher", func() {
 	var (
 		watcher *watchers.OpenrestyWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/php_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/php_test.go
@@ -35,6 +35,10 @@ func (m *mockPHPClient) GetWithHeaders(url string, headers http.Header) (*http.R
 	return m.Get(url)
 }
 
+func (m *mockPHPClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockPHPClient() *mockPHPClient {
 	return &mockPHPClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/pypi_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/pypi_test.go
@@ -35,6 +35,10 @@ func (m *mockPyPIClient) GetWithHeaders(url string, headers http.Header) (*http.
 	return m.Get(url)
 }
 
+func (m *mockPyPIClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockPyPIClient() *mockPyPIClient {
 	return &mockPyPIClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/python_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/python_test.go
@@ -35,6 +35,10 @@ func (m *mockPythonClient) GetWithHeaders(url string, headers http.Header) (*htt
 	return m.Get(url)
 }
 
+func (m *mockPythonClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockPythonClient() *mockPythonClient {
 	return &mockPythonClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/r_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/r_test.go
@@ -37,6 +37,10 @@ func (m *mockRClient) GetWithHeaders(url string, headers http.Header) (*http.Res
 	return m.Get(url)
 }
 
+func (m *mockRClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("RWatcher", func() {
 	var (
 		client  *mockRClient

--- a/dockerfiles/depwatcher-go/pkg/watchers/ruby_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/ruby_test.go
@@ -35,6 +35,10 @@ func (m *mockRubyClient) GetWithHeaders(url string, headers http.Header) (*http.
 	return m.Get(url)
 }
 
+func (m *mockRubyClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 func newMockRubyClient() *mockRubyClient {
 	return &mockRubyClient{
 		responses: make(map[string]string),

--- a/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/rubygems_cli_test.go
@@ -32,6 +32,10 @@ func (m *mockRubygemsCLIClient) GetWithHeaders(url string, headers http.Header) 
 	return m.Get(url)
 }
 
+func (m *mockRubygemsCLIClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("RubygemsCLIWatcher", func() {
 	var (
 		watcher *watchers.RubygemsCLIWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/rubygems_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/rubygems_test.go
@@ -42,6 +42,10 @@ func (m *mockRubygemsClient) GetWithHeaders(url string, headers http.Header) (*h
 	return m.Get(url)
 }
 
+func (m *mockRubygemsClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("RubygemsWatcher", func() {
 	var (
 		watcher *watchers.RubygemsWatcher

--- a/dockerfiles/depwatcher-go/pkg/watchers/tomcat_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/tomcat_test.go
@@ -26,6 +26,10 @@ func (m *tomcatMockClient) GetWithHeaders(url string, headers http.Header) (*htt
 	return m.Get(url)
 }
 
+func (m *tomcatMockClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
 var _ = Describe("TomcatWatcher", func() {
 	var (
 		watcher    *watchers.TomcatWatcher


### PR DESCRIPTION
## Problem

PR #624 attempted to fix the maven watcher falling back from SHA512 to SHA1 (Maven Central only provides `.sha1`, not `.sha512`). However the fix did not work in production — the Concourse build continued to fail with:

```
error: fetching version data: failed to fetch SHA512: request failed with status 404: https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar.sha512
```

## Root Cause

`GetWithHeaders` in `client.go` returns an **error** (not a response) for any non-2xx status code, including 404:

```go
if resp.StatusCode < 200 || resp.StatusCode >= 300 {
    resp.Body.Close()
    return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, url)
}
```

So in `maven.go`, when the SHA512 probe gets a 404, `err != nil` is true and the function returns immediately — the `resp.StatusCode == http.StatusNotFound` fallback check is **never reached**.

## Fix

Add a `GetRaw` method to `HTTPClient` and `HTTPClientImpl` that returns the response regardless of status code (no non-2xx error). `maven.go` now uses `GetRaw` for the SHA512 probe so it can inspect the 404 itself and fall through to the SHA1 fallback.

`GetWithHeaders` is refactored to delegate to `GetRaw` + add the status check on top — no behaviour change for any existing watcher.

## Verification

Tested locally against Maven Central:

```
$ echo '{"source":{"type":"maven","name":"java-cfenv","uri":"https://repo1.maven.org/maven2","group_id":"io.pivotal.cfenv","artifact_id":"java-cfenv"},"version":{"ref":"3.5.1"}}' | /tmp/test-in /tmp/out
{"ref":"3.5.1","url":"https://repo1.maven.org/maven2/io/pivotal/cfenv/java-cfenv/3.5.1/java-cfenv-3.5.1.jar","sha1":"e35e6af21d26b75f70289b2bb31725d345dbb6a7"}
```

All 333 tests pass.