### PR TITLE
Add otel agent dependency for java buildpack

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -431,6 +431,17 @@ dependencies:
     source_type: skywalking
     any_stack: true
     versions_to_keep: 2
+  open-telemetry-javaagent:
+    buildpacks:
+      java:
+        lines:
+          - line: 2.X.X
+    source_type: github_releases
+    source_params:
+      - 'repo: open-telemetry/opentelemetry-java-instrumentation'
+      - 'glob: opentelemetry-javaagent.jar'
+    any_stack: true
+    versions_to_keep: 1
   jprofiler-profiler:
     buildpacks:
       java:
@@ -517,6 +528,7 @@ skip_deprecation_check:
   - r  #! doesn't publish EOL schedule
   - tomcat  #! doesn't publish EOL schedule
   - skywalking-agent  #! doesn't publish EOL schedule
+  - open-telemetry-javaagent  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -441,7 +441,7 @@ dependencies:
       - 'repo: open-telemetry/opentelemetry-java-instrumentation'
       - 'glob: opentelemetry-javaagent.jar'
     any_stack: true
-    versions_to_keep: 1
+    versions_to_keep: 2
   jprofiler-profiler:
     buildpacks:
       java:


### PR DESCRIPTION
Add one of the remaining dependencies `opentelemetry-javaagent` for the java buildpack, more info on still not covered dependencies [here](https://github.com/cloudfoundry/buildpacks-ci/blob/master/docs/missing-java-dependencies-analysis.md). The dependency does not have any specifics with regard to cflinuxfs4/5 , should be added for both.

It is using [github_releases](https://github.com/cloudfoundry/buildpacks-ci/blob/master/dockerfiles/depwatcher-go/pkg/watchers/github_releases.go) dependency watcher, so no new watcher added with respect to it.

There are newer version of this lib already so once the pipeline is updated we'll be able to test PR version bump creation.