### PR TITLE
Add client-certificate-mapper dependency for java bp

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -35,6 +35,18 @@ dependencies:
     source_type: rubygems
     any_stack: true
     versions_to_keep: 2
+  client-certificate-mapper:
+    buildpacks:
+      java:
+        lines:
+          - line: 2.X.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: org.cloudfoundry'
+      - 'artifact_id: client-certificate-mapper'
+    any_stack: true
+    versions_to_keep: 1
   java-cfenv:
     buildpacks:
       java:
@@ -511,3 +523,4 @@ skip_deprecation_check:
   - zulu  #! JRE versions tied to Azul release schedule
   - sapmachine  #! JRE versions tied to SAP release schedule
   - appdynamics-java  #! doesn't publish EOL schedule
+  - client-certificate-mapper  #! doesn't publish EOL schedule


### PR DESCRIPTION
Add one of the remaining dependencies `client-certificate-mapper` for the java buildpack, more info on still not covered dependencies [here](https://github.com/cloudfoundry/buildpacks-ci/blob/master/docs/missing-java-dependencies-analysis.md). The dependency does not have any specifics with regard to cflinuxfs4/5 , should be added for both.
- It is using [maven](https://github.com/cloudfoundry/buildpacks-ci/blob/master/dockerfiles/depwatcher-go/pkg/watchers/maven.go) dependency watcher, so no new watchers added.
- wondering whether `tasks\build-binary-new-cflinuxfs[4/5]/builder.rb` should also be adjusted? As far as I saw the `java-cfenv` dependency using `maven` watcher is also not added