### PR TITLE
java-cfenv: mirror java-cfenv-all, not the bare core

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -57,7 +57,7 @@ dependencies:
     source_params:
       - 'uri: https://repo1.maven.org/maven2'
       - 'group_id: io.pivotal.cfenv'
-      - 'artifact_id: java-cfenv'
+      - 'artifact_id: java-cfenv-all'
     any_stack: true
     versions_to_keep: 1
   cf-metrics-exporter:


### PR DESCRIPTION
## Summary

The dependency-builds pipeline mirrors Maven `io.pivotal.cfenv:java-cfenv` — the bare **core** module, which has no `META-INF/spring.factories`, no `EnvironmentPostProcessor`, and no `CloudProfileApplicationListener`. As a result the jar shipped to the java-buildpack no longer activates the `cloud` Spring profile or maps `VCAP_SERVICES` to Spring properties — a silent regression from the 4.x buildpack, which shipped the aggregate **`java-cfenv-all`** jar.

This flips `artifact_id` to `java-cfenv-all` so the pipeline mirrors the aggregate (core + boot + profile listener).

Fixes #656.

## Verification

Maven `java-cfenv-all-3.5.1.jar` is byte-identical to the 4.x Ruby-era mirror (`java-buildpack.cloudfoundry.org/java-cfenv/java-cfenv-3.5.1.jar`), sha256 `696225e3bcd9cdd662c0df1dbeb4d2483cb0183a51ca67b0d7ee56cba87736a1` (verified against Maven Central's published `.sha1`). So this restores the exact artifact 4.x shipped, for both 3.5.1 and 4.0.0.

## Downstream (automatic after merge)

1. depwatcher polls `io.pivotal.cfenv:java-cfenv-all` → regenerates `public-buildpacks-ci-robots/binary-builds-new/java-cfenv/*.json` with the `-all` source URL and real per-version sha (also fixing the current entries, which share one sha across 3.5.1 and 4.0.0).
2. Pipeline mirrors `-all` to `buildpacks.cloudfoundry.org/dependencies/java-cfenv/`.
3. Bot auto-PRs `cloudfoundry/java-buildpack` `manifest.yml` so `uri`/`sha256` point at the CF-hosted `-all` (superseding the interim direct-Maven `uri` in cloudfoundry/java-buildpack#1352).

## Follow-up (test only, non-blocking)

`dockerfiles/depwatcher-go/pkg/watchers/maven_test.go` hardcodes the core `java-cfenv` test URL — update to `java-cfenv-all`.

