### PR TITLE
Update cflinuxfs5-release to v0.34.0-beta in test ops file

### DIFF
--- a/deployments/operations/add-cflinuxfs5-beta.yml
+++ b/deployments/operations/add-cflinuxfs5-beta.yml
@@ -6,9 +6,9 @@
   path: /releases/-
   value:
     name: cflinuxfs5
-    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs5-release?v=0.13.0-beta"
-    version: "0.13.0-beta"
-    sha1: "sha256:8a1d34ad46e3598a8c92ccdef4dcc2f58d4b9a7c32b88817093954a91da7acf7"
+    url: "https://bosh.io/d/github.com/cloudfoundry/cflinuxfs5-release?v=0.34.0-beta"
+    version: "0.34.0-beta"
+    sha1: "sha256:dd9c703407460f2c86cb3453a1fa7fab5f28a2010b65256b9512174a34c311db"
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/-


### PR DESCRIPTION
Updates `deployments/operations/add-cflinuxfs5-beta.yml` to use cflinuxfs5-release v0.34.0-beta (was v0.13.0-beta).