### PR TITLE
Add pnpm to the dependency-builds pipeline

### DIFF
--- a/pipelines/dependency-builds/config.yml
+++ b/pipelines/dependency-builds/config.yml
@@ -451,6 +451,21 @@ dependencies:
       - 'extension: .tar.gz'
     any_stack: true
     versions_to_keep: 2
+  pnpm:
+    buildpacks:
+      nodejs:
+        lines:
+          - line: latest
+    source_type: github_releases
+    source_params:
+      - 'repo: pnpm/pnpm'
+      #! Exact asset name: the glob must not also match pnpm-linux-x64-musl.tar.gz.
+      #! The npm package is not usable here — since pnpm 12 it is a stub that
+      #! downloads a native binary on install, which staging cannot do offline.
+      - 'glob: pnpm-linux-x64.tar.gz'
+    #! Pre-built upstream binary, glibc linux-x64: one build serves every stack.
+    any_stack: true
+    versions_to_keep: 2
   tomcat:
     buildpacks:
       java:
@@ -698,6 +713,7 @@ skip_deprecation_check:
   - jruby  #! tied to ruby, ruby doesn't publish EOL schedule
   - nginx  #! doesn't publish EOL schedule
   - nginx-static  #! same as nginx
+  - pnpm  #! doesn't publish EOL schedule
   - openresty  #! depends on nginx and lua deprecation
   - php  #! complicated
   - ruby  #! doesn't publish EOL schedule


### PR DESCRIPTION
Tracks pnpm so new releases are built, uploaded to the buildpacks S3 bucket and PR'd into the nodejs buildpack automatically, the same way yarn is handled. Requires the pnpm recipe in binary-builder.

Source is the linux-x64 release archive rather than the npm package. Since pnpm 12 the npm package is a stub whose preinstall script downloads a native binary, so it cannot produce a self-contained artifact for offline staging. The glob is the exact asset name so it does not also match the musl build.

github_releases already skips drafts, prereleases and any tag containing letters, so the release candidates pnpm publishes continuously are filtered out without further configuration. Checked against the live repository: 712 stable versions, latest 12.0.0, no release candidates.

The archive is a pre-built glibc binary, so one any_stack build serves every stack. pnpm publishes no EOL schedule, hence skip_deprecation_check.