### PR TITLE
Fix merge.sh: include .git/ when seeding merged-builds-metadata

### DIFF
--- a/spec/tasks/merge-builds-metadata/merge_spec.rb
+++ b/spec/tasks/merge-builds-metadata/merge_spec.rb
@@ -76,11 +76,12 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
 
   # Concourse layout:
   #
-  #   builds/                        ← git resource (seed)
+  #   builds/                        ← git resource (seed, has .git/)
   #   <stack>-builds-metadata/       ← task output from build-binary (one per stack)
   #     binary-builds-new/<dep>/
   #       <version>-<stack>.json
-  #   merged-builds-metadata/        ← task output (initially a clone of builds/)
+  #   merged-builds-metadata/        ← Concourse output dir (empty, NO .git/)
+  #                                     merge.sh seeds it via rsync from builds/
 
   def setup_builds_repo(existing_files: [])
     builds = File.join(@tmpdir, 'builds')
@@ -92,10 +93,11 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
 
   def setup_merged_repo
     merged = File.join(@tmpdir, 'merged-builds-metadata')
-    # Concourse seeds the output dir from the builds resource via rsync —
-    # simulate by cloning builds/ into merged-builds-metadata/.
-    system('git', 'clone', File.join(@tmpdir, 'builds'), merged,
-           out: '/dev/null', err: '/dev/null')
+    # Concourse provides output dirs as empty directories — no .git/.
+    # merge.sh itself seeds it via rsync from builds/, copying .git/ in.
+    # Do NOT pre-initialise as a git repo: that would hide regressions where
+    # --exclude='.git' is re-added and breaks real Concourse runs.
+    FileUtils.mkdir_p(merged)
     merged
   end
 
@@ -123,10 +125,10 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
     end
 
     it 'produces exactly one new commit in merged-builds-metadata' do
-      before = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
       run_merge(@tmpdir)
-      after = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
-      expect(after - before).to eq(1)
+      merged_count = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
+      builds_count = commit_count(File.join(@tmpdir, 'builds'))
+      expect(merged_count).to eq(builds_count + 1)
     end
 
     it 'commits both stack JSON files in a single commit' do
@@ -168,10 +170,10 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
     end
 
     it 'makes no new commit' do
-      before = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
       run_merge(@tmpdir)
-      after = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
-      expect(after).to eq(before)
+      merged_count = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
+      builds_count = commit_count(File.join(@tmpdir, 'builds'))
+      expect(merged_count).to eq(builds_count)
     end
   end
 
@@ -194,10 +196,10 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
     end
 
     it 'produces exactly one new commit' do
-      before = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
       run_merge(@tmpdir)
-      after = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
-      expect(after - before).to eq(1)
+      merged_count = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
+      builds_count = commit_count(File.join(@tmpdir, 'builds'))
+      expect(merged_count).to eq(builds_count + 1)
     end
 
     it 'commits only the new cflinuxfs5 JSON' do
@@ -254,10 +256,10 @@ RSpec.describe 'merge-builds-metadata/merge.sh' do
     end
 
     it 'makes no new commit' do
-      before = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
       run_merge(@tmpdir)
-      after = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
-      expect(after).to eq(before)
+      merged_count = commit_count(File.join(@tmpdir, 'merged-builds-metadata'))
+      builds_count = commit_count(File.join(@tmpdir, 'builds'))
+      expect(merged_count).to eq(builds_count)
     end
   end
 

--- a/tasks/merge-builds-metadata/merge.sh
+++ b/tasks/merge-builds-metadata/merge.sh
@@ -4,12 +4,10 @@ set -euo pipefail
 GIT_USER_EMAIL="${GIT_USER_EMAIL:-cf-buildpacks-eng@pivotal.io}"
 GIT_USER_NAME="${GIT_USER_NAME:-CF Buildpacks Team CI Server}"
 
-# Seed merged-builds-metadata from the builds git resource.
-# --exclude='.git' is critical: builds/ is a Concourse git resource with its
-# own .git/ directory. Without exclusion rsync overwrites the .git/ of
-# merged-builds-metadata, causing git config / git commit to operate on the
-# wrong repo identity and history.
-rsync -a --exclude='.git' builds/ merged-builds-metadata/
+# Seed merged-builds-metadata from the builds git resource (including .git/).
+# merged-builds-metadata is an output dir, so we need .git/ for commits and
+# for the subsequent `put: builds` step to push.
+rsync -a builds/ merged-builds-metadata/
 
 pushd merged-builds-metadata >/dev/null
 git config user.email "${GIT_USER_EMAIL}"


### PR DESCRIPTION
## Summary
- Remove `--exclude='.git'` from rsync in `merge.sh`

## Problem
The `build-nginx-1.30.x` job (and all multi-stack dependency builds) fails with:
```
fatal: not in a git directory
```

The `merged-builds-metadata` is a Concourse **output** (empty directory). The script needs `.git/` from the `builds` git resource to run git commands and for the `put: builds` step to push commits. The `--exclude='.git'` flag was incorrectly stripping it.

## Fix
Remove the exclusion so `.git/` is copied from `builds/` into the empty output directory.