### PR TITLE
Fix PHP deprecation dates to reflect security support EOL

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -298,19 +298,19 @@ dependencies:
         lines:
           - line: 8.2.X
             match: 8.2.\d+
-            deprecation_date: 2025-12-08
+            deprecation_date: 2026-12-31
             link: http://php.net/supported-versions.php
           - line: 8.3.X
             match: 8.3.\d+
-            deprecation_date: 2025-12-31
+            deprecation_date: 2027-12-31
             link: http://php.net/supported-versions.php
           - line: 8.4.X
             match: 8.4.\d+
-            deprecation_date: 2026-12-31
+            deprecation_date: 2028-12-31
             link: http://php.net/supported-versions.php
           - line: 8.5.X
             match: 8.5.\d+
-            deprecation_date: 2027-12-31
+            deprecation_date: 2029-12-31
             link: http://php.net/supported-versions.php
         removal_strategy: keep_latest_released
     source_type: php


### PR DESCRIPTION
## Fix PHP deprecation dates to reflect security support EOL

Update PHP deprecation dates in dependency-builds config to show when **security support ends**, not when active support ends.

### Problem

PHP has two support phases:
1. **Active Support** (2 years) - All bugs and security issues fixed
2. **Security Support** (2 years) - Only critical security fixes

The config was showing active support end dates, which could cause premature removal of PHP versions still receiving security patches.

### Changes

**File:** `pipelines/dependency-builds/config.yml`

| Version | Before (Wrong) | After (Correct) | Explanation |
|---------|----------------|-----------------|-------------|
| PHP 8.2 | 2025-12-08 | **2026-12-31** | Security support end date |
| PHP 8.3 | 2025-12-31 | **2027-12-31** | Security support end date |
| PHP 8.4 | 2026-12-31 | **2028-12-31** | Security support end date |
| PHP 8.5 | 2027-12-31 | **2029-12-31** | Security support end date |

### Impact

- ✅ Dependency builds will continue until true EOL (security support ends)
- ✅ Aligns with php-buildpack manifest dates
- ✅ Prevents premature removal of PHP versions with security support
- ✅ Matches official PHP support timeline

### Example: PHP 8.3

- **Active support ended:** Dec 31, 2025
- **Security support until:** Dec 31, 2027
- **Old config date:** 2025-12-31 (active support end) ❌
- **New config date:** 2027-12-31 (security support end) ✅

Between Jan 1, 2026 and Dec 31, 2027, PHP 8.3 still receives critical security patches and should remain available.

### Reference

- Official PHP support: https://www.php.net/supported-versions.php
- Related PR (php-buildpack manifest): cloudfoundry/php-buildpack#1304

### Note

PHP 8.1 was already correctly removed from this config (EOL Dec 31, 2025). This PR only fixes dates for currently supported versions (8.2, 8.3, 8.4, 8.5).