### PR TITLE
Add azure-application-insights and splunk-otel-javaagent for java buildpack

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -442,6 +442,28 @@ dependencies:
       - 'glob: opentelemetry-javaagent.jar'
     any_stack: true
     versions_to_keep: 2
+  azure-application-insights:
+    buildpacks:
+      java:
+        lines:
+          - line: 3.X.X
+    source_type: github_releases
+    source_params:
+      - 'repo: microsoft/ApplicationInsights-Java'
+      - 'glob: applicationinsights-agent-*.jar'
+    any_stack: true
+    versions_to_keep: 2
+  splunk-otel-javaagent:
+    buildpacks:
+      java:
+        lines:
+          - line: 2.X.X
+    source_type: github_releases
+    source_params:
+      - 'repo: signalfx/splunk-otel-java'
+      - 'glob: splunk-otel-javaagent.jar'
+    any_stack: true
+    versions_to_keep: 2
   jprofiler-profiler:
     buildpacks:
       java:
@@ -529,6 +551,8 @@ skip_deprecation_check:
   - tomcat  #! doesn't publish EOL schedule
   - skywalking-agent  #! doesn't publish EOL schedule
   - open-telemetry-javaagent  #! doesn't publish EOL schedule
+  - azure-application-insights  #! doesn't publish EOL schedule
+  - splunk-otel-javaagent  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule


### PR DESCRIPTION
Add the rest of the remaining dependencies of source type `github_releases` for the java buildpack, more info on still not covered dependencies [here](https://github.com/cloudfoundry/buildpacks-ci/blob/master/docs/missing-java-dependencies-analysis.md). There are a couple of more with regard to java-memory-assistant which is no longer maintained and the repo is archived, so not adding it currently. The dependencies do not have any specifics with regard to cflinuxfs4/5 , should be added for both. The `azure-application-insights` and `splunk-otel-javaagent` along with the already added `opentelemetry_javaagent` are the most actively maintained github releases from the java buildpack list of dependencies as mentioned [here](https://github.com/cloudfoundry/buildpacks-ci/blob/master/docs/missing-java-dependencies-analysis.md#-active-github-releases-3-dependencies---high-priority)

These dependencies are using [github_releases](https://github.com/cloudfoundry/buildpacks-ci/blob/master/dockerfiles/depwatcher-go/pkg/watchers/github_releases.go) dependency watcher, so no new watcher added with respect to it.
