### PR TITLE
Revert: Add binary-buildpack to cf-release pipeline (Linux only)

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -3,8 +3,6 @@
 #@ default_stacks = ['cflinuxfs4']
 
 supported_languages:
-- name: binary
-  stacks: #@ default_stacks
 - name: dotnet-core
   stacks: #@ default_stacks
 - name: go


### PR DESCRIPTION
This reverts commit a8102ea095832160a813980dd3563f3f4a91317a (PR #626).

## Reason for Revert

The addition of binary-buildpack to the cf-release pipeline causes BOSH release creation failures because:

1. The pipeline only builds Linux stacks (cflinuxfs4)
2. The binary-buildpack BOSH release job depends on BOTH `binary-buildpack-cflinuxfs4` AND `binary-buildpack-windows` packages
3. The `remove_old_blobs()` function removes all buildpack blobs (including Windows)
4. Only Linux blobs are re-added
5. BOSH release creation fails with: `Missing files for pattern 'binary-buildpack/binary?buildpack-windows-v*.zip'`

## Path Forward

Before re-adding binary-buildpack to the cf-release pipeline, we need to:

1. Either merge PR #627 which fixes the blob removal logic to be stack-aware
2. Or find an alternative solution that allows multi-stack buildpacks to work with Linux-only pipeline configurations

## Related

- Original PR: #626
- Failed build: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/buildpacks-team/pipelines/cf-release/jobs/create-binary-buildpack-dev-release/builds/3
- Proposed fix: #627