### PR TITLE
Add binary-buildpack to cf-release pipeline (Linux only)

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -3,6 +3,8 @@
 #@ default_stacks = ['cflinuxfs4']
 
 supported_languages:
+- name: binary
+  stacks: #@ default_stacks
 - name: dotnet-core
   stacks: #@ default_stacks
 - name: go


### PR DESCRIPTION
## Summary

- Adds `binary` to the `supported_languages` list in `cf-release-config.yml` with `cflinuxfs4` stack only
- This unblocks automated BOSH release publishing for `binary-buildpack-release`, which is currently stuck at v1.1.21 while the buildpack itself is at v1.1.26

## Context

The binary-buildpack was never included in the cf-release pipeline config, so BOSH releases stopped being produced when the old release mechanism was retired. Since the binary buildpack is stack-agnostic (no compiled dependencies), it only needs Linux (cflinuxfs4) testing to match how all other buildpacks are handled in this pipeline. Windows testing is not included and can be addressed separately if needed.

## Pre-flight checks

Before merging, please verify:
1. The binary-buildpack pipeline publishes a cflinuxfs4 artifact to the S3 path expected by cf-release (`buildpacks.cloudfoundry.org/buildpack-release-published/binary/`)
2. The `binary-buildpack-release` BOSH release repo structure is compatible with the `create-buildpack-dev-release` task