### PR TITLE
Migrate cflinuxfs4 pipeline to noble stemcell

### DIFF
--- a/deployments/operations/use-noble-stemcell.yml
+++ b/deployments/operations/use-noble-stemcell.yml
@@ -1,0 +1,6 @@
+- path: /stemcells/alias=default
+  type: replace
+  value:
+    alias: default
+    os: ubuntu-noble
+    version: latest

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -194,6 +194,7 @@ resources:
   type: registry-image
   source:
     repository: cloudfoundry/cflinuxfs4
+    tag: latest
     username: ((cfbuildpacks-dockerhub-user.username))
     password: ((cfbuildpacks-dockerhub-user.password))
 
@@ -757,8 +758,7 @@ jobs:
     - put: cflinuxfs4-image
       params:
         image: image/image.tar
-        version: version/number
-        bump_aliases: true
+        additional_tags: version/number
 
 - name: create-cflinuxfs4-release
   serial: true

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -62,8 +62,8 @@ resources:
 - name: buildpacks-ci
   type: git
   source:
-    uri: https://github.com/plamen-bardarov/buildpacks-ci
-    branch: noble-stemcell
+    uri: https://github.com/cloudfoundry/buildpacks-ci
+    branch: master
 
 - name: runtime-ci
   type: git

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -735,7 +735,7 @@ jobs:
       trigger: true
       passed: [ release-cflinuxfs4 ]
   - do:
-    - task: rename
+    - task: prepare-docker-context
       file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
       params:
         STACK: cflinuxfs4

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -58,13 +58,12 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-deployment
-    tag: v21.11.0
 
 - name: buildpacks-ci
   type: git
   source:
-    uri: https://github.com/cloudfoundry/buildpacks-ci
-    branch: master
+    uri: https://github.com/plamen-bardarov/buildpacks-ci
+    branch: noble-stemcell
 
 - name: runtime-ci
   type: git
@@ -189,7 +188,7 @@ resources:
 - name: gcp-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-google-kvm-ubuntu-jammy-go_agent
+    name: bosh-google-kvm-ubuntu-noble
 
 - name: cflinuxfs4-image
   type: registry-image
@@ -197,7 +196,6 @@ resources:
     repository: cloudfoundry/cflinuxfs4
     username: ((cfbuildpacks-dockerhub-user.username))
     password: ((cfbuildpacks-dockerhub-user.password))
-    email: cf-buildpacks-eng@pivotal.io
 
 - name: cflinuxfs4-github-release
   type: github-release
@@ -464,6 +462,8 @@ jobs:
         - rootfs-release-artifacts/dev_releases/cflinuxfs4/*.tgz
         stemcells:
         - gcp-stemcell/*.tgz
+        ops_files:
+        - buildpacks-ci/deployments/operations/use-noble-stemcell.yml
     - task: run-rootfs-smoke-test
       file: buildpacks-ci/tasks/run-rootfs-smoke-test/task.yml
       params:

--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -738,13 +738,27 @@ jobs:
       file: buildpacks-ci/tasks/rename-rootfs-for-docker/task.yml
       params:
         STACK: cflinuxfs4
-    - in_parallel:
-      - put: cflinuxfs4-image
+    - task: build-image
+      privileged: true
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: concourse/oci-build-task
+        inputs:
+        - name: docker-s3
+        outputs:
+        - name: image
         params:
-          skip_download: true
-          import_file: docker-s3/cflinuxfs4.tar.gz
-          tag: version/number
-          tag_as_latest: true
+          CONTEXT: docker-s3
+        run:
+          path: build
+    - put: cflinuxfs4-image
+      params:
+        image: image/image.tar
+        version: version/number
+        bump_aliases: true
 
 - name: create-cflinuxfs4-release
   serial: true

--- a/tasks/rename-rootfs-for-docker/task.yml
+++ b/tasks/rename-rootfs-for-docker/task.yml
@@ -12,6 +12,14 @@ outputs:
   - name: docker-s3
 run:
   path: bash
-  args: ["-c", "mv stack-s3/$STACK-*.tar.gz docker-s3/$STACK.tar.gz"]
+  args:
+  - -c
+  - |
+    set -euo pipefail
+    mv stack-s3/$STACK-*.tar.gz docker-s3/$STACK.tar.gz
+    cat > docker-s3/Dockerfile <<EOF
+    FROM scratch
+    ADD $STACK.tar.gz /
+    EOF
 params:
   STACK:


### PR DESCRIPTION
## What

Migrates the cflinuxfs4 pipeline to a noble stemcell (jammy rootfs on a noble kernel) and fixes several deprecated Concourse resource params surfaced along the way.

## Changes

- **cf-deployment resource**: removed `tag: v21.11.0` pin so it tracks the latest (noble-era) manifest instead of the old jammy-era one.
- **gcp-stemcell resource**: switched to `bosh-google-kvm-ubuntu-noble`.
- **Smoke-test deploy**: added a `use-noble-stemcell.yml` ops-file (mirrors the existing `use-xenial-stemcell.yml`) and wired it into the `cflinuxfs4-rootfs-smoke-test-deployment` put, since that manifest (from the cflinuxfs4-release repo) hardcodes `ubuntu-jammy`.
- **cflinuxfs4-image resource**: removed the invalid `email` field (leftover from the deprecated `docker-image` resource; not valid on `registry-image`).
- **upload-to-docker job**: `registry-image` has no `import_file`/`docker import` support, so the rootfs is now converted to a single-layer OCI image explicitly:
  - `prepare-docker-context` task (formerly `rename`) also emits a `FROM scratch` / `ADD rootfs` Dockerfile, making `docker-s3` a self-contained build context.
  - added a privileged `oci-build-task` step producing `image/image.tar`.
  - the put now uses `image` + `additional_tags: version/number`, with `tag: latest` in the resource source to keep pushing `latest` (replacing the invalid `import_file`/`skip_download`/`tag_as_latest` params).

## Notes

- cflinuxfs4 remains a jammy (22.04) rootfs by design; only the stemcell/kernel moves to noble.
- The functional Docker image is unchanged (single layer = rootfs) — the conversion that the deprecated `docker-image` resource did internally is now explicit.