### PR TITLE
Remove obsolete cflinuxfs5-beta ops file from buildpack pipelines

### DIFF
--- a/pipelines/buildpack/pipeline.yml
+++ b/pipelines/buildpack/pipeline.yml
@@ -583,37 +583,17 @@ jobs:
         params:
           repository: updated-bbl-state
           rebase: true
-    #! Copy cflinuxfs5 ops file to cf-deployment operations directory
-    - task: add-cflinuxfs5-ops-file
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source:
-            repository: cfbuildpacks/ci
-        inputs:
-        - name: cf-deployment
-        - name: buildpacks-ci
-        outputs:
-        - name: cf-deployment-with-cflinuxfs5
-        run:
-          path: bash
-          args:
-          - -c
-          - |
-            cp -r cf-deployment/* cf-deployment-with-cflinuxfs5/
-            cp buildpacks-ci/deployments/operations/add-cflinuxfs5-beta.yml cf-deployment-with-cflinuxfs5/operations/
     - task: deploy-cf
       file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
       input_mapping:
         bbl-state: updated-bbl-state
-        ops-files: cf-deployment-with-cflinuxfs5
+        ops-files: cf-deployment
       params:
         BBL_STATE_DIR: #@ data.values.language + "-buildpack-state"
         BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
         SYSTEM_DOMAIN: #@ data.values.language + ".buildpacks.ci.cloudfoundry.org"
         VARS_STORE_FILE: bump-deployments/bbl-gcp-cf/deployment-vars.yml
-        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml operations/add-cflinuxfs5-beta.yml
+        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml
       on_failure:
         do:
         - #@ remove_gcp_dns()


### PR DESCRIPTION
### Description:
As of cf-deployment [v58.2.0](https://github.com/cloudfoundry/cf-deployment/releases/tag/v58.2.0) (released July 10, 2026), cflinuxfs5 is now included directly in the base cf-deployment.yml manifest by default. This promotes cflinuxfs5 to an official stack in the base cf-deployment.yml manifest. 
Our pipeline was still applying `add-cflinuxfs5-beta.yml` on top, causing BOSH to fail with: `Error: Duplicate release name 'cflinuxfs5'`

### Changes:

 - Remove the add-cflinuxfs5-ops-file task that copied the custom ops file into the cf-deployment operations directory
 - Point the deploy-cf task's ops-files input directly to cf-deployment instead of the intermediate cf-deployment-with-cflinuxfs5 artifact
 - Remove operations/add-cflinuxfs5-beta.yml from OPS_FILES in the deploy-cf params
 
The `add-cflinuxfs5-beta.yml` file is left in place but is no longer referenced by the pipeline.