### PR TITLE
Fix receipt-diff resource path so bbl-up triggers

### DIFF
--- a/pipelines/cflinuxfs4.yml
+++ b/pipelines/cflinuxfs4.yml
@@ -116,7 +116,7 @@ resources:
   type: git
   source:
     uri: git@github.com:cloudfoundry/public-buildpacks-ci-robots
-    paths: [ receipt.cflinuxfs4.x86_64 ]
+    paths: [ receipt-diffs/cflinuxfs4-diff ]
     private_key: ((cf-buildpacks-eng-github-ssh-key.private_key))
     tag_filter: "newpackages_cflinuxfs4_*"
 


### PR DESCRIPTION
The receipt-diff git resource filtered on paths: [receipt.cflinuxfs4.x86_64], a file that has never existed in public-buildpacks-ci-robots. The receipts actually live at receipt-diffs/cflinuxfs4-diff.

This was silently harmless on older git-resource versions, which ignored paths when tag_filter was set. Newer versions intersect paths with the tag_filter, so the nonexistent path filtered out every newpackages_cflinuxfs4_* tag and bbl-up stopped triggering. Point paths at the real file.