### PR TITLE
Add custom watchers and adjust dependency config

### DIFF
--- a/dockerfiles/depwatcher-go/internal/factory/factory.go
+++ b/dockerfiles/depwatcher-go/internal/factory/factory.go
@@ -336,6 +336,14 @@ func CheckWithClient(source Source, currentVersion *base.Internal, client base.H
 		watcher := watchers.NewGroovyWatcher(client)
 		versions, err = watcher.Check()
 
+	case "sealights_agent":
+		watcher := watchers.NewSealightsAgentWatcher(client)
+		versions, err = watcher.Check()
+
+	case "jrebel":
+		watcher := watchers.NewJRebelWatcher(client)
+		versions, err = watcher.Check()
+
 	default:
 		return nil, fmt.Errorf("unknown type: %s", source.Type)
 	}
@@ -599,6 +607,14 @@ func InWithClient(source Source, version base.Internal, client base.HTTPClient) 
 
 	case "groovy":
 		watcher := watchers.NewGroovyWatcher(client)
+		return watcher.In(version.Ref)
+
+	case "sealights_agent":
+		watcher := watchers.NewSealightsAgentWatcher(client)
+		return watcher.In(version.Ref)
+
+	case "jrebel":
+		watcher := watchers.NewJRebelWatcher(client)
 		return watcher.In(version.Ref)
 
 	default:

--- a/dockerfiles/depwatcher-go/pkg/watchers/jrebel.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/jrebel.go
@@ -1,0 +1,80 @@
+package watchers
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/base"
+)
+
+const jrebelReleasesURL = "https://www.jrebel.com/jrebel-releases"
+const jrebelDownloadBase = "https://dl.zeroturnaround.com/jrebel/releases/jrebel-%s-nosetup.zip"
+
+var jrebelVersionPattern = regexp.MustCompile(`href="https://dl\.zeroturnaround\.com/jrebel/releases/jrebel-(\d{4}\.\d+\.\d+)-nosetup\.zip"`)
+
+type JRebelWatcher struct {
+	client base.HTTPClient
+}
+
+func NewJRebelWatcher(client base.HTTPClient) *JRebelWatcher {
+	return &JRebelWatcher{client: client}
+}
+
+func (w *JRebelWatcher) Check() ([]base.Internal, error) {
+	resp, err := w.client.Get(jrebelReleasesURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch JRebel releases page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JRebel releases page: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	var versions []base.Internal
+
+	for _, match := range jrebelVersionPattern.FindAllSubmatch(body, -1) {
+		v := string(match[1])
+		if !seen[v] {
+			seen[v] = true
+			versions = append(versions, base.Internal{Ref: v})
+		}
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no JRebel versions found on releases page")
+	}
+
+	versions = base.SortVersions(versions)
+
+	if len(versions) > 10 {
+		versions = versions[len(versions)-10:]
+	}
+
+	return versions, nil
+}
+
+func (w *JRebelWatcher) In(ref string) (base.Release, error) {
+	url := fmt.Sprintf(jrebelDownloadBase, ref)
+
+	resp, err := w.client.Get(url)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to download JRebel: %w", err)
+	}
+	defer resp.Body.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, resp.Body); err != nil {
+		return base.Release{}, fmt.Errorf("failed to compute SHA256: %w", err)
+	}
+
+	return base.Release{
+		Ref:    ref,
+		URL:    url,
+		SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+	}, nil
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/jrebel_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/jrebel_test.go
@@ -1,0 +1,161 @@
+package watchers_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/watchers"
+)
+
+type mockJRebelClient struct {
+	responses map[string]mockResponse
+}
+
+func (m *mockJRebelClient) Get(url string) (*http.Response, error) {
+	resp, exists := m.responses[url]
+	if !exists {
+		return nil, fmt.Errorf("unexpected URL: %s", url)
+	}
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+	}, nil
+}
+
+func (m *mockJRebelClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *mockJRebelClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+const jrebelReleasesPage = "https://www.jrebel.com/jrebel-releases"
+const jrebelDlBase = "https://dl.zeroturnaround.com/jrebel/releases/jrebel-%s-nosetup.zip"
+
+func jrebelHTML(versions ...string) string {
+	var links strings.Builder
+	for _, v := range versions {
+		links.WriteString(fmt.Sprintf(`<a href="https://dl.zeroturnaround.com/jrebel/releases/jrebel-%s-nosetup.zip">Download</a>`, v))
+	}
+	return "<html><body>" + links.String() + "</body></html>"
+}
+
+var _ = Describe("JRebelWatcher", func() {
+	var (
+		client  *mockJRebelClient
+		watcher *watchers.JRebelWatcher
+	)
+
+	BeforeEach(func() {
+		client = &mockJRebelClient{responses: make(map[string]mockResponse)}
+		watcher = watchers.NewJRebelWatcher(client)
+	})
+
+	Describe("Check", func() {
+		Context("when the releases page lists versions", func() {
+			It("returns sorted versions", func() {
+				client.responses[jrebelReleasesPage] = mockResponse{
+					body:   jrebelHTML("2025.4.1", "2025.4.2", "2025.3.0"),
+					status: 200,
+				}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(3))
+				Expect(versions[0].Ref).To(Equal("2025.3.0"))
+				Expect(versions[1].Ref).To(Equal("2025.4.1"))
+				Expect(versions[2].Ref).To(Equal("2025.4.2"))
+			})
+
+			It("deduplicates versions appearing multiple times", func() {
+				client.responses[jrebelReleasesPage] = mockResponse{
+					body:   jrebelHTML("2025.4.1", "2025.4.1", "2025.4.2"),
+					status: 200,
+				}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(2))
+			})
+
+			It("ignores links that do not match the versioned nosetup pattern", func() {
+				html := `<html><body>
+<a href="https://dl.zeroturnaround.com/jrebel/releases/jrebel-stable-nosetup.zip">stable</a>
+<a href="https://dl.zeroturnaround.com/jrebel/releases/jrebel-2026.2.1-nosetup.zip">Download</a>
+</body></html>`
+				client.responses[jrebelReleasesPage] = mockResponse{body: html, status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("2026.2.1"))
+			})
+		})
+
+		Context("when there are more than 10 versions", func() {
+			It("returns only the 10 most recent", func() {
+				var vers []string
+				for i := 1; i <= 12; i++ {
+					vers = append(vers, fmt.Sprintf("2025.%d.0", i))
+				}
+				client.responses[jrebelReleasesPage] = mockResponse{
+					body:   jrebelHTML(vers...),
+					status: 200,
+				}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(10))
+				Expect(versions[0].Ref).To(Equal("2025.3.0"))
+				Expect(versions[9].Ref).To(Equal("2025.12.0"))
+			})
+		})
+
+		Context("when no versions are found", func() {
+			It("returns an error", func() {
+				client.responses[jrebelReleasesPage] = mockResponse{body: "<html><body></body></html>", status: 200}
+
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no JRebel versions found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch JRebel releases page"))
+			})
+		})
+	})
+
+	Describe("In", func() {
+		Context("when fetching a specific version", func() {
+			It("returns the release with URL and computed SHA256", func() {
+				url := fmt.Sprintf(jrebelDlBase, "2026.2.1")
+				client.responses[url] = mockResponse{body: "hello", status: 200}
+
+				release, err := watcher.In("2026.2.1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("2026.2.1"))
+				Expect(release.URL).To(Equal(url))
+				Expect(release.SHA256).To(Equal("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"))
+			})
+		})
+
+		Context("when the download fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.In("2026.2.1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to download JRebel"))
+			})
+		})
+	})
+})

--- a/dockerfiles/depwatcher-go/pkg/watchers/sealights_agent.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/sealights_agent.go
@@ -1,0 +1,94 @@
+package watchers
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/base"
+)
+
+const sealightsLatestURL = "https://agents.sealights.co/sealights-java/sealights-java-latest.zip"
+const sealightsDownloadBase = "https://agents.sealights.co/sealights-java/sealights-java-%s.zip"
+const sealightsVersionFile = "sealights-java-version.txt"
+
+type SealightsAgentWatcher struct {
+	client base.HTTPClient
+}
+
+func NewSealightsAgentWatcher(client base.HTTPClient) *SealightsAgentWatcher {
+	return &SealightsAgentWatcher{client: client}
+}
+
+func (w *SealightsAgentWatcher) Check() ([]base.Internal, error) {
+	version, err := w.fetchLatestVersion()
+	if err != nil {
+		return nil, err
+	}
+	return []base.Internal{{Ref: version}}, nil
+}
+
+func (w *SealightsAgentWatcher) In(ref string) (base.Release, error) {
+	url := fmt.Sprintf(sealightsDownloadBase, ref)
+
+	resp, err := w.client.Get(url)
+	if err != nil {
+		return base.Release{}, fmt.Errorf("failed to download SeaLights agent: %w", err)
+	}
+	defer resp.Body.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, resp.Body); err != nil {
+		return base.Release{}, fmt.Errorf("failed to compute SHA256: %w", err)
+	}
+
+	return base.Release{
+		Ref:    ref,
+		URL:    url,
+		SHA256: fmt.Sprintf("%x", hash.Sum(nil)),
+	}, nil
+}
+
+func (w *SealightsAgentWatcher) fetchLatestVersion() (string, error) {
+	resp, err := w.client.Get(sealightsLatestURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch SeaLights latest zip: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SeaLights latest zip: %w", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("failed to open SeaLights zip: %w", err)
+	}
+
+	for _, f := range zr.File {
+		if f.Name == sealightsVersionFile {
+			rc, err := f.Open()
+			if err != nil {
+				return "", fmt.Errorf("failed to open %s: %w", sealightsVersionFile, err)
+			}
+			defer rc.Close()
+
+			versionBytes, err := io.ReadAll(rc)
+			if err != nil {
+				return "", fmt.Errorf("failed to read %s: %w", sealightsVersionFile, err)
+			}
+
+			version := strings.TrimSpace(string(versionBytes))
+			if version == "" {
+				return "", fmt.Errorf("empty version in %s", sealightsVersionFile)
+			}
+			return version, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s not found in SeaLights latest zip", sealightsVersionFile)
+}

--- a/dockerfiles/depwatcher-go/pkg/watchers/sealights_agent_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/sealights_agent_test.go
@@ -1,0 +1,129 @@
+package watchers_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/buildpacks-ci/depwatcher-go/pkg/watchers"
+)
+
+type mockSealightsClient struct {
+	responses map[string]mockResponse
+}
+
+func (m *mockSealightsClient) Get(url string) (*http.Response, error) {
+	resp, exists := m.responses[url]
+	if !exists {
+		return nil, fmt.Errorf("unexpected URL: %s", url)
+	}
+	return &http.Response{
+		StatusCode: resp.status,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+	}, nil
+}
+
+func (m *mockSealightsClient) GetWithHeaders(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *mockSealightsClient) GetRaw(url string, headers http.Header) (*http.Response, error) {
+	return m.Get(url)
+}
+
+// buildZip creates an in-memory zip with a sealights-java-version.txt entry.
+func buildZip(version string) string {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("sealights-java-version.txt")
+	w.Write([]byte(version))
+	zw.Close()
+	return buf.String()
+}
+
+const sealightsLatest = "https://agents.sealights.co/sealights-java/sealights-java-latest.zip"
+
+var _ = Describe("SealightsAgentWatcher", func() {
+	var (
+		client  *mockSealightsClient
+		watcher *watchers.SealightsAgentWatcher
+	)
+
+	BeforeEach(func() {
+		client = &mockSealightsClient{responses: make(map[string]mockResponse)}
+		watcher = watchers.NewSealightsAgentWatcher(client)
+	})
+
+	Describe("Check", func() {
+		Context("when the latest zip contains a version file", func() {
+			It("returns the version from sealights-java-version.txt", func() {
+				client.responses[sealightsLatest] = mockResponse{body: buildZip("4.0.2778"), status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("4.0.2778"))
+			})
+
+			It("trims whitespace from the version", func() {
+				client.responses[sealightsLatest] = mockResponse{body: buildZip("4.0.2778\n"), status: 200}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions[0].Ref).To(Equal("4.0.2778"))
+			})
+		})
+
+		Context("when the latest zip has no version file", func() {
+			It("returns an error", func() {
+				var buf bytes.Buffer
+				zw := zip.NewWriter(&buf)
+				zw.Create("some-other-file.jar")
+				zw.Close()
+
+				client.responses[sealightsLatest] = mockResponse{body: buf.String(), status: 200}
+
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("sealights-java-version.txt not found"))
+			})
+		})
+
+		Context("when the HTTP request fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.Check()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to fetch SeaLights latest zip"))
+			})
+		})
+	})
+
+	Describe("In", func() {
+		Context("when fetching a specific version", func() {
+			It("returns the release with URL and computed SHA256", func() {
+				url := "https://agents.sealights.co/sealights-java/sealights-java-4.0.2778.zip"
+				client.responses[url] = mockResponse{body: "hello", status: 200}
+
+				release, err := watcher.In("4.0.2778")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("4.0.2778"))
+				Expect(release.URL).To(Equal(url))
+				Expect(release.SHA256).To(Equal("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"))
+			})
+		})
+
+		Context("when the download fails", func() {
+			It("returns an error", func() {
+				_, err := watcher.In("4.0.2778")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to download SeaLights agent"))
+			})
+		})
+	})
+})

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -442,6 +442,7 @@ dependencies:
     buildpacks:
       java:
         lines:
+          - line: 9.0.X
           - line: 10.1.X
           - line: 11.0.X
     source_type: tomcat

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -563,6 +563,23 @@ dependencies:
     source_type: groovy
     any_stack: true
     versions_to_keep: 2
+  sealights-agent:
+    buildpacks:
+      java:
+        lines:
+          - line: 4.X.X
+    source_type: sealights_agent
+    any_stack: true
+    versions_to_keep: 2
+  jrebel:
+    buildpacks:
+      java:
+        lines:
+          - line: 2025.X.X
+          - line: 2026.X.X
+    source_type: jrebel
+    any_stack: true
+    versions_to_keep: 2
   jprofiler-profiler:
     buildpacks:
       java:
@@ -659,6 +676,8 @@ skip_deprecation_check:
   - newrelic  #! doesn't publish EOL schedule
   - google-stackdriver-profiler  #! doesn't publish EOL schedule
   - groovy  #! doesn't publish EOL schedule
+  - sealights-agent  #! doesn't publish EOL schedule
+  - jrebel  #! doesn't publish EOL schedule
   - jprofiler-profiler  #! doesn't publish EOL schedule
   - your-kit-profiler  #! doesn't publish EOL schedule
   - openjdk  #! JRE versions tied to BellSoft Liberica schedule

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -547,6 +547,18 @@ dependencies:
     source_type: newrelic_agent
     any_stack: true
     versions_to_keep: 2
+  datadog-javaagent:
+    buildpacks:
+      java:
+        lines:
+          - line: 1.X.X
+    source_type: maven
+    source_params:
+      - 'uri: https://repo1.maven.org/maven2'
+      - 'group_id: com.datadoghq'
+      - 'artifact_id: dd-java-agent'
+    any_stack: true
+    versions_to_keep: 2
   google-stackdriver-profiler:
     buildpacks:
       java:
@@ -674,6 +686,7 @@ skip_deprecation_check:
   - mariadb-jdbc  #! doesn't publish EOL schedule
   - jacoco  #! doesn't publish EOL schedule
   - newrelic  #! doesn't publish EOL schedule
+  - datadog-javaagent  #! doesn't publish EOL schedule
   - google-stackdriver-profiler  #! doesn't publish EOL schedule
   - groovy  #! doesn't publish EOL schedule
   - sealights-agent  #! doesn't publish EOL schedule


### PR DESCRIPTION
Add more java buildpack dependencies to the dependency-builds pipeline.
- `jrebel` java agent - add to dependency config and custom dependency watcher.  No issues for cflinuxfs5, it bundles a native libjrebel64.so for Linux x86-64, but its maximum glibc requirement is only GLIBC_2.4 (from 2006). cflinuxfs5's glibc 2.39 is fully compatible.
- `sealights-agent` - add to dependency config and custom dependency watcher. SeaLights Java agent is a pure JAR-based zip, no native binaries, no glibc dependency thus no issues on cflinuxfs5.
- `datadog-javaagent` - add to dependency config, `maven` watcher is used. No native binaries, no glibc dependency with regard to cflinuxfs5.
- added also tomcat 9 to automatic updates