### PR TITLE
Add binary buildpack to cf-release pipeline

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -3,6 +3,8 @@
 #@ default_stacks = ['cflinuxfs4', 'cflinuxfs5']
 
 supported_languages:
+- name: binary
+  stacks: #@ default_stacks
 - name: dotnet-core
   stacks: #@ default_stacks
 - name: go


### PR DESCRIPTION
## Summary
- Add `binary` to `supported_languages` in `cf-release-config.yml` with `default_stacks` (cflinuxfs4, cflinuxfs5)

## Context
This enables the cf-release pipeline to automatically create dev releases, deploy, run CATs, and publish final releases for the binary buildpack — the same flow used by all other buildpacks. Requires the binary-buildpack-release repo to have cflinuxfs5 package support (companion PR: cloudfoundry/binary-buildpack-release).