### PR TITLE
Fix regex in newrelic watcher

### DIFF
--- a/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/newrelic_agent.go
@@ -31,8 +31,8 @@ func (w *NewRelicAgentWatcher) Check() ([]base.Internal, error) {
 		return nil, fmt.Errorf("failed to read New Relic agent index: %w", err)
 	}
 
-	// Apache directory listing links look like: href="8.25.1/"
-	pattern := regexp.MustCompile(`href="(\d+\.\d+\.\d+)/"`)
+	// Apache directory listing links look like: <a href="/newrelic/java-agent/newrelic-agent/9.2.0">9.2.0/</a>"
+	pattern := regexp.MustCompile(`>(\d+\.\d+\.\d+)/<`)
 	var versions []base.Internal
 
 	for _, match := range pattern.FindAllSubmatch(body, -1) {


### PR DESCRIPTION
Fix the regex for checking newrelic versions with `newrelic` dependency watcher. Otherwise no new version is found with:
```
error: checking versions: no New Relic Java agent versions found in index
```