### PR TITLE
Remove Node.js 20 from dependency-builds pipeline

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -269,9 +269,6 @@ dependencies:
     buildpacks:
       nodejs:
         lines:
-          - line: 20.X.X
-            deprecation_date: 2026-04-30
-            link: https://github.com/nodejs/Release
           - line: 22.X.X
             deprecation_date: 2027-04-30
             link: https://github.com/nodejs/Release


### PR DESCRIPTION
## Summary
- Remove Node.js 20.X.X version line from dependency-builds pipeline

## Context
Node.js 20 reached EOL on 2026-04-30. This removes the `build-node-20.x.x` and `update-node-20.x.x-nodejs` jobs from the pipeline.