### PR TITLE
Add binary-buildpack to cf-release pipeline preserving Windows blob

### DIFF
--- a/pipelines/cf-release/cf-release-config.yml
+++ b/pipelines/cf-release/cf-release-config.yml
@@ -23,4 +23,6 @@ supported_languages:
   stacks: #@ default_stacks
 - name: staticfile
   stacks: #@ default_stacks
+- name: binary
+  stacks: #@ default_stacks
 

--- a/tasks/cf-release/create-buildpack-dev-release/run
+++ b/tasks/cf-release/create-buildpack-dev-release/run
@@ -31,22 +31,61 @@ get_version() {
 buildpack_blob_is_latest() {
   local new_version=$1
 
-  local existing_version
-  if [[ "$(bosh blobs --dir release --column=path)" =~ v?([0-9\.]+).zip ]]; then
-    existing_version="${BASH_REMATCH[1]}"
-  else
-    echo "Could not determine version of existing buildpack blob"
-    exit 1
-  fi
+  local blob_paths
+  blob_paths="$(bosh blobs --dir release --column=path)"
 
-  [[ "${existing_version}" == "${new_version}" ]] && return 0 || return 1
+  # Check if ALL input stacks are at the new version
+  local all_latest=true
+  for buildpack_file in buildpack-*/*.zip; do
+    local filename
+    filename="$(basename "${buildpack_file}")"
+    if [[ "${filename}" =~ -([a-z0-9]+)-v[0-9] ]]; then
+      local stack="${BASH_REMATCH[1]}"
+      local relevant_blob
+      relevant_blob="$(echo "${blob_paths}" | grep "${stack}" || true)"
+      if [[ -z "${relevant_blob}" ]]; then
+        # No existing blob for this stack (e.g. first time adding cflinuxfs5) - not latest
+        all_latest=false
+        break
+      elif [[ "${relevant_blob}" =~ v?([0-9\.]+).zip ]]; then
+        local existing_version="${BASH_REMATCH[1]}"
+        if [[ "${existing_version}" != "${new_version}" ]]; then
+          all_latest=false
+          break
+        fi
+      fi
+    fi
+  done
+
+  [[ "${all_latest}" == "true" ]] && return 0 || return 1
 }
 
 remove_old_blobs() {
-  bosh blobs --dir release --json \
-    | jq -r '.Tables[0].Rows[].path' \
-    | grep buildpack \
-    | xargs -I {} bosh remove-blob --dir release {}
+  local stacks_to_replace=()
+  for buildpack_file in buildpack-*/*.zip; do
+    local filename
+    filename="$(basename "${buildpack_file}")"
+    # Extract stack from filename pattern: name_buildpack-STACK-vVERSION+TIMESTAMP.zip
+    if [[ "${filename}" =~ -([a-z0-9]+)-v[0-9] ]]; then
+      stacks_to_replace+=("${BASH_REMATCH[1]}")
+    fi
+  done
+
+  local blob_paths
+  blob_paths="$(bosh blobs --dir release --json | jq -r '.Tables[0].Rows[].path' | grep buildpack)"
+
+  for blob_path in ${blob_paths}; do
+    local should_remove=false
+    for stack in "${stacks_to_replace[@]}"; do
+      if [[ "${blob_path}" == *"-${stack}-"* ]]; then
+        should_remove=true
+        break
+      fi
+    done
+    if [[ "${should_remove}" == "true" ]]; then
+      bosh remove-blob --dir release "${blob_path}"
+    fi
+  done
 }
 
 add_new_blobs() {


### PR DESCRIPTION
**Summary**
- Add binary to the cf-release pipeline's supported_languages so BOSH releases are automatically built
- Modify create-buildpack-dev-release/run to only remove/replace blobs for stacks being updated, preserving the existing Windows blob (binary_buildpack-windows-v1.1.15.zip)

**Context**
The binary-buildpack-release BOSH release has not been built through the automated cf-release pipeline. It was excluded from cf-release-config.yml likely due to Windows testing requirements — our CI/CD infrastructure does not have a Windows BBL environment.
However, the Windows blob has been pinned at v1.1.15 since that version and has been successfully carried forward unchanged through releases v1.1.15 to v1.1.21. There is no need to re-test an unchanged artifact.
The existing remove_old_blobs() function removed all blobs matching "buildpack", which would delete the Windows blob since it is not provided as a pipeline input. Similarly, buildpack_blob_is_latest() matched against all blob paths, potentially picking up the Windows blob version (v1.1.15) instead of the Linux one.

**Changes**
pipelines/cf-release/cf-release-config.yml
- Added binary with default stacks (cflinuxfs4, cflinuxfs5)
- 
tasks/cf-release/create-buildpack-dev-release/run
- buildpack_blob_is_latest(): Now extracts the stack name from input filenames and filters blob paths to only check versions for stacks being updated. This prevents the Windows blob version from interfering with the version check.
- remove_old_blobs(): Instead of removing all blobs, it now scans input zip filenames to determine which stacks are being replaced, and only removes blobs whose path matches one of those stacks.

**How It Works End-to-End**
When the pipeline runs for binary:
1. S3 resources provide binary_buildpack-cflinuxfs4-vX.Y.Z.zip and binary_buildpack-cflinuxfs5-vX.Y.Z.zip
2. buildpack_blob_is_latest checks only cflinuxfs4/cflinuxfs5 blob versions
3. remove_old_blobs removes only the old cflinuxfs4/cflinuxfs5 blobs
4. add_new_blobs adds the new cflinuxfs4/cflinuxfs5 blobs
5. The Windows blob (binary_buildpack-windows-v1.1.15.zip) is preserved throughout
6. bosh create-release packages everything including the unchanged Windows package
The deploy+CATs phase tests on a Linux-only environment (no Windows cells needed), which is fine since the Windows blob is not changing.