### PR TITLE
Add nginx 1.30.X to dependency-builds pipeline

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -235,6 +235,8 @@ dependencies:
             link: https://nginx.org/
           - line: 1.29.X
             link: https://nginx.org/
+          - line: 1.30.X
+            link: https://nginx.org/
     versions_to_keep: 2
   openresty:
     buildpacks:
@@ -250,15 +252,15 @@ dependencies:
           #! nginx deprecation dates are 1 year after the mainline release date
           #! each odd version line (ex. 1.19) is the "mainline"
           #! the even numbered version line that precedes the mainline is the associated stable version line.
-          - line: 1.26.X
+          - line: 1.29.X
             link: https://nginx.org/
-          - line: 1.27.X
+          - line: 1.30.X
             link: https://nginx.org/
       staticfile:
         lines:
-          - line: 1.26.X
+          - line: 1.29.X
             link: https://nginx.org/
-          - line: 1.27.X
+          - line: 1.30.X
             link: https://nginx.org/
     source_type: nginx
     versions_to_keep: 2


### PR DESCRIPTION
## Summary
- Add nginx `1.30.X` stable line to the nginx buildpack dependency tracking
- Bump `nginx-static` (php + staticfile buildpacks) from 1.26+1.27 to 1.29+1.30

## Context
nginx 1.30 is the new stable release line. This updates the dependency-builds pipeline to track it. After merging, the pipeline needs to be re-set in Concourse.