### PR TITLE
Fix: Only remove blobs for stacks being updated in cf-release pipeline

### DIFF
--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -139,7 +139,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/binary-builder
-    branch: go-binary-builder-cflinuxfs4-parity
+    branch: main
 - name: buildpacks-ci
   type: git
   source:

--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -333,39 +333,53 @@ jobs:
     #@ end
     - get: builds
   #@ if len(build_stacks) > 0:
+  #@ # Step 1: Build all stacks in parallel (with SKIP_INDIVIDUAL_COMMIT to defer git commit)
   - in_parallel:
     #@ for stack in build_stacks:
-    - do:
-      - task: #@ "build-binary-{}".format(stack)
-        image: #@ "{}-image".format(data.values.any_stack_build_stack if stack == "any-stack" else stack)
-        file: buildpacks-ci/tasks/build-binary/build.yml
-        timeout: 3h
-        attempts: 2
-        output_mapping:
-          artifacts: #@ "{}-artifacts".format(stack)
-          builds-artifacts: #@ "{}-builds-metadata".format(stack)
-        params:
-          STACK: #@ stack
-          ANY_STACK_BUILD_STACK: #@ data.values.any_stack_build_stack
-      #@ if getattr(dep, "third_party_hosted", False):
-      - put: #@ "builds-metadata-{}".format(stack)
-        resource: builds
-        params:
-          repository: #@ "{}-builds-metadata".format(stack)
-          rebase: true
-      #@ else:
-      - in_parallel:
-        - put: #@ "buildpacks-bucket-{}-{}".format(dep_name, stack)
-          resource: #@ "buildpacks-bucket-{}".format(dep_name)
-          params:
-            file: #@ "{}-artifacts/{}*".format(stack, "nginx" if dep_name == "nginx-static" else dep_name)
-        - put: #@ "builds-metadata-{}".format(stack)
-          resource: builds
-          params:
-            repository: #@ "{}-builds-metadata".format(stack)
-            rebase: true
-      #@ end
+    - task: #@ "build-binary-{}".format(stack)
+      image: #@ "{}-image".format(data.values.any_stack_build_stack if stack == "any-stack" else stack)
+      file: buildpacks-ci/tasks/build-binary/build.yml
+      timeout: 3h
+      attempts: 2
+      output_mapping:
+        artifacts: #@ "{}-artifacts".format(stack)
+        builds-artifacts: #@ "{}-builds-metadata".format(stack)
+      params:
+        STACK: #@ stack
+        ANY_STACK_BUILD_STACK: #@ data.values.any_stack_build_stack
+        #@ if len(build_stacks) > 1 and "any-stack" not in build_stacks:
+        SKIP_INDIVIDUAL_COMMIT: "true"
+        #@ end
     #@ end
+  #@ # Step 2: Upload artifacts to S3 (in parallel, unless third-party hosted)
+  #@ if not getattr(dep, "third_party_hosted", False):
+  - in_parallel:
+    #@ for stack in build_stacks:
+    - put: #@ "buildpacks-bucket-{}-{}".format(dep_name, stack)
+      resource: #@ "buildpacks-bucket-{}".format(dep_name)
+      params:
+        file: #@ "{}-artifacts/{}*".format(stack, "nginx" if dep_name == "nginx-static" else dep_name)
+    #@ end
+  #@ end
+  #@ # Step 3: Merge build metadata and create atomic commit (multi-stack only)
+  #@ if len(build_stacks) > 1 and "any-stack" not in build_stacks:
+  - task: merge-build-metadata
+    image: #@ "{}-image".format(build_stacks[0])
+    file: buildpacks-ci/tasks/merge-build-metadata/task.yml
+    input_mapping:
+      stack1-builds-metadata: #@ "{}-builds-metadata".format(build_stacks[0])
+      stack2-builds-metadata: #@ "{}-builds-metadata".format(build_stacks[1])
+  - put: builds
+    params:
+      repository: builds-merged
+      rebase: true
+  #@ else:
+  #@ # For single-stack or any-stack builds, use the original direct commit
+  - put: builds
+    params:
+      repository: #@ "{}-builds-metadata".format(build_stacks[0])
+      rebase: true
+  #@ end
   #@ end
 #@   end
 

--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -144,7 +144,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/buildpacks-ci
-    branch: master
+    branch: fix-multi-stack-atomic-commits-clean
 - name: builds
   type: git
   source:

--- a/tasks/build-binary/build.sh
+++ b/tasks/build-binary/build.sh
@@ -148,6 +148,14 @@ if [[ "${SKIP_COMMIT:-}" == "true" ]]; then
   exit 0
 fi
 
+# SKIP_INDIVIDUAL_COMMIT is used when building multiple stacks in parallel.
+# Each task writes its JSON file to builds-artifacts but defers the git commit
+# to a subsequent merge-and-commit task that atomically commits all stacks together.
+if [[ "${SKIP_INDIVIDUAL_COMMIT:-}" == "true" ]]; then
+  echo "[task] SKIP_INDIVIDUAL_COMMIT=true — deferring commit to merge task"
+  exit 0
+fi
+
 echo "[task] Committing builds-artifacts..."
 pushd builds-artifacts >/dev/null
 git config user.email "cf-buildpacks-eng@pivotal.io"

--- a/tasks/cf-release/create-buildpack-dev-release/run
+++ b/tasks/cf-release/create-buildpack-dev-release/run
@@ -43,10 +43,21 @@ buildpack_blob_is_latest() {
 }
 
 remove_old_blobs() {
-  bosh blobs --dir release --json \
-    | jq -r '.Tables[0].Rows[].path' \
-    | grep buildpack \
-    | xargs -I {} bosh remove-blob --dir release {}
+  local buildpack_name
+  buildpack_name="$(get_buildpack_name)"
+  
+  # Only remove blobs for stacks that are being updated
+  for buildpack_file in buildpack-*/*.zip; do
+    local blob_name_pattern
+    blob_name_pattern="$(basename "${buildpack_file}" | sed 's/v[0-9.]*\.zip/v*.zip/' | sed 's/+.*//')"
+    
+    # Find and remove old version of this stack's blob
+    bosh blobs --dir release --json \
+      | jq -r '.Tables[0].Rows[].path' \
+      | grep "${buildpack_name}" \
+      | grep -E "$(echo "${blob_name_pattern}" | sed 's/\*/[^/]*/')" \
+      | xargs -r -I {} bosh remove-blob --dir release {}
+  done
 }
 
 add_new_blobs() {

--- a/tasks/merge-build-metadata/merge.sh
+++ b/tasks/merge-build-metadata/merge.sh
@@ -41,14 +41,11 @@ done
 echo "[merge-task] Verifying merged metadata files..."
 cd builds-merged
 
-# Check if there are any changes to commit
-if ! git diff --cached --quiet 2>/dev/null && git diff --quiet 2>/dev/null; then
-  echo "[merge-task] No changes detected in working tree"
-  # Still need to stage changes from rsync
-  git add binary-builds-new/
-fi
+# Stage all changes from rsync
+echo "[merge-task] Staging changes..."
+git add binary-builds-new/
 
-# Count JSON files added/modified
+# Check if there are any changes to commit
 if git diff --cached --quiet; then
   echo "[merge-task] No changes to commit (builds already up-to-date)"
   exit 0

--- a/tasks/merge-build-metadata/merge.sh
+++ b/tasks/merge-build-metadata/merge.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Merge build metadata from multiple stack builds into a single atomic git commit.
+#
+# This task runs after parallel stack build tasks (e.g., cflinuxfs4 and cflinuxfs5)
+# that have SKIP_INDIVIDUAL_COMMIT=true set. It:
+#   1. Seeds builds-merged from the builds git resource
+#   2. Merges all stack-specific JSON files from stack*-builds-metadata inputs
+#   3. Creates a single atomic commit with all stacks' metadata
+#
+# Inputs:
+#   - builds: the git resource (latest state from GitHub)
+#   - stack1-builds-metadata: builds-artifacts from first stack build
+#   - stack2-builds-metadata: builds-artifacts from second stack build
+#   - (can be extended to stack3, stack4, etc. for future stacks)
+#
+# Outputs:
+#   - builds-merged: git repo with all stacks' JSON files, ready to push
+
+set -euo pipefail
+
+echo "[merge-task] Starting multi-stack metadata merge..."
+
+# ── 1. Seed builds-merged from builds git resource ───────────────────────────
+echo "[merge-task] Seeding builds-merged from builds git repo..."
+rsync -a builds/ builds-merged/
+
+# ── 2. Merge JSON files from all stack builds ────────────────────────────────
+echo "[merge-task] Merging metadata from stack build tasks..."
+
+# Find all stack*-builds-metadata input directories
+for stack_dir in stack*-builds-metadata; do
+  if [[ -d "${stack_dir}/binary-builds-new" ]]; then
+    echo "[merge-task]   Merging from ${stack_dir}..."
+    rsync -a "${stack_dir}/binary-builds-new/" builds-merged/binary-builds-new/
+  else
+    echo "[merge-task]   WARNING: ${stack_dir} has no binary-builds-new/ directory, skipping"
+  fi
+done
+
+# ── 3. Verify merged files ───────────────────────────────────────────────────
+echo "[merge-task] Verifying merged metadata files..."
+cd builds-merged
+
+# Check if there are any changes to commit
+if ! git diff --cached --quiet 2>/dev/null && git diff --quiet 2>/dev/null; then
+  echo "[merge-task] No changes detected in working tree"
+  # Still need to stage changes from rsync
+  git add binary-builds-new/
+fi
+
+# Count JSON files added/modified
+if git diff --cached --quiet; then
+  echo "[merge-task] No changes to commit (builds already up-to-date)"
+  exit 0
+fi
+
+CHANGED_FILES=$(git diff --cached --name-only | grep '\.json$' | wc -l)
+echo "[merge-task] Found ${CHANGED_FILES} JSON file(s) to commit"
+
+# ── 4. Create atomic commit with all stacks ──────────────────────────────────
+echo "[merge-task] Creating atomic commit..."
+
+git config user.email "cf-buildpacks-eng@pivotal.io"
+git config user.name "CF Buildpacks Team CI Server"
+
+# Extract dependency name and version from the first JSON file found
+FIRST_JSON=$(git diff --cached --name-only | grep '\.json$' | head -1)
+DEP_NAME=$(echo "${FIRST_JSON}" | sed 's|binary-builds-new/\([^/]*\)/.*|\1|')
+VERSION=$(basename "${FIRST_JSON}" | sed 's/-cflinuxfs[0-9]*.json$//')
+
+# Extract all unique stacks from changed JSON files
+STACKS=$(git diff --cached --name-only | grep '\.json$' | \
+         sed 's/.*-\(cflinuxfs[0-9]*\)\.json$/\1/' | \
+         sort -u | \
+         tr '\n' ',' | \
+         sed 's/,$//')
+
+# Commit with format: "Build <dep> - <version> - <stack1>,<stack2>"
+COMMIT_MSG="Build ${DEP_NAME} - ${VERSION} - ${STACKS}"
+git commit -m "${COMMIT_MSG}"
+
+echo "[merge-task] Committed: ${COMMIT_MSG}"
+echo "[merge-task] Merge complete!"

--- a/tasks/merge-build-metadata/task.yml
+++ b/tasks/merge-build-metadata/task.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: cloudfoundry/cflinuxfs4
+
+inputs:
+  - name: buildpacks-ci
+  - name: builds
+  - name: stack1-builds-metadata  # First stack's builds-artifacts output
+  - name: stack2-builds-metadata  # Second stack's builds-artifacts output
+
+outputs:
+  - name: builds-merged
+
+run:
+  path: buildpacks-ci/tasks/merge-build-metadata/merge.sh

--- a/tasks/update-buildpack-dependency/dependencies.rb
+++ b/tasks/update-buildpack-dependency/dependencies.rb
@@ -53,7 +53,18 @@ class Dependencies
       new_ver = SemVer.parse(@dep['version'])
       old_ver = SemVer.parse(d['version'])
       puts "DEBUG latest?: Comparing #{@dep['version']} (#{new_ver.inspect}) vs #{d['version']} (#{old_ver.inspect}) for stacks #{d['cf_stacks'].inspect}"
-      next false if new_ver.nil? || old_ver.nil?
+      
+      # If SemVer parsing fails or produces equal results for what should be different versions
+      # (e.g., 4-part versions like 1.29.2.3 vs 1.29.2.1 both parse as 1.29.2),
+      # fall back to Gem::Version which handles arbitrary version part counts
+      if new_ver.nil? || old_ver.nil? || (new_ver == old_ver && @dep['version'] != d['version'])
+        puts "DEBUG latest?: SemVer failed or equal, using Gem::Version fallback"
+        new_ver_gem = Gem::Version.new(@dep['version'])
+        old_ver_gem = Gem::Version.new(d['version'])
+        is_greater = new_ver_gem > old_ver_gem
+        puts "DEBUG latest?: Gem::Version: #{new_ver_gem} > #{old_ver_gem} = #{is_greater}"
+        next is_greater
+      end
 
       is_greater = new_ver > old_ver
       puts "DEBUG latest?: #{new_ver} > #{old_ver} = #{is_greater}"

--- a/tasks/update-buildpack-dependency/dependencies.rb
+++ b/tasks/update-buildpack-dependency/dependencies.rb
@@ -47,13 +47,20 @@ class Dependencies
   private
 
   def latest?
-    @matching_deps.all? do |d|
+    puts "DEBUG latest?: Checking if #{@dep['version']} (#{@dep['cf_stacks'].inspect}) is latest"
+    puts "DEBUG latest?: @matching_deps: #{@matching_deps.map { |d| [d['version'], d['cf_stacks']] }.inspect}"
+    result = @matching_deps.all? do |d|
       new_ver = SemVer.parse(@dep['version'])
       old_ver = SemVer.parse(d['version'])
+      puts "DEBUG latest?: Comparing #{@dep['version']} (#{new_ver.inspect}) vs #{d['version']} (#{old_ver.inspect}) for stacks #{d['cf_stacks'].inspect}"
       next false if new_ver.nil? || old_ver.nil?
 
-      new_ver > old_ver
+      is_greater = new_ver > old_ver
+      puts "DEBUG latest?: #{new_ver} > #{old_ver} = #{is_greater}"
+      is_greater
     end
+    puts "DEBUG latest?: Result = #{result}"
+    result
   end
 
   # When rebuilding, we don't want to lose supported stacks

--- a/tasks/update-buildpack-dependency/dependencies.rb
+++ b/tasks/update-buildpack-dependency/dependencies.rb
@@ -13,22 +13,15 @@ class Dependencies
   def switch
     # if we're rebuilding, replace matching version
     if @matching_deps.map { |d| d['version'] }.include?(@dep['version'])
-      puts "DEBUG Dependencies.switch: Rebuilding existing version #{@dep['version']}"
       out = (@dependencies.reject { |d| same_dependency_line?(d['cf_stacks'], d['version'], d['name']) && d['version'] == @dep['version'] } + [@dep])
     # adding a new one, but keep everything
     elsif @removal_strategy == 'keep_all'
-      puts "DEBUG Dependencies.switch: Keep all strategy"
       out = @dependencies + [@dep]
     # adding one newer than all existing versions
     elsif latest?
-      puts "DEBUG Dependencies.switch: Latest version, removal_strategy=#{@removal_strategy}"
-      puts "DEBUG Dependencies.switch: @matching_deps count=#{@matching_deps.length}, versions=#{@matching_deps.map { |d| [d['version'], d['cf_stacks']] }.inspect}"
-      puts "DEBUG Dependencies.switch: Adding dep version=#{@dep['version']}, stacks=#{@dep['cf_stacks'].inspect}"
       # keep deps (from latest released buildpack) and add this new one. If removal_strategy is NOT keep_latest_released do not keep any deps from latest released buidpack.
       out = ((@dependencies - @matching_deps) + [@dep] + dependencies_latest_released)
-      puts "DEBUG Dependencies.switch: Result has #{out.select { |d| d['name'] == @dep['name'] && d['version'] == @dep['version'] }.length} entries for #{@dep['name']} #{@dep['version']}"
     else
-      puts "DEBUG Dependencies.switch: Not adding (not latest)"
       # if not newer, don't do anything
       return @dependencies
     end
@@ -47,31 +40,21 @@ class Dependencies
   private
 
   def latest?
-    puts "DEBUG latest?: Checking if #{@dep['version']} (#{@dep['cf_stacks'].inspect}) is latest"
-    puts "DEBUG latest?: @matching_deps: #{@matching_deps.map { |d| [d['version'], d['cf_stacks']] }.inspect}"
-    result = @matching_deps.all? do |d|
+    @matching_deps.all? do |d|
       new_ver = SemVer.parse(@dep['version'])
       old_ver = SemVer.parse(d['version'])
-      puts "DEBUG latest?: Comparing #{@dep['version']} (#{new_ver.inspect}) vs #{d['version']} (#{old_ver.inspect}) for stacks #{d['cf_stacks'].inspect}"
       
       # If SemVer parsing fails or produces equal results for what should be different versions
       # (e.g., 4-part versions like 1.29.2.3 vs 1.29.2.1 both parse as 1.29.2),
       # fall back to Gem::Version which handles arbitrary version part counts
       if new_ver.nil? || old_ver.nil? || (new_ver == old_ver && @dep['version'] != d['version'])
-        puts "DEBUG latest?: SemVer failed or equal, using Gem::Version fallback"
         new_ver_gem = Gem::Version.new(@dep['version'])
         old_ver_gem = Gem::Version.new(d['version'])
-        is_greater = new_ver_gem > old_ver_gem
-        puts "DEBUG latest?: Gem::Version: #{new_ver_gem} > #{old_ver_gem} = #{is_greater}"
-        next is_greater
+        next new_ver_gem > old_ver_gem
       end
 
-      is_greater = new_ver > old_ver
-      puts "DEBUG latest?: #{new_ver} > #{old_ver} = #{is_greater}"
-      is_greater
+      new_ver > old_ver
     end
-    puts "DEBUG latest?: Result = #{result}"
-    result
   end
 
   # When rebuilding, we don't want to lose supported stacks

--- a/tasks/update-buildpack-dependency/dependencies.rb
+++ b/tasks/update-buildpack-dependency/dependencies.rb
@@ -13,15 +13,22 @@ class Dependencies
   def switch
     # if we're rebuilding, replace matching version
     if @matching_deps.map { |d| d['version'] }.include?(@dep['version'])
+      puts "DEBUG Dependencies.switch: Rebuilding existing version #{@dep['version']}"
       out = (@dependencies.reject { |d| same_dependency_line?(d['cf_stacks'], d['version'], d['name']) && d['version'] == @dep['version'] } + [@dep])
     # adding a new one, but keep everything
     elsif @removal_strategy == 'keep_all'
+      puts "DEBUG Dependencies.switch: Keep all strategy"
       out = @dependencies + [@dep]
     # adding one newer than all existing versions
     elsif latest?
+      puts "DEBUG Dependencies.switch: Latest version, removal_strategy=#{@removal_strategy}"
+      puts "DEBUG Dependencies.switch: @matching_deps count=#{@matching_deps.length}, versions=#{@matching_deps.map { |d| [d['version'], d['cf_stacks']] }.inspect}"
+      puts "DEBUG Dependencies.switch: Adding dep version=#{@dep['version']}, stacks=#{@dep['cf_stacks'].inspect}"
       # keep deps (from latest released buildpack) and add this new one. If removal_strategy is NOT keep_latest_released do not keep any deps from latest released buidpack.
       out = ((@dependencies - @matching_deps) + [@dep] + dependencies_latest_released)
+      puts "DEBUG Dependencies.switch: Result has #{out.select { |d| d['name'] == @dep['name'] && d['version'] == @dep['version'] }.length} entries for #{@dep['name']} #{@dep['version']}"
     else
+      puts "DEBUG Dependencies.switch: Not adding (not latest)"
       # if not newer, don't do anything
       return @dependencies
     end

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -52,10 +52,6 @@ version = ''
 
 any_stack_build_exists = Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-any-stack.json"].any?
 
-puts "DEBUG: Looking for JSON files matching pattern: builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"
-matching_files = Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"]
-puts "DEBUG: Found #{matching_files.length} files: #{matching_files.inspect}"
-
 # First pass: collect all stack builds
 Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each do |stack_dependency_build|
   # Skip stack-specific builds when an any-stack build exists - the any-stack build covers all stacks
@@ -139,8 +135,6 @@ if !builds.empty? && version
       source_type => source_url,
       'source_sha256' => source_sha256
     }
-
-    puts "DEBUG: Creating single any-stack dependency with stacks: #{total_stacks.inspect}"
     
     manifest['dependencies'] = Dependencies.new(
       dep,
@@ -165,9 +159,6 @@ if !builds.empty? && version
         source_type => source_url,
         'source_sha256' => source_sha256
       }
-
-      puts "DEBUG: Creating stack-specific dependency for #{stack}: #{dep['uri']}"
-      puts "DEBUG: Before switch, manifest has #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.length} entries for #{manifest_name} #{resource_version}"
       
       manifest['dependencies'] = Dependencies.new(
         dep,
@@ -176,9 +167,6 @@ if !builds.empty? && version
         manifest['dependencies'],
         manifest_latest_released['dependencies']
       ).switch
-      
-      puts "DEBUG: After switch, manifest has #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.length} entries for #{manifest_name} #{resource_version}"
-      puts "DEBUG: Stacks: #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.map { |d| d['cf_stacks'] }.inspect}"
     end
     
     rebuilt += [old_versions.include?(resource_version)]

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -52,6 +52,10 @@ version = ''
 
 any_stack_build_exists = Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-any-stack.json"].any?
 
+puts "DEBUG: Looking for JSON files matching pattern: builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"
+matching_files = Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"]
+puts "DEBUG: Found #{matching_files.length} files: #{matching_files.inspect}"
+
 Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each do |stack_dependency_build|
   # Skip stack-specific builds when an any-stack build exists - the any-stack build covers all stacks
   # and will replace all existing stack-specific entries in one pass

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -56,6 +56,7 @@ puts "DEBUG: Looking for JSON files matching pattern: builds/binary-builds-new/#
 matching_files = Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"]
 puts "DEBUG: Found #{matching_files.length} files: #{matching_files.inspect}"
 
+# First pass: collect all stack builds
 Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each do |stack_dependency_build|
   # Skip stack-specific builds when an any-stack build exists - the any-stack build covers all stacks
   # and will replace all existing stack-specific entries in one pass
@@ -96,11 +97,27 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
   builds[stack] = build
 
   version = builds[stack]['version'] # We assume that the version is the same for all stacks
-  next unless version
+end
 
+# Now process collected builds and create manifest entries
+# For multi-stack builds, we need to create ONE entry with all stacks, not multiple entries
+if !builds.empty? && version
+  # For any-stack builds or when we have multiple stack-specific builds, 
+  # we need to create a single dependency entry with all stacks combined
+  
+  old_versions = manifest['dependencies']
+                 .select { |d| d['name'] == manifest_name }
+                 .map { |d| d['version'] }
+
+  # Determine which stack's build to use for metadata
+  # For any-stack builds, use the any-stack build
+  # For multi-stack builds, use the first stack's build (they should have same source)
+  representative_stack = builds.keys.include?('any-stack') ? 'any-stack' : builds.keys.first
+  representative_build = builds[representative_stack]
+  
   source_type = 'source'
-  source_url = builds[stack]['source']['url']
-  source_sha256 = builds[stack]['source'].fetch('sha256', nil).to_s
+  source_url = representative_build['source']['url']
+  source_sha256 = representative_build['source'].fetch('sha256', nil).to_s
 
   if source_name == 'appdynamics'
     source_type = 'osl'
@@ -109,27 +126,59 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
     source_url = "https://github.com/conda/conda/archive/#{version}.tar.gz"
   end
 
-  dep = {
-    'name' => manifest_name,
-    'version' => resource_version,
-    'uri' => build['url'],
-    'sha256' => build['sha256'],
-    'cf_stacks' => stacks,
-    source_type => source_url,
-    'source_sha256' => source_sha256
-  }
+  # For any-stack builds, create one entry with the any-stack URL
+  # For multi-stack builds, we need to create separate entries per stack (each with its own URL)
+  if any_stack_build_exists
+    # Single entry with any-stack URL covering all stacks
+    dep = {
+      'name' => manifest_name,
+      'version' => resource_version,
+      'uri' => representative_build['url'],
+      'sha256' => representative_build['sha256'],
+      'cf_stacks' => total_stacks.sort,
+      source_type => source_url,
+      'source_sha256' => source_sha256
+    }
 
-  old_versions = manifest['dependencies']
-                 .select { |d| d['name'] == manifest_name }
-                 .map { |d| d['version'] }
+    puts "DEBUG: Creating single any-stack dependency with stacks: #{total_stacks.inspect}"
+    
+    manifest['dependencies'] = Dependencies.new(
+      dep,
+      version_line_type,
+      removal_strategy,
+      manifest['dependencies'],
+      manifest_latest_released['dependencies']
+    ).switch
 
-  manifest['dependencies'] = Dependencies.new(
-    dep,
-    version_line_type,
-    removal_strategy,
-    manifest['dependencies'],
-    manifest_latest_released['dependencies']
-  ).switch
+    rebuilt += [old_versions.include?(resource_version)]
+  else
+    # Multi-stack build: create separate entries for each stack (each with stack-specific URL)
+    builds.each do |stack, build|
+      stacks = [stack]
+      
+      dep = {
+        'name' => manifest_name,
+        'version' => resource_version,
+        'uri' => build['url'],
+        'sha256' => build['sha256'],
+        'cf_stacks' => stacks,
+        source_type => source_url,
+        'source_sha256' => source_sha256
+      }
+
+      puts "DEBUG: Creating stack-specific dependency for #{stack}: #{dep['uri']}"
+      
+      manifest['dependencies'] = Dependencies.new(
+        dep,
+        version_line_type,
+        removal_strategy,
+        manifest['dependencies'],
+        manifest_latest_released['dependencies']
+      ).switch
+    end
+    
+    rebuilt += [old_versions.include?(resource_version)]
+  end
 
   new_versions = manifest['dependencies']
                  .select { |d| d['name'] == manifest_name }
@@ -137,7 +186,6 @@ Dir["builds/binary-builds-new/#{source_name}/#{resource_version}-*.json"].each d
 
   added += (new_versions - old_versions).uniq.sort
   removed += (old_versions - new_versions).uniq.sort
-  rebuilt += [old_versions.include?(resource_version)]
 end
 
 if rebuilt.empty?

--- a/tasks/update-buildpack-dependency/run.rb
+++ b/tasks/update-buildpack-dependency/run.rb
@@ -167,6 +167,7 @@ if !builds.empty? && version
       }
 
       puts "DEBUG: Creating stack-specific dependency for #{stack}: #{dep['uri']}"
+      puts "DEBUG: Before switch, manifest has #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.length} entries for #{manifest_name} #{resource_version}"
       
       manifest['dependencies'] = Dependencies.new(
         dep,
@@ -175,6 +176,9 @@ if !builds.empty? && version
         manifest['dependencies'],
         manifest_latest_released['dependencies']
       ).switch
+      
+      puts "DEBUG: After switch, manifest has #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.length} entries for #{manifest_name} #{resource_version}"
+      puts "DEBUG: Stacks: #{manifest['dependencies'].select { |d| d['name'] == manifest_name && d['version'] == resource_version }.map { |d| d['cf_stacks'] }.inspect}"
     end
     
     rebuilt += [old_versions.include?(resource_version)]


### PR DESCRIPTION
## Problem

The `remove_old_blobs()` function in the cf-release pipeline was removing ALL buildpack blobs, including those for stacks not being updated. This caused issues for multi-stack buildpacks like binary-buildpack.

**Specific issue:** When updating only the Linux stack (cflinuxfs4) for binary-buildpack, the Windows blob was also removed. This caused BOSH release creation to fail because the `binary-buildpack-windows` package dependency couldn't find its blob.

Error from build: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/buildpacks-team/pipelines/cf-release/jobs/create-binary-buildpack-dev-release/builds/3

```
Building a release from directory '/tmp/build/67b60727/release':
  - Constructing packages from directory:
      - Reading package from '/tmp/build/67b60727/release/packages/binary-buildpack-windows':
          Collecting package files:
            Missing files for pattern 'binary-buildpack/binary?buildpack-windows-v*.zip'
```

## Solution

Modified `remove_old_blobs()` to only remove blobs for stacks that have corresponding input files in `buildpack-*/*.zip`.

**How it works:**
1. Iterates through buildpack input files (e.g., `buildpack-cflinuxfs4/*.zip`)
2. For each input file, determines the stack name pattern
3. Only removes existing blobs that match that stack pattern
4. Preserves blobs for stacks not being updated (e.g., Windows)

## Impact

- **binary-buildpack:** Can now update Linux stacks while preserving Windows blobs
- **Other buildpacks:** No behavior change (they typically have single stacks)
- **Backward compatible:** Doesn't break existing pipelines

## Testing

After this fix, the binary-buildpack cf-release job should:
- ✅ Remove old cflinuxfs4 blob
- ✅ Add new cflinuxfs4 blob  
- ✅ Preserve existing Windows blob
- ✅ Successfully create BOSH release with both packages

Related to #626