### PR TITLE
Set meaningful PR description for dependency version update PRs

### DIFF
--- a/pipelines/dependency-builds/pipeline.yml
+++ b/pipelines/dependency-builds/pipeline.yml
@@ -429,6 +429,7 @@ jobs:
     params:
       repo_location: buildpack
       title: #@ "Updating version for {} for {} ".format(dep_name, line_hash["line"])
+      description: #@ "Automated update of {} dependency for version line {}.".format(dep_name, line_hash["line"])
       branch_prefix: "pr-by-releng-bot"
       auto_merge: false
       base: #@ get_buildpack_branch(bp_name)


### PR DESCRIPTION
## Summary

- All version-update PRs were showing "This is default description of the PR" because no `description` param was passed to the `create-pull-request-resource`
- Add a `description` param with the dependency name and version line (e.g. "Automated update of node dependency for version line 20.")