### PR TITLE
Add java bp dependencies and custom watchers

### DIFF
--- a/dockerfiles/depwatcher-go/internal/factory/factory.go
+++ b/dockerfiles/depwatcher-go/internal/factory/factory.go
@@ -324,6 +324,10 @@ func CheckWithClient(source Source, currentVersion *base.Internal, client base.H
 		watcher := watchers.NewSkyWalkingWatcher(client)
 		versions, err = watcher.Check()
 
+	case "newrelic_agent":
+		watcher := watchers.NewNewRelicAgentWatcher(client)
+		versions, err = watcher.Check()
+
 	default:
 		return nil, fmt.Errorf("unknown type: %s", source.Type)
 	}
@@ -575,6 +579,10 @@ func InWithClient(source Source, version base.Internal, client base.HTTPClient) 
 
 	case "skywalking":
 		watcher := watchers.NewSkyWalkingWatcher(client)
+		return watcher.In(version.Ref)
+
+	case "newrelic_agent":
+		watcher := watchers.NewNewRelicAgentWatcher(client)
 		return watcher.In(version.Ref)
 
 	default:

--- a/dockerfiles/depwatcher-go/internal/factory/factory.go
+++ b/dockerfiles/depwatcher-go/internal/factory/factory.go
@@ -332,6 +332,10 @@ func CheckWithClient(source Source, currentVersion *base.Internal, client base.H
 		watcher := watchers.NewStackdriverProfilerWatcher(client)
 		versions, err = watcher.Check()
 
+	case "groovy":
+		watcher := watchers.NewGroovyWatcher(client)
+		versions, err = watcher.Check()
+
 	default:
 		return nil, fmt.Errorf("unknown type: %s", source.Type)
 	}
@@ -591,6 +595,10 @@ func InWithClient(source Source, version base.Internal, client base.HTTPClient) 
 
 	case "stackdriver_profiler":
 		watcher := watchers.NewStackdriverProfilerWatcher(client)
+		return watcher.In(version.Ref)
+
+	case "groovy":
+		watcher := watchers.NewGroovyWatcher(client)
 		return watcher.In(version.Ref)
 
 	default:

--- a/dockerfiles/depwatcher-go/internal/factory/factory.go
+++ b/dockerfiles/depwatcher-go/internal/factory/factory.go
@@ -328,6 +328,10 @@ func CheckWithClient(source Source, currentVersion *base.Internal, client base.H
 		watcher := watchers.NewNewRelicAgentWatcher(client)
 		versions, err = watcher.Check()
 
+	case "stackdriver_profiler":
+		watcher := watchers.NewStackdriverProfilerWatcher(client)
+		versions, err = watcher.Check()
+
 	default:
 		return nil, fmt.Errorf("unknown type: %s", source.Type)
 	}
@@ -583,6 +587,10 @@ func InWithClient(source Source, version base.Internal, client base.HTTPClient) 
 
 	case "newrelic_agent":
 		watcher := watchers.NewNewRelicAgentWatcher(client)
+		return watcher.In(version.Ref)
+
+	case "stackdriver_profiler":
+		watcher := watchers.NewStackdriverProfilerWatcher(client)
 		return watcher.In(version.Ref)
 
 	default:

--- a/dockerfiles/depwatcher-go/pkg/watchers/groovy.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/groovy.go
@@ -1,0 +1,99 @@
+package watchers
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/base"
+)
+
+const groovyStorageBase = "https://groovy.jfrog.io/artifactory/api/storage/dist-release-local/groovy-zips"
+const groovyDownloadBase = "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips"
+
+type groovyChild struct {
+	URI    string `json:"uri"`
+	Folder bool   `json:"folder"`
+}
+
+type groovyDirResponse struct {
+	Children []groovyChild `json:"children"`
+}
+
+type groovyFileResponse struct {
+	Checksums struct {
+		SHA256 string `json:"sha256"`
+	} `json:"checksums"`
+	DownloadURI string `json:"downloadUri"`
+}
+
+type GroovyWatcher struct {
+	client base.HTTPClient
+}
+
+func NewGroovyWatcher(client base.HTTPClient) *GroovyWatcher {
+	return &GroovyWatcher{client: client}
+}
+
+// stable release: apache-groovy-binary-X.Y.Z.zip (no alpha/beta/rc suffix)
+var groovyVersionPattern = regexp.MustCompile(`^/apache-groovy-binary-(\d+\.\d+\.\d+)\.zip$`)
+
+func (w *GroovyWatcher) Check() ([]base.Internal, error) {
+	resp, err := w.client.Get(groovyStorageBase + "/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Groovy file list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var dir groovyDirResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dir); err != nil {
+		return nil, fmt.Errorf("failed to parse Groovy file list: %w", err)
+	}
+
+	var versions []base.Internal
+	for _, child := range dir.Children {
+		if child.Folder {
+			continue
+		}
+		if m := groovyVersionPattern.FindStringSubmatch(child.URI); m != nil {
+			versions = append(versions, base.Internal{Ref: m[1]})
+		}
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no Groovy versions found in file list")
+	}
+
+	versions = base.SortVersions(versions)
+
+	if len(versions) > 10 {
+		versions = versions[len(versions)-10:]
+	}
+
+	return versions, nil
+}
+
+func (w *GroovyWatcher) In(ref string) (base.Release, error) {
+	metaURL := fmt.Sprintf("%s/apache-groovy-binary-%s.zip", groovyStorageBase, ref)
+
+	resp, err := w.client.Get(metaURL)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to fetch Groovy metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var meta groovyFileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return base.Release{}, fmt.Errorf("failed to parse Groovy metadata: %w", err)
+	}
+
+	if meta.Checksums.SHA256 == "" {
+		return base.Release{}, fmt.Errorf("no SHA256 found in Groovy metadata for %s", ref)
+	}
+
+	return base.Release{
+		Ref:    ref,
+		URL:    fmt.Sprintf("%s/apache-groovy-binary-%s.zip", groovyDownloadBase, ref),
+		SHA256: meta.Checksums.SHA256,
+	}, nil
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/groovy_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/groovy_test.go
@@ -1,0 +1,168 @@
+package watchers_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/watchers"
+)
+
+type mockGroovyClient struct {
+	responses map[string]mockResponse
+}
+
+func (m *mockGroovyClient) Get(url string) (*http.Response, error) {
+	resp, exists := m.responses[url]
+	if !exists {
+		return nil, fmt.Errorf("unexpected URL: %s", url)
+	}
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+	}, nil
+}
+
+func (m *mockGroovyClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *mockGroovyClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+const groovyDirURL = "https://groovy.jfrog.io/artifactory/api/storage/dist-release-local/groovy-zips/"
+const groovyMetaBase = "https://groovy.jfrog.io/artifactory/api/storage/dist-release-local/groovy-zips"
+const groovyDlBase = "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips"
+
+var _ = Describe("GroovyWatcher", func() {
+	var (
+		client  *mockGroovyClient
+		watcher *watchers.GroovyWatcher
+	)
+
+	BeforeEach(func() {
+		client = &mockGroovyClient{responses: make(map[string]mockResponse)}
+		watcher = watchers.NewGroovyWatcher(client)
+	})
+
+	Describe("Check", func() {
+		Context("when the Artifactory listing returns files", func() {
+			It("returns sorted stable versions, excluding pre-releases and .asc files", func() {
+				dirJSON := `{"children": [
+					{"uri": "/apache-groovy-binary-4.0.29.zip", "folder": false},
+					{"uri": "/apache-groovy-binary-4.0.29.zip.asc", "folder": false},
+					{"uri": "/apache-groovy-binary-4.0.30.zip", "folder": false},
+					{"uri": "/apache-groovy-binary-4.0.0-alpha-1.zip", "folder": false},
+					{"uri": "/apache-groovy-binary-4.0.0-beta-1.zip", "folder": false},
+					{"uri": "/apache-groovy-binary-4.0.0-rc-1.zip", "folder": false}
+				]}`
+
+				client.responses[groovyDirURL] = mockResponse{body: dirJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(2))
+				Expect(versions[0].Ref).To(Equal("4.0.29"))
+				Expect(versions[1].Ref).To(Equal("4.0.30"))
+			})
+
+			It("skips folder entries", func() {
+				dirJSON := `{"children": [
+					{"uri": "/some-folder", "folder": true},
+					{"uri": "/apache-groovy-binary-4.0.32.zip", "folder": false}
+				]}`
+
+				client.responses[groovyDirURL] = mockResponse{body: dirJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("4.0.32"))
+			})
+		})
+
+		Context("when there are more than 10 versions", func() {
+			It("returns only the 10 most recent", func() {
+				var children []string
+				for i := 1; i <= 12; i++ {
+					children = append(children, fmt.Sprintf(`{"uri": "/apache-groovy-binary-4.0.%d.zip", "folder": false}`, i))
+				}
+				dirJSON := fmt.Sprintf(`{"children": [%s]}`, strings.Join(children, ","))
+
+				client.responses[groovyDirURL] = mockResponse{body: dirJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(10))
+				Expect(versions[0].Ref).To(Equal("4.0.3"))
+				Expect(versions[9].Ref).To(Equal("4.0.12"))
+			})
+		})
+
+		Context("when no stable versions are found", func() {
+			It("returns an error", func() {
+				dirJSON := `{"children": [
+					{"uri": "/apache-groovy-binary-4.0.0-alpha-1.zip", "folder": false}
+				]}`
+
+				client.responses[groovyDirURL] = mockResponse{body: dirJSON, status: 200}
+
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no Groovy versions found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch Groovy file list"))
+			})
+		})
+	})
+
+	Describe("In", func() {
+		Context("when fetching a specific version", func() {
+			It("returns the release with download URL and SHA256 from Artifactory metadata", func() {
+				metaJSON := `{
+					"checksums": {"sha256": "f03e8838b56c202d8c864d462f6117d3512fdb6d1db9afcd47dfd1af81683f50"},
+					"downloadUri": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.32.zip"
+				}`
+
+				client.responses[groovyMetaBase+"/apache-groovy-binary-4.0.32.zip"] = mockResponse{body: metaJSON, status: 200}
+
+				release, err := watcher.In("4.0.32")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("4.0.32"))
+				Expect(release.URL).To(Equal(groovyDlBase + "/apache-groovy-binary-4.0.32.zip"))
+				Expect(release.SHA256).To(Equal("f03e8838b56c202d8c864d462f6117d3512fdb6d1db9afcd47dfd1af81683f50"))
+			})
+		})
+
+		Context("when metadata has no SHA256", func() {
+			It("returns an error", func() {
+				metaJSON := `{"checksums": {}}`
+
+				client.responses[groovyMetaBase+"/apache-groovy-binary-4.0.32.zip"] = mockResponse{body: metaJSON, status: 200}
+
+				_, err := watcher.In("4.0.32")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no SHA256 found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.In("4.0.32")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch Groovy metadata"))
+			})
+		})
+	})
+})

--- a/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent.go
@@ -1,0 +1,74 @@
+package watchers
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/base"
+)
+
+const newrelicIndexURL = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/"
+
+type NewRelicAgentWatcher struct {
+	client base.HTTPClient
+}
+
+func NewNewRelicAgentWatcher(client base.HTTPClient) *NewRelicAgentWatcher {
+	return &NewRelicAgentWatcher{client: client}
+}
+
+func (w *NewRelicAgentWatcher) Check() ([]base.Internal, error) {
+	resp, err := w.client.Get(newrelicIndexURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch New Relic agent index: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read New Relic agent index: %w", err)
+	}
+
+	// Apache directory listing links look like: href="8.25.1/"
+	pattern := regexp.MustCompile(`href="(\d+\.\d+\.\d+)/"`)
+	var versions []base.Internal
+
+	for _, match := range pattern.FindAllSubmatch(body, -1) {
+		versions = append(versions, base.Internal{Ref: string(match[1])})
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no New Relic Java agent versions found in index")
+	}
+
+	versions = base.SortVersions(versions)
+
+	if len(versions) > 10 {
+		versions = versions[len(versions)-10:]
+	}
+
+	return versions, nil
+}
+
+func (w *NewRelicAgentWatcher) In(ref string) (base.Release, error) {
+	url := fmt.Sprintf("%s%s/newrelic-agent-%s.jar", newrelicIndexURL, ref, ref)
+
+	resp, err := w.client.Get(url)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to download New Relic agent: %w", err)
+	}
+	defer resp.Body.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, resp.Body); err != nil {
+		return base.Release{}, fmt.Errorf("failed to compute SHA256: %w", err)
+	}
+
+	return base.Release{
+		Ref:    ref,
+		URL:    url,
+		SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+	}, nil
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent_test.go
@@ -1,0 +1,146 @@
+package watchers_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/watchers"
+)
+
+type mockNewRelicAgentClient struct {
+	responses map[string]mockResponse
+}
+
+func (m *mockNewRelicAgentClient) Get(url string) (*http.Response, error) {
+	resp, exists := m.responses[url]
+	if !exists {
+		return nil, fmt.Errorf("unexpected URL: %s", url)
+	}
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+	}, nil
+}
+
+func (m *mockNewRelicAgentClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *mockNewRelicAgentClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+const indexURL = "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/"
+
+var _ = Describe("NewRelicAgentWatcher", func() {
+	var (
+		client  *mockNewRelicAgentClient
+		watcher *watchers.NewRelicAgentWatcher
+	)
+
+	BeforeEach(func() {
+		client = &mockNewRelicAgentClient{responses: make(map[string]mockResponse)}
+		watcher = watchers.NewNewRelicAgentWatcher(client)
+	})
+
+	Describe("Check", func() {
+		Context("when the index page lists versions", func() {
+			It("returns sorted versions", func() {
+				indexHTML := `<html><body>
+<a href="9.1.0/">9.1.0/</a>
+<a href="9.2.0/">9.2.0/</a>
+<a href="8.25.1/">8.25.1/</a>
+<a href="current">current</a>
+</body></html>`
+
+				client.responses[indexURL] = mockResponse{body: indexHTML, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(3))
+				Expect(versions[0].Ref).To(Equal("8.25.1"))
+				Expect(versions[1].Ref).To(Equal("9.1.0"))
+				Expect(versions[2].Ref).To(Equal("9.2.0"))
+			})
+
+			It("skips non-version links", func() {
+				indexHTML := `<html><body>
+<a href="..">Parent</a>
+<a href="current">current</a>
+<a href="9.2.0/">9.2.0/</a>
+</body></html>`
+
+				client.responses[indexURL] = mockResponse{body: indexHTML, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("9.2.0"))
+			})
+		})
+
+		Context("when the index contains more than 10 versions", func() {
+			It("returns only the last 10 versions", func() {
+				var links strings.Builder
+				for i := 1; i <= 12; i++ {
+					links.WriteString(fmt.Sprintf(`<a href="9.%d.0/">9.%d.0/</a>`, i, i))
+				}
+				indexHTML := fmt.Sprintf("<html><body>%s</body></html>", links.String())
+
+				client.responses[indexURL] = mockResponse{body: indexHTML, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(10))
+				Expect(versions[0].Ref).To(Equal("9.3.0"))
+				Expect(versions[9].Ref).To(Equal("9.12.0"))
+			})
+		})
+
+		Context("when no versions are found", func() {
+			It("returns an error", func() {
+				client.responses[indexURL] = mockResponse{body: "<html><body></body></html>", status: 200}
+
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no New Relic Java agent versions found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch New Relic agent index"))
+			})
+		})
+	})
+
+	Describe("In", func() {
+		Context("when fetching a specific version", func() {
+			It("returns the release with URL and computed SHA256", func() {
+				jarURL := indexURL + "9.2.0/newrelic-agent-9.2.0.jar"
+				client.responses[jarURL] = mockResponse{body: "hello", status: 200}
+
+				release, err := watcher.In("9.2.0")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("9.2.0"))
+				Expect(release.URL).To(Equal(jarURL))
+				Expect(release.SHA256).To(Equal("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"))
+			})
+		})
+
+		Context("when the download fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.In("9.2.0")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to download New Relic agent"))
+			})
+		})
+	})
+})

--- a/dockerfiles/depwatcher-go/pkg/watchers/stackdriver_profiler.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/stackdriver_profiler.go
@@ -1,0 +1,95 @@
+package watchers
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/base"
+)
+
+const stackdriverProfilerBucket = "https://storage.googleapis.com/storage/v1/b/cloud-profiler/o"
+const stackdriverProfilerDownloadBase = "https://storage.googleapis.com/cloud-profiler/java/"
+
+type gcsObjectsResponse struct {
+	Items []gcsObject `json:"items"`
+}
+
+type gcsObject struct {
+	Name string `json:"name"`
+}
+
+type StackdriverProfilerWatcher struct {
+	client base.HTTPClient
+}
+
+func NewStackdriverProfilerWatcher(client base.HTTPClient) *StackdriverProfilerWatcher {
+	return &StackdriverProfilerWatcher{client: client}
+}
+
+func (w *StackdriverProfilerWatcher) Check() ([]base.Internal, error) {
+	url := stackdriverProfilerBucket + "?prefix=java%2Fcloud-profiler-java-agent_&maxResults=1000"
+
+	resp, err := w.client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Cloud Profiler agent list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result gcsObjectsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse Cloud Profiler agent list: %w", err)
+	}
+
+	// Match non-alpine tarballs: cloud-profiler-java-agent_YYYYMMDD_RCNN.tar.gz
+	pattern := regexp.MustCompile(`java/cloud-profiler-java-agent_(\d{8}_RC\d+)\.tar\.gz$`)
+	var versions []string
+
+	for _, item := range result.Items {
+		if m := pattern.FindStringSubmatch(item.Name); m != nil {
+			versions = append(versions, m[1])
+		}
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no Cloud Profiler Java agent versions found")
+	}
+
+	// YYYYMMDD_RCNN sorts correctly lexicographically
+	sort.Strings(versions)
+
+	if len(versions) > 10 {
+		versions = versions[len(versions)-10:]
+	}
+
+	result2 := make([]base.Internal, len(versions))
+	for i, v := range versions {
+		result2[i] = base.Internal{Ref: v}
+	}
+
+	return result2, nil
+}
+
+func (w *StackdriverProfilerWatcher) In(ref string) (base.Release, error) {
+	url := fmt.Sprintf("%scloud-profiler-java-agent_%s.tar.gz", stackdriverProfilerDownloadBase, ref)
+
+	resp, err := w.client.Get(url)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to download Cloud Profiler agent: %w", err)
+	}
+	defer resp.Body.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, resp.Body); err != nil {
+		return base.Release{}, fmt.Errorf("failed to compute SHA256: %w", err)
+	}
+
+	return base.Release{
+		Ref:    ref,
+		URL:    url,
+		SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+	}, nil
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/stackdriver_profiler_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/stackdriver_profiler_test.go
@@ -1,0 +1,147 @@
+package watchers_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/watchers"
+)
+
+type mockStackdriverProfilerClient struct {
+	responses map[string]mockResponse
+}
+
+func (m *mockStackdriverProfilerClient) Get(url string) (*http.Response, error) {
+	resp, exists := m.responses[url]
+	if !exists {
+		return nil, fmt.Errorf("unexpected URL: %s", url)
+	}
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+	}, nil
+}
+
+func (m *mockStackdriverProfilerClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *mockStackdriverProfilerClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+const gcsListURL = "https://storage.googleapis.com/storage/v1/b/cloud-profiler/o?prefix=java%2Fcloud-profiler-java-agent_&maxResults=1000"
+const profilerDownloadBase = "https://storage.googleapis.com/cloud-profiler/java/"
+
+var _ = Describe("StackdriverProfilerWatcher", func() {
+	var (
+		client  *mockStackdriverProfilerClient
+		watcher *watchers.StackdriverProfilerWatcher
+	)
+
+	BeforeEach(func() {
+		client = &mockStackdriverProfilerClient{responses: make(map[string]mockResponse)}
+		watcher = watchers.NewStackdriverProfilerWatcher(client)
+	})
+
+	Describe("Check", func() {
+		Context("when the GCS API returns objects", func() {
+			It("returns sorted non-alpine versions", func() {
+				gcsJSON := `{"items": [
+					{"name": "java/cloud-profiler-java-agent_20240205_RC00.tar.gz"},
+					{"name": "java/cloud-profiler-java-agent_20241028_RC00.tar.gz"},
+					{"name": "java/cloud-profiler-java-agent_20240215_RC00.tar.gz"},
+					{"name": "java/cloud-profiler-java-agent_20241028_RC00_alpine.tar.gz"},
+					{"name": "java/latest/profiler_java_agent.tar.gz"}
+				]}`
+
+				client.responses[gcsListURL] = mockResponse{body: gcsJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(3))
+				Expect(versions[0].Ref).To(Equal("20240205_RC00"))
+				Expect(versions[1].Ref).To(Equal("20240215_RC00"))
+				Expect(versions[2].Ref).To(Equal("20241028_RC00"))
+			})
+
+			It("excludes alpine variants", func() {
+				gcsJSON := `{"items": [
+					{"name": "java/cloud-profiler-java-agent_20241028_RC00.tar.gz"},
+					{"name": "java/cloud-profiler-java-agent_20241028_RC00_alpine.tar.gz"}
+				]}`
+
+				client.responses[gcsListURL] = mockResponse{body: gcsJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("20241028_RC00"))
+			})
+		})
+
+		Context("when there are more than 10 versions", func() {
+			It("returns only the 10 most recent", func() {
+				var items []string
+				for i := 1; i <= 12; i++ {
+					items = append(items, fmt.Sprintf(`{"name": "java/cloud-profiler-java-agent_202401%02d_RC00.tar.gz"}`, i))
+				}
+				gcsJSON := fmt.Sprintf(`{"items": [%s]}`, strings.Join(items, ","))
+
+				client.responses[gcsListURL] = mockResponse{body: gcsJSON, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(10))
+				Expect(versions[0].Ref).To(Equal("20240103_RC00"))
+				Expect(versions[9].Ref).To(Equal("20240112_RC00"))
+			})
+		})
+
+		Context("when no versions are found", func() {
+			It("returns an error", func() {
+				client.responses[gcsListURL] = mockResponse{body: `{"items": []}`, status: 200}
+
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no Cloud Profiler Java agent versions found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch Cloud Profiler agent list"))
+			})
+		})
+	})
+
+	Describe("In", func() {
+		Context("when fetching a specific version", func() {
+			It("returns the release with URL and computed SHA256", func() {
+				tarURL := profilerDownloadBase + "cloud-profiler-java-agent_20241028_RC00.tar.gz"
+				client.responses[tarURL] = mockResponse{body: "hello", status: 200}
+
+				release, err := watcher.In("20241028_RC00")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("20241028_RC00"))
+				Expect(release.URL).To(Equal(tarURL))
+				Expect(release.SHA256).To(Equal("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"))
+			})
+		})
+
+		Context("when the download fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.In("20241028_RC00")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to download Cloud Profiler agent"))
+			})
+		})
+	})
+})

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -513,6 +513,14 @@ dependencies:
       - 'packaging: zip'
     any_stack: true
     versions_to_keep: 2  
+  newrelic-agent:
+    buildpacks:
+      java:
+        lines:
+          - line: latest
+    source_type: newrelic_agent
+    any_stack: true
+    versions_to_keep: 2  
   jprofiler-profiler:
     buildpacks:
       java:
@@ -606,6 +614,7 @@ skip_deprecation_check:
   - postgresql-jdbc  #! doesn't publish EOL schedule
   - mariadb-jdbc  #! doesn't publish EOL schedule
   - jacoco  #! doesn't publish EOL schedule
+  - newrelic-agent  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -60,6 +60,18 @@ dependencies:
       - 'artifact_id: java-cfenv'
     any_stack: true
     versions_to_keep: 1
+  cf-metrics-exporter:
+    buildpacks:
+      java:
+        lines:
+          - line: 0.7.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: io.github.rabobank'
+      - 'artifact_id: cf-metrics-exporter'
+    any_stack: true
+    versions_to_keep: 2
   composer:
     buildpacks:
       php:
@@ -631,3 +643,4 @@ skip_deprecation_check:
   - sapmachine  #! JRE versions tied to SAP release schedule
   - appdynamics-java  #! doesn't publish EOL schedule
   - client-certificate-mapper  #! doesn't publish EOL schedule
+  - cf-metrics-exporter  #! doesn't publish EOL schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -520,7 +520,15 @@ dependencies:
           - line: latest
     source_type: newrelic_agent
     any_stack: true
-    versions_to_keep: 2  
+    versions_to_keep: 2
+  google-stackdriver-profiler:
+    buildpacks:
+      java:
+        lines:
+          - line: latest
+    source_type: stackdriver_profiler
+    any_stack: true
+    versions_to_keep: 2
   jprofiler-profiler:
     buildpacks:
       java:
@@ -615,6 +623,7 @@ skip_deprecation_check:
   - mariadb-jdbc  #! doesn't publish EOL schedule
   - jacoco  #! doesn't publish EOL schedule
   - newrelic-agent  #! doesn't publish EOL schedule
+  - google-stackdriver-profiler  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -72,6 +72,20 @@ dependencies:
       - 'artifact_id: cf-metrics-exporter'
     any_stack: true
     versions_to_keep: 2
+  spring-boot-cli:
+    buildpacks:
+      java:
+        lines:
+          - line: 2.7.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: org.springframework.boot'
+      - 'artifact_id: spring-boot-cli'
+      - 'classifier: bin'
+      - 'packaging: tar.gz'
+    any_stack: true
+    versions_to_keep: 2
   composer:
     buildpacks:
       php:
@@ -653,3 +667,4 @@ skip_deprecation_check:
   - appdynamics-java  #! doesn't publish EOL schedule
   - client-certificate-mapper  #! doesn't publish EOL schedule
   - cf-metrics-exporter  #! doesn't publish EOL schedule
+  - spring-boot-cli  #! doesn't publish EOL schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -541,6 +541,14 @@ dependencies:
     source_type: stackdriver_profiler
     any_stack: true
     versions_to_keep: 2
+  groovy:
+    buildpacks:
+      java:
+        lines:
+          - line: 4.0.X
+    source_type: groovy
+    any_stack: true
+    versions_to_keep: 2
   jprofiler-profiler:
     buildpacks:
       java:
@@ -636,6 +644,7 @@ skip_deprecation_check:
   - jacoco  #! doesn't publish EOL schedule
   - newrelic-agent  #! doesn't publish EOL schedule
   - google-stackdriver-profiler  #! doesn't publish EOL schedule
+  - groovy  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule


### PR DESCRIPTION
Add more java buildpack dependencies to the dependency-builds pipeline.
- `newrelic` java agent - add to dependency config and custom dependency watcher. No discrepancies for cflinuxfs4/5 stacks.
- `google-stackdriver-profiler` - add to config and custom dependency watcher. No discrepancies for cflinuxfs4/5 stacks.
- `groovy` -  add to config and custom dependency watcher. No discrepancies for cflinuxfs4/5 stacks.
- `cf-metrics-exporter` - add to config, existing 'maven` dependency watcher is used. No discrepancies for cflinuxfs4/5 stacks.
- `spring-boot-cli` - add to config, existing 'maven` dependency watcher is used. No discrepancies for cflinuxfs4/5 stacks.