### PR TITLE
Fix yourkit dependency watcher

### DIFF
--- a/dockerfiles/depwatcher-go/pkg/watchers/yourkit.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/yourkit.go
@@ -18,36 +18,17 @@ func NewYourKitWatcher(client base.HTTPClient) *YourKitWatcher {
 }
 
 func (w *YourKitWatcher) Check() ([]base.Internal, error) {
-	resp, err := w.client.Get("https://www.yourkit.com/download/")
-	if err != nil {
-		return nil, fmt.Errorf("fetching downloads page: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status code %d fetching https://www.yourkit.com/download/", resp.StatusCode)
-	}
-
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("parsing HTML: %w", err)
-	}
-
-	pattern := regexp.MustCompile(`.+/YourKit-JavaProfiler-([\d]{4})\.([\d]{1,2})-b([\d]+)-x64\.zip`)
 	versionMap := make(map[string]bool)
 
-	doc.Find("a[href]").Each(func(i int, s *goquery.Selection) {
-		href, exists := s.Attr("href")
-		if !exists {
-			return
-		}
+	// Scrape archive page for older versions (old-style zip links with -b<build> suffix)
+	if err := w.scrapeArchivePage(versionMap); err != nil {
+		return nil, err
+	}
 
-		matches := pattern.FindStringSubmatch(href)
-		if matches != nil && len(matches) >= 4 {
-			version := fmt.Sprintf("%s.%s.%s", matches[1], matches[2], matches[3])
-			versionMap[version] = true
-		}
-	})
+	// Scrape main download page for current version (installer redirect links)
+	if err := w.scrapeCurrentVersion(versionMap); err != nil {
+		return nil, err
+	}
 
 	var versions []base.Internal
 	for v := range versionMap {
@@ -57,19 +38,94 @@ func (w *YourKitWatcher) Check() ([]base.Internal, error) {
 	return base.SortVersions(versions), nil
 }
 
+func (w *YourKitWatcher) scrapeArchivePage(versionMap map[string]bool) error {
+	resp, err := w.client.Get("https://www.yourkit.com/download/archive.jsp")
+	if err != nil {
+		return fmt.Errorf("fetching archive page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code %d fetching archive page", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("parsing archive HTML: %w", err)
+	}
+
+	// Old-style links: .../YourKit-JavaProfiler-2025.9-b191-x64.zip
+	pattern := regexp.MustCompile(`.+/YourKit-JavaProfiler-([\d]{4})\.([\d]{1,2})-b([\d]+)-x64\.zip`)
+
+	doc.Find("a[href]").Each(func(i int, s *goquery.Selection) {
+		href, exists := s.Attr("href")
+		if !exists {
+			return
+		}
+		matches := pattern.FindStringSubmatch(href)
+		if matches != nil && len(matches) >= 4 {
+			version := fmt.Sprintf("%s.%s.%s", matches[1], matches[2], matches[3])
+			versionMap[version] = true
+		}
+	})
+
+	return nil
+}
+
+func (w *YourKitWatcher) scrapeCurrentVersion(versionMap map[string]bool) error {
+	resp, err := w.client.Get("https://www.yourkit.com/download/")
+	if err != nil {
+		return fmt.Errorf("fetching downloads page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code %d fetching downloads page", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("parsing downloads HTML: %w", err)
+	}
+
+	// The page contains "Version: 2026.3" and "Build: #176" as separate text nodes.
+	// Collect the full text and extract both values.
+	pageText := doc.Text()
+
+	versionPattern := regexp.MustCompile(`Version:\s*([\d]{4}\.[\d]{1,2})`)
+	buildPattern := regexp.MustCompile(`Build:\s*#([\d]+)`)
+
+	versionMatches := versionPattern.FindStringSubmatch(pageText)
+	buildMatches := buildPattern.FindStringSubmatch(pageText)
+
+	if versionMatches != nil && buildMatches != nil {
+		version := fmt.Sprintf("%s.%s", versionMatches[1], buildMatches[1])
+		versionMap[version] = true
+	}
+
+	return nil
+}
+
 func (w *YourKitWatcher) In(ref string) (base.Release, error) {
-	// Parse version to construct filename and URL
 	v, err := semver.Parse(ref)
 	if err != nil {
 		return base.Release{}, fmt.Errorf("parsing version: %w", err)
 	}
 
-	// Filename format: YourKit-JavaProfiler-<year>.<minor>-b<build>-x64.zip
-	filename := fmt.Sprintf("YourKit-JavaProfiler-%d.%d-b%d-x64.zip", v.Major, v.Minor, v.Patch)
-	url := fmt.Sprintf("https://download.yourkit.com/yjp/%d.%d/%s", v.Major, v.Minor, filename)
+	// Try new-style URL first (2026+): download.yourkit.com/yjp/YEAR.MINOR.PATCH/YourKit-Java-Profiler-...
+	newURL := fmt.Sprintf("https://download.yourkit.com/yjp/%d.%d.%d/YourKit-Java-Profiler-%d.%d.%d-x64.zip",
+		v.Major, v.Minor, v.Patch, v.Major, v.Minor, v.Patch)
+	resp, err := w.client.GetRaw(newURL, nil)
+	if err == nil {
+		resp.Body.Close()
+		if resp.StatusCode == 200 {
+			return base.Release{Ref: ref, URL: newURL}, nil
+		}
+	}
 
-	return base.Release{
-		Ref: ref,
-		URL: url,
-	}, nil
+	// Fall back to old-style URL: archive.yourkit.com/yjp/YEAR.MINOR/YourKit-JavaProfiler-...-b<build>-x64.zip
+	oldURL := fmt.Sprintf("https://archive.yourkit.com/yjp/%d.%d/YourKit-JavaProfiler-%d.%d-b%d-x64.zip",
+		v.Major, v.Minor, v.Major, v.Minor, v.Patch)
+	return base.Release{Ref: ref, URL: oldURL}, nil
 }
+

--- a/dockerfiles/depwatcher-go/pkg/watchers/yourkit_test.go
+++ b/dockerfiles/depwatcher-go/pkg/watchers/yourkit_test.go
@@ -19,27 +19,70 @@ var _ = Describe("YourKitWatcher", func() {
 	})
 
 	Describe("Check", func() {
-		Context("when the HTML contains valid download links", func() {
-			It("returns all versions found", func() {
-				client.Response = `<html><body>
-					<a href="/yjp/2022/YourKit-JavaProfiler-2022.9-b238-x64.zip">Download</a>
-					<a href="/yjp/2022/YourKit-JavaProfiler-2022.3-b237-x64.zip">Download</a>
-					<a href="/yjp/2021/YourKit-JavaProfiler-2021.11-b236-x64.zip">Download</a>
-				</body></html>`
+		Context("when the archive page has old-style zip links and the download page has version/build text", func() {
+			It("returns versions from both sources without duplicates", func() {
+				client.Responses = map[string]string{
+					"https://www.yourkit.com/download/archive.jsp": `<html><body>
+						<a href="https://archive.yourkit.com/yjp/2025.9/YourKit-JavaProfiler-2025.9-b191-x64.zip">Download</a>
+						<a href="https://archive.yourkit.com/yjp/2025.3/YourKit-JavaProfiler-2025.3-b154-x64.zip">Download</a>
+					</body></html>`,
+					"https://www.yourkit.com/download/": `<html><body>
+						<p>Version: 2026.3</p>
+						<p>Build: #176</p>
+					</body></html>`,
+				}
 
 				versions, err := watcher.Check()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(versions).To(HaveLen(3))
+				Expect(versions[0].Ref).To(Equal("2025.3.154"))
+				Expect(versions[1].Ref).To(Equal("2025.9.191"))
+				Expect(versions[2].Ref).To(Equal("2026.3.176"))
+			})
+		})
+
+		Context("when the download page has no version/build info", func() {
+			It("returns only archive versions", func() {
+				client.Responses = map[string]string{
+					"https://www.yourkit.com/download/archive.jsp": `<html><body>
+						<a href="https://archive.yourkit.com/yjp/2025.9/YourKit-JavaProfiler-2025.9-b191-x64.zip">Download</a>
+					</body></html>`,
+					"https://www.yourkit.com/download/": `<html><body><p>No version info</p></body></html>`,
+				}
+
+				versions, err := watcher.Check()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versions).To(HaveLen(1))
+				Expect(versions[0].Ref).To(Equal("2025.9.191"))
 			})
 		})
 	})
 
 	Describe("In", func() {
-		It("returns the release details for a specific version", func() {
-			release, err := watcher.In("2022.9.238")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(release.Ref).To(Equal("2022.9.238"))
-			Expect(release.URL).To(Equal("https://download.yourkit.com/yjp/2022.9/YourKit-JavaProfiler-2022.9-b238-x64.zip"))
+		Context("when the new-style URL is available", func() {
+			It("returns the new-style URL for a 2026+ version", func() {
+				client.Responses = map[string]string{
+					"https://download.yourkit.com/yjp/2026.3.176/YourKit-Java-Profiler-2026.3.176-x64.zip": "",
+				}
+				client.StatusCode = 200
+
+				release, err := watcher.In("2026.3.176")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("2026.3.176"))
+				Expect(release.URL).To(Equal("https://download.yourkit.com/yjp/2026.3.176/YourKit-Java-Profiler-2026.3.176-x64.zip"))
+			})
+		})
+
+		Context("when the new-style URL is not available", func() {
+			It("falls back to the old-style archive URL", func() {
+				client.StatusCode = 404
+
+				release, err := watcher.In("2025.9.191")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(release.Ref).To(Equal("2025.9.191"))
+				Expect(release.URL).To(Equal("https://archive.yourkit.com/yjp/2025.9/YourKit-JavaProfiler-2025.9-b191-x64.zip"))
+			})
 		})
 	})
 })
+


### PR DESCRIPTION
---

Currently `build-your-kit-profiler-latest` job would run forever if triggered to seek new your-kit-profiler version.

Root cause

The YourKit download page (yourkit.com/download/) changed its structure. It no longer lists direct .zip file links — it now uses installer redirect links (/dl/installer?product=yjp&arch=x86-64&os=Linux&version=2026.3). The old regex matched zero links, so Check() returned an empty list, causing the Concourse resource to poll forever finding nothing new.

Additionally the current version (2026.3) uses a new filename format: YourKit-Java-Profiler-2026.3.176-x64.zip (no -b<build> separator, different hostname, full version in path).

Fix (yourkit.go)

Check() now scrapes two sources:
1. https://www.yourkit.com/download/archive.jsp — still has old-style zip links for 2025.9, 2025.3, etc. (regex unchanged)
2. https://www.yourkit.com/download/ — extracts the current version from the page text "Version: 2026.3" 

In() now tries the new-style URL first (download.yourkit.com/yjp/YEAR.MINOR.PATCH/YourKit-Java-Profiler-...) and falls back to the old archive URL (archive.yourkit.com/yjp/YEAR.MINOR/YourKit-JavaProfiler-...-b<build>-x64.zip) if the new URL returns non-200.