### PR TITLE
Add more maven watcher dependencies

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -510,6 +510,7 @@ dependencies:
       - 'uri: https://repo1.maven.org/maven2'
       - 'group_id: org.jacoco'
       - 'artifact_id: jacoco'
+      - 'packaging: zip'
     any_stack: true
     versions_to_keep: 2  
   jprofiler-profiler:

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -464,6 +464,54 @@ dependencies:
       - 'glob: splunk-otel-javaagent.jar'
     any_stack: true
     versions_to_keep: 2
+  elastic-apm-agent:
+    buildpacks:
+      java:
+        lines:
+          - line: 1.X.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: co.elastic.apm'
+      - 'artifact_id: elastic-apm-agent'
+    any_stack: true
+    versions_to_keep: 2
+  postgresql-jdbc:
+    buildpacks:
+      java:
+        lines:
+          - line: 42.X.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: org.postgresql'
+      - 'artifact_id: postgresql'
+    any_stack: true
+    versions_to_keep: 2
+  mariadb-jdbc:
+    buildpacks:
+      java:
+        lines:
+          - line: 3.X.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: org.mariadb.jdbc'
+      - 'artifact_id: mariadb-java-client'
+    any_stack: true
+    versions_to_keep: 2
+  jacoco:
+    buildpacks:
+      java:
+        lines:
+          - line: 0.8.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: org.jacoco'
+      - 'artifact_id: jacoco'
+    any_stack: true
+    versions_to_keep: 2  
   jprofiler-profiler:
     buildpacks:
       java:
@@ -553,6 +601,10 @@ skip_deprecation_check:
   - open-telemetry-javaagent  #! doesn't publish EOL schedule
   - azure-application-insights  #! doesn't publish EOL schedule
   - splunk-otel-javaagent  #! doesn't publish EOL schedule
+  - elastic-apm-agent  #! doesn't publish EOL schedule
+  - postgresql-jdbc  #! doesn't publish EOL schedule
+  - mariadb-jdbc  #! doesn't publish EOL schedule
+  - jacoco  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule


### PR DESCRIPTION
Add more java buildpack dependencies to the dependency-builds pipeline. They use the `maven` watcher already available
- `elastic-apm-agent` - no stack specifics, relevant to both cflinuxfs4/5
- `postgresql-jdbc` - no stack specifics, relevant to both cflinuxfs4/5
- `mariadb-jdbc` - no stack specifics, relevant to both cflinuxfs4/5
- `jacoco` - no stack specifics, relevant to both cflinuxfs4/5
List of dependencies relevant to the maven watcher can be found [here](https://github.com/cloudfoundry/buildpacks-ci/blob/master/docs/missing-java-dependencies-analysis.md#-active-maven-central-12-dependencies---high-priority). 