### PR TITLE
Add cflinuxfs5 to cf-release pipeline default stacks

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -1,6 +1,6 @@
 #@data/values
 ---
-#@ default_stacks = ['cflinuxfs4']
+#@ default_stacks = ['cflinuxfs4', 'cflinuxfs5']
 
 supported_languages:
 - name: dotnet-core


### PR DESCRIPTION
This change adds cflinuxfs5 (Ubuntu 24.04 noble) to the default_stacks list in the cf-release pipeline configuration.

Previously, only cflinuxfs4 was in the default stacks, which meant:
- Buildpack releases only uploaded cflinuxfs4 blobs to S3
- BOSH release creation failed when cflinuxfs5 packages were defined
- CI builds failed with: "Missing files for pattern 'go?buildpack-cflinuxfs5-*.zip'"

With this change:
- Both cflinuxfs4 and cflinuxfs5 blobs will be uploaded during offlinization
- BOSH releases can include both stack packages
- Enables gradual migration from cflinuxfs4 to cflinuxfs5

This change affects all buildpacks in the cf-release pipeline:
- dotnet-core, go, java, nginx, nodejs, php, python, r, ruby, staticfile

Tested with: go-buildpack-release (BOSH release creation now succeeds)