### PR TITLE
Remove Go 1.23.X and 1.24.X from dependency builds (EOL)

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -160,11 +160,8 @@ dependencies:
     buildpacks:
       go:
         lines:
-          #! go version lines lose support the day that the version line 2 minor bumps ahead is released
-          #! for example, 1.17.X reaches EOS whenever 1.19 releases. This gap is roughly 12 months.
-          - line: 1.24.X
-            deprecation_date: ""
-            link: https://golang.org/doc/devel/release.html
+          #! go version lines lose support when two newer major releases exist
+          #! for example, 1.23.X loses support when 1.25 releases (1.24 and 1.25 are the two newer versions)
           - line: 1.25.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html

--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -162,9 +162,6 @@ dependencies:
         lines:
           #! go version lines lose support the day that the version line 2 minor bumps ahead is released
           #! for example, 1.17.X reaches EOS whenever 1.19 releases. This gap is roughly 12 months.
-          - line: 1.23.X
-            deprecation_date: ""
-            link: https://golang.org/doc/devel/release.html
           - line: 1.24.X
             deprecation_date: ""
             link: https://golang.org/doc/devel/release.html


### PR DESCRIPTION
## Remove Go 1.23.X and 1.24.X from dependency builds (End of Life)

Stop building Go 1.23.X and 1.24.X binaries as both reached End of Life.

### Changes

**File:** `pipelines/dependency-builds/config.yml`

Remove Go 1.23.X and 1.24.X from the build lines:

```yaml
# REMOVED:
- line: 1.23.X
  deprecation_date: ""
  link: https://golang.org/doc/devel/release.html
- line: 1.24.X
  deprecation_date: ""
  link: https://golang.org/doc/devel/release.html
```

### Go Support Policy

Each Go version is supported **until there are two newer major releases**.

This means: when 2 newer versions exist, the version becomes EOL.

**Official policy:** https://go.dev/doc/devel/release

> "Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release."

**Timeline:**
- Go 1.23 released: Aug 13, 2024
- Go 1.24 released: Feb 11, 2025 → Go 1.22 EOL
- Go 1.25 released: Aug 12, 2025 → **Go 1.23 EOL** (2 newer: 1.24, 1.25)
- Go 1.26 released: Feb 10, 2026 → **Go 1.24 EOL** (2 newer: 1.25, 1.26)

### Current Status (July 2026)

| Version | Released | Status | Remains in Config |
|---------|----------|--------|-------------------|
| Go 1.23 | Aug 2024 | 🔴 EOL (11 months ago) | ❌ Removed |
| Go 1.24 | Feb 2025 | 🔴 EOL (4 months ago) | ❌ Removed |
| Go 1.25 | Aug 2025 | ✅ Supported (1 newer exists) | ✅ Yes |
| Go 1.26 | Feb 2026 | ✅ Latest | ✅ Yes |

**Only 2 versions are supported at any time** (latest and latest-1)

### Why This Change

**Prevent building unsupported Go versions:**
- Go 1.23 receives no security updates since August 2025
- Go 1.24 receives no security updates since February 2026
- Dependency pipeline should not produce binaries for EOL versions
- Aligns with go-buildpack which should remove both versions from manifest

### Impact

- ✅ New Go 1.23.X and 1.24.X releases will NOT be built automatically
- ✅ Dependency builds will only produce supported Go versions (1.25, 1.26)
- ✅ Prevents accidental addition of EOL Go to buildpack manifests

### Related PRs

- go-buildpack: Will need PR to remove both Go 1.23 and 1.24 from manifest

### Reference

- Official Go release policy: https://go.dev/doc/devel/release
- Go release history: https://go.dev/doc/devel/release
