### PR TITLE
Add BOSH resource tags for cost tracking (belongs-to, environment)

### DIFF
--- a/deployments/operations/add-resource-tags.yml
+++ b/deployments/operations/add-resource-tags.yml
@@ -1,0 +1,15 @@
+# add-resource-tags.yml
+# Adds resource tracking tags to all BOSH-managed VMs and disks.
+# These tags help identify resources for cost tracking and prevent accidental deletion.
+#
+# Reference: https://github.com/cloudfoundry/community/issues/1185
+#
+# Tags:
+#   belongs-to:  Identifies the working group that owns these resources
+#   environment: Identifies the BBL environment type
+
+- type: replace
+  path: /tags?
+  value:
+    belongs-to: app-runtime-interfaces
+    environment: buildpacks-bbl-env

--- a/pipelines/buildpack/pipeline.yml
+++ b/pipelines/buildpack/pipeline.yml
@@ -583,17 +583,25 @@ jobs:
         params:
           repository: updated-bbl-state
           rebase: true
+    - task: collect-ops-files
+      file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+      input_mapping:
+        base-ops-files: cf-deployment
+        new-ops-files: buildpacks-ci
+      params:
+        BASE_OPS_FILE_DIR: operations
+        NEW_OPS_FILES: deployments/operations/add-resource-tags.yml
     - task: deploy-cf
       file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
       input_mapping:
         bbl-state: updated-bbl-state
-        ops-files: cf-deployment
+        ops-files: collected-ops-files
       params:
         BBL_STATE_DIR: #@ data.values.language + "-buildpack-state"
         BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
         SYSTEM_DOMAIN: #@ data.values.language + ".buildpacks.ci.cloudfoundry.org"
         VARS_STORE_FILE: bump-deployments/bbl-gcp-cf/deployment-vars.yml
-        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml
+        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml operations/add-resource-tags.yml
       on_failure:
         do:
         - #@ remove_gcp_dns()

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -300,12 +300,21 @@ jobs:
       BASE_OPS_FILE_DIR: operations
       NEW_OPS_FILES: #@ "bump-" + language.name + "-buildpack.yml"
 #@ end
+  - task: add-resource-tags-ops-file
+    file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+    input_mapping:
+      base-ops-files: collected-ops-files
+      new-ops-files: buildpacks-ci
+    params:
+      BASE_OPS_FILE_DIR: operations
+      NEW_OPS_FILES: deployments/operations/add-resource-tags.yml
 
 #@ base_ops_files = [
 #@   "operations/experimental/fast-deploy-with-downtime-and-danger.yml",
 #@   "operations/use-compiled-releases.yml",
 #@   "operations/scale-to-one-az.yml",
 #@   "operations/test/scale-to-one-az-addon-parallel-cats.yml",
+#@   "operations/add-resource-tags.yml",
 #@ ]
 #@ buildpack_ops_file_paths = []
 #@ for language in data.values.supported_languages:

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -487,6 +487,7 @@ jobs:
         - buildpacks-opsfile/use-latest-buildpack-releases.yml
         - rootfs-release-artifacts/use-dev-release-opsfile.yml
         - capi-release-artifacts/use-dev-release-opsfile.yml
+        - buildpacks-ci/deployments/operations/add-resource-tags.yml
         vars:
           system_domain: cflinuxfs4.buildpacks.ci.cloudfoundry.org
 


### PR DESCRIPTION
## Summary

Add BOSH resource tags to all CF deployments to enable resource tracking and prevent accidental deletion.

This complements [buildpacks-envs PR #5](https://github.com/cloudfoundry/buildpacks-envs/pull/5) which covers Terraform/BBL infrastructure.

Reference: [CF Community Cost Optimization Guidelines](https://github.com/cloudfoundry/community/issues/1185)

## Tags Added

- `belongs-to: app-runtime-interfaces` - Identifies the owning working group
- `environment: buildpacks-bbl-env` - Identifies the BBL environment type

## Changes

### New Ops File
- `deployments/operations/add-resource-tags.yml` - Adds tags to deployment manifest

### Pipeline Updates

**buildpack pipeline** (`pipelines/buildpack/pipeline.yml`):
- Added `collect-ops-files` task before `deploy-cf` to include tags ops file
- Updated `ops-files` input mapping to use collected ops files
- Added `operations/add-resource-tags.yml` to `OPS_FILES` list

**cf-release pipeline** (`pipelines/cf-release/cf-release.yml`):
- Added `add-resource-tags-ops-file` task to collect the tags ops file
- Added `operations/add-resource-tags.yml` to `base_ops_files` list

**cflinuxfs4 pipeline** (`pipelines/cflinuxfs4.yml`):
- Added `buildpacks-ci/deployments/operations/add-resource-tags.yml` to `ops_files` in deploy job

## Resources Tagged (BOSH-managed)

These tags will be applied to all VMs and persistent disks created by BOSH:
- Diego cells
- Routers
- API servers
- All other CF components
- Persistent disks attached to these VMs

## Complete Resource Labeling Coverage

| Resource Type | How Tagged | PR |
|--------------|------------|-----|
| GCP IPs, forwarding rules, DNS | Terraform labels | [buildpacks-envs #5](https://github.com/cloudfoundry/buildpacks-envs/pull/5) |
| BOSH VMs and disks | BOSH tags (this PR) | This PR |

## Applying Tags

Tags will be applied automatically on the next CF deployment in each pipeline.