### PR TITLE
Remove any_stack from pip and Python build tools for FIPS compatibility

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -325,7 +325,9 @@ dependencies:
         lines:
           - line: latest
     source_type: pypi
-    any_stack: true
+    #! pip contains C extensions (_ssl, etc.) that depend on system OpenSSL libraries
+    #! FIPS mode on cflinuxfs5 requires pip to be compiled against FIPS-compatible OpenSSL
+    #! Building stack-specific binaries ensures compatibility across different Ubuntu versions
     versions_to_keep: 2
   pipenv:
     buildpacks:
@@ -414,7 +416,8 @@ dependencies:
         lines:
           - line: latest
     source_type: pypi
-    any_stack: true
+    #! setuptools includes compiled extensions that may depend on system libraries
+    #! Stack-specific builds ensure compatibility across different Ubuntu versions
     versions_to_keep: 2
   flit-core:
     buildpacks:
@@ -422,7 +425,8 @@ dependencies:
         lines:
           - line: latest
     source_type: pypi
-    any_stack: true
+    #! flit-core is a Python build backend that may have system library dependencies
+    #! Stack-specific builds ensure compatibility across different Ubuntu versions
     versions_to_keep: 2
   poetry-core:
     buildpacks:
@@ -430,7 +434,8 @@ dependencies:
         lines:
           - line: latest
     source_type: pypi
-    any_stack: true
+    #! poetry-core is a Python build backend that may have system library dependencies
+    #! Stack-specific builds ensure compatibility across different Ubuntu versions
     versions_to_keep: 2
   yarn:
     buildpacks:


### PR DESCRIPTION
## Problem

Python-buildpack v1.9.2 fails on cflinuxfs5 with FIPS mode enabled with the following error:

```
ssl.SSLError: [CRYPTO] unknown error (0x7880025) (_ssl.c:3191)
File: pip/_internal/cli/index_command.py:49 in _create_truststore_ssl_context
ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
```

**Environment:**
- Stack: cflinuxfs5 with FIPS mode enabled
- Python: 3.14.6
- pip: 26.1.2
- Result: ❌ Staging fails

**Works on cflinuxfs4:**
- Same Python/pip versions
- No FIPS mode
- Result: ✅ Staging succeeds

## Root Cause

pip, setuptools, flit-core, and poetry-core are marked as `any_stack: true` in the dependency-builds config. This causes them to be built only on cflinuxfs4 (specified in `any_stack_build_stack: cflinuxfs4`), and the same binaries are used on cflinuxfs5.

**The issue:**
1. pip 26.1.2 contains C extensions (`_ssl`, etc.) compiled against cflinuxfs4's OpenSSL
2. cflinuxfs5 has different OpenSSL configuration (Ubuntu 24.04 vs 22.04)
3. When FIPS mode is enabled on cflinuxfs5, the OpenSSL library rejects certain SSL operations
4. pip's truststore library fails to create an SSL context → staging fails

**Why it's not truly stack-agnostic:**
- pip contains compiled C extensions that link to system libraries (OpenSSL, libc)
- Different Ubuntu versions have different library versions and FIPS configurations
- Binary built on cflinuxfs4 is not compatible with cflinuxfs5 FIPS environment

## Solution

Remove `any_stack: true` from:
- **pip** - contains C extensions for SSL/TLS that depend on OpenSSL
- **setuptools** - includes compiled extensions
- **flit-core** - Python build backend with potential system dependencies
- **poetry-core** - Python build backend with potential system dependencies

After this change, dependency-builds will create stack-specific binaries:
- `pip_26.1.2_linux_x64_cflinuxfs4.tgz` (built on Ubuntu 22.04)
- `pip_26.1.2_linux_x64_cflinuxfs5.tgz` (built on Ubuntu 24.04, FIPS-compatible)

## Changes

```diff
- any_stack: true
+ #! pip contains C extensions (_ssl, etc.) that depend on system OpenSSL libraries
+ #! FIPS mode on cflinuxfs5 requires pip to be compiled against FIPS-compatible OpenSSL
+ #! Building stack-specific binaries ensures compatibility across different Ubuntu versions
```

## Impact

- **cflinuxfs4**: No change - continues using cflinuxfs4-specific pip builds
- **cflinuxfs5**: Will use cflinuxfs5-specific pip builds (FIPS-compatible)
- **Fixes**: python-buildpack staging failures on FIPS-enabled cflinuxfs5
- **No breaking changes**: Existing applications continue to work

## Testing Plan

After merging and updating the dependency-builds pipeline:

1.  Verify dependency-builds creates pip binaries for both stacks:
   - Check pipeline for `pip-cflinuxfs4` and `pip-cflinuxfs5` jobs
   - Confirm binaries are uploaded to buildpacks.cloudfoundry.org

2.  Test python-buildpack on cflinuxfs5 with FIPS:
   - Deploy test app on us50 staging landscape (FIPS-enabled)
   - Verify pip install succeeds during staging
   - Confirm no SSL errors

3.  Verify backward compatibility:
   - Test python-buildpack on cflinuxfs4 (non-FIPS)
   - Ensure existing apps continue to work
