### PR TITLE
Add GCP resource labeling for cost tracking

### DIFF
--- a/deployments/operations/tag-bbl-env.yml
+++ b/deployments/operations/tag-bbl-env.yml
@@ -1,0 +1,19 @@
+---
+# CF Deployment GCP Resource Tagging Ops File
+# Adds GCP labels to all CF deployment resources for cost tracking
+#
+# Based on: https://github.com/cloudfoundry/capi-ci/blob/main/cf-deployment-operations/tag-bbl-env.yml
+# Required by: ARI Working Group for cost tracking (https://github.com/cloudfoundry/community/issues/1185)
+#
+# Usage: Pass variable bbl_env_name when deploying
+# Example: bosh deploy ... --var bbl_env_name=python-buildpacks-bbl-env
+#
+# Labels applied:
+#   belongs-to: buildpacks-and-stacks (ARI working group area)
+#   environment: <bbl_env_name> (specific buildpack environment)
+
+- type: replace
+  path: /tags?
+  value:
+    environment: ((bbl_env_name))
+    belongs-to: buildpacks-and-stacks

--- a/pipelines/buildpack/pipeline.yml
+++ b/pipelines/buildpack/pipeline.yml
@@ -583,17 +583,40 @@ jobs:
         params:
           repository: updated-bbl-state
           rebase: true
+    #! Copy custom ops file for GCP resource tagging
+    - task: add-tag-ops-file
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: cfbuildpacks/ci
+        inputs:
+        - name: cf-deployment
+        - name: buildpacks-ci
+        outputs:
+        - name: cf-deployment-with-tags
+        run:
+          path: bash
+          args:
+          - -c
+          - |
+            set -euo pipefail
+            cp -r cf-deployment/* cf-deployment-with-tags/
+            cp buildpacks-ci/deployments/operations/tag-bbl-env.yml cf-deployment-with-tags/operations/
+            echo "Added tag-bbl-env.yml ops file"
     - task: deploy-cf
       file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
       input_mapping:
         bbl-state: updated-bbl-state
-        ops-files: cf-deployment
+        ops-files: cf-deployment-with-tags
       params:
         BBL_STATE_DIR: #@ data.values.language + "-buildpack-state"
         BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
         SYSTEM_DOMAIN: #@ data.values.language + ".buildpacks.ci.cloudfoundry.org"
         VARS_STORE_FILE: bump-deployments/bbl-gcp-cf/deployment-vars.yml
-        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml
+        OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml operations/scale-to-one-az.yml operations/tag-bbl-env.yml
+        BOSH_DEPLOY_ARGS: #@ "--var bbl_env_name=" + data.values.language + "-buildpacks-bbl-env"
       on_failure:
         do:
         - #@ remove_gcp_dns()

--- a/pipelines/cf-release/cf-release.yml
+++ b/pipelines/cf-release/cf-release.yml
@@ -300,12 +300,21 @@ jobs:
       BASE_OPS_FILE_DIR: operations
       NEW_OPS_FILES: #@ "bump-" + language.name + "-buildpack.yml"
 #@ end
+  - task: add-resource-tags-ops-file
+    file: cf-deployment-concourse-tasks/collect-ops-files/task.yml
+    input_mapping:
+      base-ops-files: collected-ops-files
+      new-ops-files: buildpacks-ci
+    params:
+      BASE_OPS_FILE_DIR: operations
+      NEW_OPS_FILES: deployments/operations/tag-bbl-env.yml
 
 #@ base_ops_files = [
 #@   "operations/experimental/fast-deploy-with-downtime-and-danger.yml",
 #@   "operations/use-compiled-releases.yml",
 #@   "operations/scale-to-one-az.yml",
 #@   "operations/test/scale-to-one-az-addon-parallel-cats.yml",
+#@   "operations/tag-bbl-env.yml",
 #@ ]
 #@ buildpack_ops_file_paths = []
 #@ for language in data.values.supported_languages:
@@ -323,6 +332,7 @@ jobs:
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp-service-account-key))
       SYSTEM_DOMAIN: releases.buildpacks.ci.cloudfoundry.org
       OPS_FILES: #@ "\n".join(all_ops_files)
+      BOSH_DEPLOY_ARGS: "--var bbl_env_name=releases-buildpack-state"
     on_failure:
       do:
       - #@ remove_gcp_dns("updated-bbl-state")

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -487,8 +487,10 @@ jobs:
         - buildpacks-opsfile/use-latest-buildpack-releases.yml
         - rootfs-release-artifacts/use-dev-release-opsfile.yml
         - capi-release-artifacts/use-dev-release-opsfile.yml
+        - buildpacks-ci/deployments/operations/tag-bbl-env.yml
         vars:
           system_domain: cflinuxfs4.buildpacks.ci.cloudfoundry.org
+          bbl_env_name: cflinuxfs4
 
 - name: cats
   serial: true


### PR DESCRIPTION
## Summary
Implement GCP resource tagging for all buildpack CF environments to enable cost tracking and comply with ARI working group requirements.

## Background

**ARI Working Group Mandate:** All GCP resources must be labeled for cost tracking. Unlabeled resources may be deleted.

**Reference:** https://github.com/cloudfoundry/community/issues/1185

## Labels Applied

```yaml
belongs-to: buildpacks-and-stacks
environment: {language}-buildpacks-bbl-env
```

**Examples:**
- `belongs-to: buildpacks-and-stacks`
- `environment: python-buildpacks-bbl-env`
- `environment: ruby-buildpacks-bbl-env`

## Changes

### 1. New Ops File: `deployments/operations/tag-bbl-env.yml`
- Adds GCP labels to all CF deployment resources (VMs, disks, networks, load balancers)
- Uses variable `((bbl_env_name))` for dynamic environment naming
- Based on CAPI implementation: https://github.com/cloudfoundry/capi-ci/blob/main/cf-deployment-operations/tag-bbl-env.yml

### 2. Pipeline Updates: `pipelines/buildpack/pipeline.yml`
- Added `add-tag-ops-file` task to copy custom ops file to cf-deployment
- Updated `deploy-cf` task:
  - Changed input from `cf-deployment` to `cf-deployment-with-tags`
  - Added `operations/tag-bbl-env.yml` to `OPS_FILES`
  - Added `BOSH_DEPLOY_ARGS` with `--var bbl_env_name={language}-buildpacks-bbl-env`

## Implementation Pattern

Following the CAPI team's proven approach for GCP resource labeling:
- ✅ CF deployment resources (this PR)
- ⏳ Jumpbox labeling (separate, in bbl-state repo)
- ⏳ BOSH director labeling (separate, in bbl-state repo)

## Testing Plan

1. Run `./bin/update-pipelines --buildpacks-only` to deploy updated pipelines
2. Trigger python-buildpack pipeline as test case
3. Verify labels in GCP console after deployment
4. Roll out to all buildpack pipelines once validated

## Impact

All 13 buildpack environments will have labeled resources:
- python-buildpacks-bbl-env
- ruby-buildpacks-bbl-env
- go-buildpacks-bbl-env
- nodejs-buildpacks-bbl-env
- php-buildpacks-bbl-env
- java-buildpacks-bbl-env
- dotnet-core-buildpacks-bbl-env
- staticfile-buildpacks-bbl-env
- binary-buildpacks-bbl-env
- nginx-buildpacks-bbl-env
- r-buildpacks-bbl-env
- apt-buildpacks-bbl-env
- hwc-buildpacks-bbl-env

## Post-Merge Actions

1. Run `./bin/update-pipelines --buildpacks-only`
2. Add BBL terraform overrides for jumpbox and director (separate effort)
3. Run retroactive labeling scripts for existing resources
4. Verify cost tracking dashboard shows buildpacks-and-stacks

## References

- **Community Issue:** https://github.com/cloudfoundry/community/issues/1185
- **CAPI Example:** https://github.com/cloudfoundry/capi-ci/blob/main/cf-deployment-operations/tag-bbl-env.yml
- **CAPI Pipeline:** https://github.com/cloudfoundry/capi-ci/blob/main/ci/pipeline.yml#L772